### PR TITLE
Do not persist tdnf cache in output container

### DIFF
--- a/frontend/mariner2/handle_container.go
+++ b/frontend/mariner2/handle_container.go
@@ -208,9 +208,13 @@ rm -rf ` + rpmdbDir + `
 	worker := builderImg.
 		Run(
 			shArgs("/tmp/install.sh"),
-			marinerTdnfCache,
+			defaultMarinerTdnfCahe(),
 			llb.AddMount("/tmp/rpms", rpmDir, llb.SourcePath("/RPMS")),
 			llb.AddMount("/tmp/install.sh", installer, llb.SourcePath("install.sh")),
+			// Mount the tdnf cache into the workpath so that:
+			// 1. tdnf will use the cache
+			// 2. Repo data and packages are not left behind in the final image.
+			marinerTdnfCacheWithPrefix(workPath),
 		)
 
 	// This adds a mount to the worker so that all the commands are run with this mount added

--- a/frontend/mariner2/handle_depsonly.go
+++ b/frontend/mariner2/handle_depsonly.go
@@ -25,7 +25,7 @@ func handleDepsOnly(ctx context.Context, client gwclient.Client, spec *dalec.Spe
 
 	rpmDir := baseImg.Run(
 		shArgs(`set -ex; dir="/tmp/rpms/RPMS/$(uname -m)"; mkdir -p "${dir}"; tdnf install -y --releasever=2.0 --downloadonly --alldeps --downloaddir "${dir}" `+strings.Join(getRuntimeDeps(spec), " ")),
-		marinerTdnfCache,
+		defaultMarinerTdnfCahe(),
 	).
 		AddMount("/tmp/rpms", llb.Scratch())
 


### PR DESCRIPTION
Before this change when installing the new package into the container target tdnf is keeping a cache at /var/cache/tdnf in the new container's rootfs.
This blows up the image size.
As an example, before this change the go-md2man image from the docs is ~220MB, now it is ~47MB.