### PR TITLE
fix: redirectio: syscall.Dup2 not found on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
 
           docker run -d --net=host registry
           docker buildx create --use --driver-opt network=host
+      - name: Check frontend platforms
+        run:  |
+          # Make sure the frontend image builds on all platforms
+          docker buildx bake --set frontend.tags="" --set frontend.platform=linux/amd64,linux/arm64 frontend
       - name: build frontend tooling
         run: |
           set -e

--- a/cmd/dalec-redirectio/main.go
+++ b/cmd/dalec-redirectio/main.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func main() {
@@ -43,19 +44,19 @@ func main() {
 	}
 
 	if stdin != 0 {
-		if err := syscall.Dup2(stdin, 0); err != nil {
+		if err := unix.Dup2(stdin, 0); err != nil {
 			panic(err)
 		}
 	}
 
 	if stdout != 0 {
-		if err := syscall.Dup2(stdout, 1); err != nil {
+		if err := unix.Dup2(stdout, 1); err != nil {
 			panic(err)
 		}
 	}
 
 	if stderr != 0 {
-		if err := syscall.Dup2(stderr, 2); err != nil {
+		if err := unix.Dup2(stderr, 2); err != nil {
 			panic(err)
 		}
 	}
@@ -65,7 +66,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := syscall.Exec(cmd, args, os.Environ()); err != nil {
+	if err := unix.Exec(cmd, args, os.Environ()); err != nil {
 		panic(fmt.Errorf("%q: %w", strings.Join(args, " "), err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	go.etcd.io/bbolt v1.3.7
+	golang.org/x/sys v0.13.0
 	google.golang.org/grpc v1.57.0
 )
 
@@ -98,7 +99,6 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect


### PR DESCRIPTION
This should use the unix package anyway since syscall is deprecated. The unix package has this system call defined but the `syscall` package does not (for arm64).