### PR TITLE
Allow the toolchain image to be set by a named context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,29 @@ jobs:
           cache: false
       - name: Expose GitHub tokens for caching
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: Setup dockerd
+      - name: Setup builder
         run: |
-          cp /etc/docker/daemon.json /tmp/daemon.json || echo "{}" > /tmp/daemon.json
-          jq '.features += {"containerd-snapshotter": true}' /tmp/daemon.json | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
+          docker run -d --net=host registry
+          docker buildx create --use --driver-opt network=host
       - name: build frontend tooling
         run: |
-          docker buildx bake frontend mariner2-toolchain
+          set -e
+
+          # Build the frontend image and push it to the local registry
+          docker buildx bake \
+            --set frontend.output=type=registry \
+            --set frontend.tags=localhost:5000/dalec/frontend \
+            --set frontend.cache-from=type=gha,scope=dalec/frontend/ci \
+            --set frontend.cache-to=type=gha,scope=dalec/frontend/ci,mode=max \
+            frontend
       - name: test
         run: |
-          docker buildx bake test-runc
+          # Set the buildkit syntax to the one we stored in the local registry
+          # The bakefile will read this and pass it along to the runc target
+          export BUILDKIT_SYNTAX=localhost:5000/dalec/frontend
+
+          docker buildx bake \
+            --set mariner2-toolchain.cache-from=type=gha,scope=dalec/mariner2-toolchain/ci \
+            --set mariner2-toolchain.cache-to=type=gha,scope=dalec/mariner2-toolchain/ci,mode=max \
+            --set runc-mariner2-*.contexts.mariner2-toolchain=target:mariner2-toolchain \
+            test-runc

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN \
 FROM scratch AS frontend
 COPY --from=frontend-build /frontend /frontend
 LABEL moby.buildkit.frontend.network.none="true"
-LABEL moby.buildkit.frontend.caps="moby.buildkit.frontend.inputs,moby.buildkit.frontend.subrequests"
+LABEL moby.buildkit.frontend.caps="moby.buildkit.frontend.inputs,moby.buildkit.frontend.subrequests,moby.buildkit.frontend.contexts"
 ENTRYPOINT ["/frontend"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,13 +1,12 @@
 group "default" {
-    targets = ["frontend", "mariner2-toolchain"]
+    targets = ["frontend"]
 }
 
 target "frontend" {
     target = "frontend"
-    tags = ["ghcr.io/azure/dalec/frontend:latest", "local/dalec/frontend", BUILDKIT_SYNTAX]
+    tags = ["ghcr.io/azure/dalec/frontend:latest", BUILDKIT_SYNTAX]
 }
 
-// Toolchain builds the full mariner container with the mariner build tookit
 target "mariner2-toolchain" {
     dockerfile = "./frontend/mariner2/Dockerfile"
     target = "toolchain"
@@ -42,7 +41,6 @@ variable "RUNC_REVISION" {
     default = "1"
 }
 
-
 variable "BUILDKIT_SYNTAX" {
     default = "local/dalec/frontend"
 }
@@ -58,6 +56,9 @@ target "runc" {
     matrix = {
         distro = ["mariner2"]
         tgt = ["rpm", "container", "toolkitroot"]
+    }
+    contexts = {
+        "mariner2-toolchain" = "target:mariner2-toolchain"
     }
     target = "${distro}/${tgt}"
     // only tag the container target


### PR DESCRIPTION
This makes it easier to setup testing in CI where we need to use a containerized buildx builder.