### PR TITLE
Remove toolchain_rpms after chroot is created

### DIFF
--- a/frontend/mariner2/Dockerfile
+++ b/frontend/mariner2/Dockerfile
@@ -40,4 +40,9 @@ RUN <<EOF
 set -e;
 make toolchain -j$(nproc) chroot-tools REBUILD_TOOLS=n
 rm -rf /build/build/worker/worker_chroot
+rm -rf /build/build/toolchain_rpms/*
 EOF
+# These manifest files are used to populate the toolchain rpms.  Since we've
+# removed the rpms if we don't remove these manifests the toolkit will want to
+# install them again when we build packages.
+RUN for i in resources/manifests/package/*.txt; do [ -f "$i" ] || continue; echo "" > "$i"; done

--- a/frontend/mariner2/target_rpm.go
+++ b/frontend/mariner2/target_rpm.go
@@ -175,7 +175,6 @@ func specToRpmLLB(spec *dalec.Spec, noMerge bool, getDigest getDigestFunc, mr ll
 		}
 		for i := 0; i < runtime.NumCPU(); i++ {
 			llb.AddMount(dir(i, "upstream-cached-rpms"), llb.Scratch(), llb.AsPersistentCacheDir(cachedRpmsName, llb.CacheMountLocked)).SetRunOption(ei)
-			llb.AddMount(dir(i, "toolchainrpms"), work, llb.SourcePath("/build/build/toolchain_rpms"))
 		}
 	})
 


### PR DESCRIPTION
These rpms are only needed to create the worker_chroot.tar.gz. After that they just sit and take up lots of space.

This shrinks the toolchain image by half.