### PR TITLE
Add strict yaml unmarshal option

### DIFF
--- a/load.go
+++ b/load.go
@@ -292,7 +292,7 @@ func (s *Spec) SubstituteArgs(env map[string]string) error {
 // LoadSpec loads a spec from the given data.
 func LoadSpec(dt []byte) (*Spec, error) {
 	var spec Spec
-	if err := yaml.Unmarshal(dt, &spec); err != nil {
+	if err := yaml.UnmarshalWithOptions(dt, &spec, yaml.Strict()); err != nil {
 		return nil, fmt.Errorf("error unmarshalling spec: %w", err)
 	}
 

--- a/load_test.go
+++ b/load_test.go
@@ -1,6 +1,7 @@
 package dalec
 
 import (
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,9 @@ import (
 	"reflect"
 	"testing"
 )
+
+//go:embed test/fixtures/unmarshall/source-inline.yml
+var sourceInlineTemplate []byte
 
 func TestSourceValidation(t *testing.T) {
 	cases := []struct {
@@ -334,29 +338,10 @@ func TestSourceFillDefaults(t *testing.T) {
 }
 
 func TestSourceInlineUnmarshalling(t *testing.T) {
-	yaml := `
-sources:
-	TestFileOctelPreGo113:
-		inline:
-			file:
-				contents: Hello world!
-				permissions: 0644
-	TestFileOctelGo113:
-		inline:
-			file:
-				contents: Hello world!
-				permissions: 0o644
-	TestDirOctelPreGo113:
-		inline:
-			dir:
-				permissions: 0755
-	TestDirOctelGo113:
-		inline:
-			dir:
-				permissions: 0o755
-`
-
-	spec, err := LoadSpec([]byte(yaml))
+	// NOTE: not using text template yaml for this test
+	// tabs seem to be illegal in yaml indentation
+	// yaml unmarshalling with strict mode doesn't produce a great error message.
+	spec, err := LoadSpec(sourceInlineTemplate)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/fixtures/unmarshall/source-inline.yml
+++ b/test/fixtures/unmarshall/source-inline.yml
@@ -1,0 +1,19 @@
+sources:
+  TestFileOctelPreGo113:
+    inline:
+      file:
+        contents: Hello world!
+        permissions: 0644
+  TestFileOctelGo113:
+    inline:
+      file:
+        contents: Hello world!
+        permissions: 0o644
+  TestDirOctelPreGo113:
+    inline:
+      dir:
+        permissions: 0755
+  TestDirOctelGo113:
+    inline:
+      dir:
+        permissions: 0o755


### PR DESCRIPTION
This PR adds strict option for yaml unmarshal, any unknow field or typo `field` in a dalec spec will result in error
This should solve Issue #81 

example output when trying to build example with unknow field.
```
go-md2man-2.yml:1
--------------------
   1 | >>> # syntax=local/dalec/frontend:latest
   2 |     name: go-md2man
   3 |     version: 2.0.3
--------------------
ERROR: failed to solve: error loading spec: error unmarshalling spec: [9:1] unknown field "fake-field"
       6 | license: MIT
       7 | description: A tool to convert markdown into man pages (roff).
       8 | website: https://github.com/cpuguy83/go-md2man
    >  9 | fake-field: test
           ^
      10 | sources:
      11 |   src:
      12 |     git:
```