### PR TITLE
Various fixes for patches

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -417,6 +417,24 @@
 			"type": "object",
 			"description": "PackageDependencies is a list of dependencies for a package."
 		},
+		"PatchSpec": {
+			"properties": {
+				"source": {
+					"type": "string",
+					"description": "Source is the name of the source that contains the patch to apply."
+				},
+				"strip": {
+					"type": "integer",
+					"description": "Strip is the number of leading path components to strip from the patch.\nThe default is 1 which is typical of a git diff."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"source"
+			],
+			"description": "PatchSpec is used to apply a patch to a source with a given set of options."
+		},
 		"Source": {
 			"properties": {
 				"ref": {
@@ -558,7 +576,7 @@
 				"patches": {
 					"additionalProperties": {
 						"items": {
-							"type": "string"
+							"$ref": "#/$defs/PatchSpec"
 						},
 						"type": "array"
 					},

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -193,7 +193,7 @@ func (w *specWrapper) PrepareSources() (fmt.Stringer, error) {
 
 	for _, v := range w.Spec.Patches {
 		for _, p := range v {
-			patches[p] = true
+			patches[p.Source] = true
 		}
 	}
 
@@ -221,8 +221,8 @@ func (w *specWrapper) PrepareSources() (fmt.Stringer, error) {
 			fmt.Fprintf(b, "mkdir -p %%{_builddir}/%s\n", name)
 			fmt.Fprintf(b, "tar -C %%{_builddir}/%s -xzf %%{_sourcedir}/%s.tar.gz\n", name, name)
 
-			for _, p := range w.Spec.Patches[name] {
-				fmt.Fprintf(b, "patch -d %q -p1 -s < %%{_sourcedir}/%s\n", name, p)
+			for _, patch := range w.Spec.Patches[name] {
+				fmt.Fprintf(b, "patch -d %q -p%d -s < %%{_sourcedir}/%s\n", name, *patch.Strip, patch.Source)
 			}
 			return nil
 		}(name, src)

--- a/load.go
+++ b/load.go
@@ -20,6 +20,8 @@ func knownArg(key string) bool {
 	}
 }
 
+const DefaultPatchStrip int = 1
+
 // LoadSpec loads a spec from the given data.
 // env is a map of environment variables to use for shell-style expansion in the spec.
 func LoadSpec(dt []byte, env map[string]string) (*Spec, error) {
@@ -95,6 +97,16 @@ func LoadSpec(dt []byte, env map[string]string) (*Spec, error) {
 			if err := t.processBuildArgs(lex, args, path.Join(name, t.Name)); err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	for k, patches := range spec.Patches {
+		for i, ps := range patches {
+			if ps.Strip != nil {
+				continue
+			}
+			strip := DefaultPatchStrip
+			spec.Patches[k][i].Strip = &strip
 		}
 	}
 

--- a/spec.go
+++ b/spec.go
@@ -55,7 +55,7 @@ type Spec struct {
 	// The value is the list of patches to apply to the source.
 	// The patch must be present in the `Sources` map.
 	// Each patch is applied in order and the result is used as the source for the build.
-	Patches map[string][]string `yaml:"patches,omitempty" json:"patches,omitempty"`
+	Patches map[string][]PatchSpec `yaml:"patches,omitempty" json:"patches,omitempty"`
 
 	// Build is the configuration for building the artifacts in the package.
 	Build ArtifactBuild `yaml:"build,omitempty" json:"build,omitempty"`
@@ -93,6 +93,16 @@ type Spec struct {
 	// Each item in this list is run with a separate rootfs and cannot interact with other tests.
 	// Each [TestSpec] is run with a separate rootfs, asyncronously from other [TestSpec].
 	Tests []*TestSpec `yaml:"tests,omitempty" json:"tests,omitempty"`
+}
+
+// PatchSpec is used to apply a patch to a source with a given set of options.
+// This is used in [Spec.Patches]
+type PatchSpec struct {
+	// Source is the name of the source that contains the patch to apply.
+	Source string `yaml:"source" json:"source" jsonschema:"required"`
+	// Strip is the number of leading path components to strip from the patch.
+	// The default is 1 which is typical of a git diff.
+	Strip *int `yaml:"strip,omitempty" json:"strip,omitempty"`
 }
 
 // ChangelogEntry is an entry in the changelog.

--- a/test/fixtures/git-patch.yml
+++ b/test/fixtures/git-patch.yml
@@ -30,4 +30,4 @@ build:
 
 patches:
   src:
-    - patch1
+    - source: patch1

--- a/test/fixtures/kubernetes-patch.yml
+++ b/test/fixtures/kubernetes-patch.yml
@@ -42,6 +42,6 @@ build:
 
 patches:
   src:
-    - patch_120129
-    - patch_120134
-    - patch_121882
+    - source: patch_120129
+    - source: patch_120134
+    - source: patch_121882


### PR DESCRIPTION
1. Use `patch -d` to set directory and avoid bash directory state
2. Change patches spec to allow for passing options to patch, specifically path stripping which can vary depending on what generated the patch.