### PR TITLE
Add support for inline sources

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -424,6 +424,9 @@
 				"build": {
 					"$ref": "#/$defs/SourceBuild"
 				},
+				"inline": {
+					"$ref": "#/$defs/SourceInline"
+				},
 				"path": {
 					"type": "string",
 					"description": "Path is the path to the source after fetching it based on the identifier."
@@ -538,6 +541,70 @@
 				"url"
 			],
 			"description": "No longer supports `.git` URLs as git repos."
+		},
+		"SourceInline": {
+			"properties": {
+				"file": {
+					"$ref": "#/$defs/SourceInlineFile",
+					"description": "File is the inline file to generate.\nFile is treated as a literal single file.\n[SourceIsDir] will return false when this is set.\nThis is mutally exclusive with [Dir]"
+				},
+				"dir": {
+					"$ref": "#/$defs/SourceInlineDir",
+					"description": "Dir creates a directory with the given files and directories.\n[SourceIsDir] will return true when this is set.\nThis is mutally exclusive with [File]"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "SourceInline is used to generate a source from inline content."
+		},
+		"SourceInlineDir": {
+			"properties": {
+				"files": {
+					"additionalProperties": {
+						"$ref": "#/$defs/SourceInlineFile"
+					},
+					"type": "object",
+					"description": "Files is the list of files to include in the directory.\nThe map key is the name of the file.\n\nFiles with path separators in the key will be rejected."
+				},
+				"permissions": {
+					"type": "integer",
+					"description": "Permissions is the octal permissions to set on the directory."
+				},
+				"uid": {
+					"type": "integer",
+					"description": "UID is the user ID to set on the directory and all files and directories within it.\nUID must be greater than or equal to 0"
+				},
+				"gid": {
+					"type": "integer",
+					"description": "GID is the group ID to set on the directory and all files and directories within it.\nUID must be greater than or equal to 0"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "SourceInlineDir is used by by [SourceInline] to represent a filesystem directory."
+		},
+		"SourceInlineFile": {
+			"properties": {
+				"content": {
+					"type": "string",
+					"description": "Content is the contents."
+				},
+				"permissions": {
+					"type": "integer",
+					"description": "Permissions is the octal file permissions to set on the file."
+				},
+				"uid": {
+					"type": "integer",
+					"description": "UID is the user ID to set on the directory and all files and directories within it.\nUID must be greater than or equal to 0"
+				},
+				"gid": {
+					"type": "integer",
+					"description": "GID is the group ID to set on the directory and all files and directories within it.\nUID must be greater than or equal to 0"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "SourceInlineContent is used to specify the content of an inline source."
 		},
 		"SourceMount": {
 			"properties": {

--- a/files.go
+++ b/files.go
@@ -92,7 +92,7 @@ func (s *SourceInlineDir) validate() error {
 
 	for k, f := range s.Files {
 		if strings.ContainsRune(k, os.PathSeparator) {
-			errs = append(errs, errors.Errorf("file name %q must not contain path separator", k))
+			errs = append(errs, errors.Wrapf(sourceNamePathSeparatorError, "file %q", k))
 		}
 		if err := f.validate(); err != nil {
 			errs = append(errs, errors.Wrapf(err, "file %q", k))

--- a/files.go
+++ b/files.go
@@ -1,0 +1,170 @@
+package dalec
+
+import (
+	goerrors "errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultFilePerms = 0o644
+	defaultDirPerms  = 0o755
+)
+
+func (d *SourceInlineDir) PopulateAt(p string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		perms := d.Permissions.Perm()
+		if perms == 0 {
+			perms = defaultDirPerms
+		}
+
+		st = st.File(llb.Mkdir(p, perms, llb.WithUIDGID(int(d.UID), int(d.GID))))
+
+		sorted := SortMapKeys(d.Files)
+		for _, k := range sorted {
+			f := d.Files[k]
+			st = st.With(f.PopulateAt(filepath.Join(p, k)))
+		}
+
+		return st
+	}
+}
+
+func (f *SourceInlineFile) PopulateAt(p string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		perms := f.Permissions.Perm()
+		if perms == 0 {
+			perms = defaultFilePerms
+		}
+
+		return st.File(
+			llb.Mkfile(p, perms, []byte(f.Contents), llb.WithUIDGID(int(f.UID), int(f.GID))),
+		)
+	}
+}
+
+func (s *SourceInline) validate(subpath string) (retErr error) {
+	var errs []error
+
+	if s.File == nil && s.Dir == nil {
+		errs = append(errs, errors.New("inline source is missing contents to inline"))
+	}
+
+	if s.File != nil && s.Dir != nil {
+		errs = append(errs, errors.New("inline source variant cannot have both a file and dir set"))
+	}
+
+	if s.Dir != nil {
+		if err := s.Dir.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if s.File != nil {
+		if subpath != "" {
+			errs = append(errs, errors.New("inline file source cannot have a path set"))
+		}
+		if err := s.File.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return goerrors.Join(errs...)
+}
+
+func (s *SourceInlineDir) validate() error {
+	var errs []error
+
+	if s.UID < 0 {
+		errs = append(errs, errors.Errorf("uid %d must be non-negative", s.UID))
+	}
+
+	if s.GID < 0 {
+		errs = append(errs, errors.Errorf("gid %d must be non-negative", s.GID))
+	}
+
+	for k, f := range s.Files {
+		if strings.ContainsRune(k, os.PathSeparator) {
+			errs = append(errs, errors.Errorf("file name %q must not contain path separator", k))
+		}
+		if err := f.validate(); err != nil {
+			errs = append(errs, errors.Wrapf(err, "file %q", k))
+		}
+	}
+	return goerrors.Join(errs...)
+}
+
+func (s *SourceInlineFile) validate() error {
+	var errs []error
+
+	if s.UID < 0 {
+		errs = append(errs, errors.Errorf("uid %d must be non-negative", s.UID))
+	}
+
+	if s.GID < 0 {
+		errs = append(errs, errors.Errorf("gid %d must be non-negative", s.GID))
+	}
+
+	return goerrors.Join(errs...)
+}
+
+func (s *SourceInline) Doc(w io.Writer, name string) {
+	if s.File != nil {
+		s.File.Doc(w, name)
+	}
+
+	if s.Dir != nil {
+		s.Dir.Doc(w, name)
+	}
+
+}
+
+func (s *SourceInlineFile) Doc(w io.Writer, name string) {
+	fmt.Fprintln(w, `	cat << EOF > `+name+`
+`+s.Contents+`
+	EOF`)
+
+	if s.UID != 0 {
+		fmt.Fprintln(w, `	chown `+strconv.Itoa(s.UID)+" "+name)
+	}
+	if s.GID != 0 {
+		fmt.Fprintln(w, `	chgrp `+strconv.Itoa(s.GID)+" "+name)
+	}
+
+	perms := s.Permissions.Perm()
+	if perms == 0 {
+		perms = 0o644
+	}
+	fmt.Fprintf(w, "	chmod %o %s\n", perms.Perm(), name)
+}
+
+func (s *SourceInlineDir) Doc(w io.Writer, name string) {
+	fmt.Fprintln(w, `	mkdir -p `+name)
+
+	if s.UID != 0 {
+		fmt.Fprintln(w, `	chown `+strconv.Itoa(s.UID)+" "+name)
+	}
+	if s.GID != 0 {
+		fmt.Fprintln(w, `	chgrp `+strconv.Itoa(s.GID)+" "+name)
+	}
+
+	perms := s.Permissions.Perm()
+	if perms == 0 {
+		perms = 0o644
+	}
+
+	sorted := SortMapKeys(s.Files)
+	for _, k := range sorted {
+		v := s.Files[k]
+		v.Doc(w, filepath.Join(name, k))
+	}
+
+	fmt.Fprintf(w, "	chmod %o %s\n", perms.Perm(), name)
+}

--- a/frontend/debug/handle_sources.go
+++ b/frontend/debug/handle_sources.go
@@ -19,14 +19,15 @@ func HandleSources(ctx context.Context, gwc client.Client, spec *dalec.Spec) (cl
 
 	sources := make([]llb.State, 0, len(spec.Sources))
 	for name, src := range spec.Sources {
+		name := name
+		src := src
 		f := dalec.Source2LLBGetter(spec, src, name)
 		st, err := f(sOpt)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		to := llb.Scratch().File(llb.Mkdir("/"+name, 0o755, llb.WithParents(true)))
-		sources = append(sources, to.File(llb.Copy(st, "/", "/"+name, dalec.WithDirContentsOnly())))
+		sources = append(sources, st)
 	}
 
 	def, err := dalec.MergeAtPath(llb.Scratch(), sources, "/").Marshal(ctx)

--- a/frontend/rpm/handle_sources.go
+++ b/frontend/rpm/handle_sources.go
@@ -97,6 +97,8 @@ func Dalec2SourcesLLB(spec *dalec.Spec, sOpt dalec.SourceOpts, opts ...llb.Const
 			s = src.Context.Name
 		case src.Build != nil:
 			s = fmt.Sprintf("%v", src.Build.Source)
+		case src.Inline != nil:
+			s = "inline"
 		default:
 			return nil, fmt.Errorf("no non-nil source provided")
 		}

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -157,7 +157,7 @@ func (w *specWrapper) Sources() (fmt.Stringer, error) {
 			ref += ".tar.gz"
 		}
 
-		doc, err := src.Doc()
+		doc, err := src.Doc(name)
 		if err != nil {
 			return nil, fmt.Errorf("error getting doc for source %s: %w", name, err)
 		}

--- a/load.go
+++ b/load.go
@@ -114,6 +114,7 @@ func fillDefaults(s *Source) {
 		}
 	case s.Build != nil:
 		fillDefaults(&s.Build.Source)
+	case s.Inline != nil:
 	}
 }
 
@@ -141,9 +142,6 @@ func (s *Source) validate(failContext ...string) (retErr error) {
 
 		count++
 	}
-	if retErr != nil {
-		return retErr
-	}
 
 	if s.Git != nil {
 		count++
@@ -164,6 +162,13 @@ func (s *Source) validate(failContext ...string) (retErr error) {
 			retErr = goerrors.Join(retErr, err)
 		}
 
+		count++
+	}
+
+	if s.Inline != nil {
+		if err := s.Inline.validate(s.Path); err != nil {
+			retErr = goerrors.Join(retErr, err)
+		}
 		count++
 	}
 

--- a/load_test.go
+++ b/load_test.go
@@ -2,6 +2,7 @@ package dalec
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -381,5 +382,35 @@ sources:
 				}
 			}
 		})
+	}
+}
+
+func TestSourceNameWithPathSeparator(t *testing.T) {
+	spec := &Spec{
+		Sources: map[string]Source{
+			"forbidden/name": {
+				Inline: &SourceInline{
+					File: &SourceInlineFile{},
+				},
+			},
+		},
+	}
+
+	err := spec.Validate()
+	if err == nil {
+		t.Fatal("expected error, but received none")
+	}
+
+	var expected *InvalidSourceError
+	if !errors.As(err, &expected) {
+		t.Fatalf("expected %T, got %T", expected, err)
+	}
+
+	if expected.Name != "forbidden/name" {
+		t.Error("expected error to contain source name")
+	}
+
+	if !errors.Is(err, sourceNamePathSeparatorError) {
+		t.Errorf("expected error to be sourceNamePathSeparatorError, got: %v", err)
 	}
 }

--- a/source.go
+++ b/source.go
@@ -12,6 +12,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// InvalidSourceError is an error type returned when a source is invalid.
+type InvalidSourceError struct {
+	Name string
+	Err  error
+}
+
+func (s *InvalidSourceError) Error() string {
+	return fmt.Sprintf("invalid source %s: %v", s.Name, s.Err)
+}
+
+func (s *InvalidSourceError) Unwrap() error {
+	return s.Err
+}
+
+var sourceNamePathSeparatorError = errors.New("source name must not container path separator")
+
 type LLBGetter func(sOpts SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error)
 
 type ForwarderFunc func(llb.State, *SourceBuild) (llb.State, error)

--- a/spec.go
+++ b/spec.go
@@ -225,6 +225,51 @@ type SourceBuild struct {
 	Args map[string]string `yaml:"args,omitempty" json:"args,omitempty"`
 }
 
+// SourceInlineContent is used to specify the content of an inline source.
+type SourceInlineFile struct {
+	// Content is the contents.
+	Contents string `yaml:"content,omitempty" json:"content,omitempty"`
+	// Permissions is the octal file permissions to set on the file.
+	Permissions fs.FileMode `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+	// UID is the user ID to set on the directory and all files and directories within it.
+	// UID must be greater than or equal to 0
+	UID int `yaml:"uid,omitempty" json:"uid,omitempty"`
+	// GID is the group ID to set on the directory and all files and directories within it.
+	// UID must be greater than or equal to 0
+	GID int `yaml:"gid,omitempty" json:"gid,omitempty"`
+}
+
+// SourceInlineDir is used by by [SourceInline] to represent a filesystem directory.
+type SourceInlineDir struct {
+	// Files is the list of files to include in the directory.
+	// The map key is the name of the file.
+	//
+	// Files with path separators in the key will be rejected.
+	Files map[string]*SourceInlineFile `yaml:"files,omitempty" json:"files,omitempty"`
+	// Permissions is the octal permissions to set on the directory.
+	Permissions fs.FileMode `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+
+	// UID is the user ID to set on the directory and all files and directories within it.
+	// UID must be greater than or equal to 0
+	UID int `yaml:"uid,omitempty" json:"uid,omitempty"`
+	// GID is the group ID to set on the directory and all files and directories within it.
+	// UID must be greater than or equal to 0
+	GID int `yaml:"gid,omitempty" json:"gid,omitempty"`
+}
+
+// SourceInline is used to generate a source from inline content.
+type SourceInline struct {
+	// File is the inline file to generate.
+	// File is treated as a literal single file.
+	// [SourceIsDir] will return false when this is set.
+	// This is mutally exclusive with [Dir]
+	File *SourceInlineFile `yaml:"file,omitempty" json:"file,omitempty"`
+	// Dir creates a directory with the given files and directories.
+	// [SourceIsDir] will return true when this is set.
+	// This is mutally exclusive with [File]
+	Dir *SourceInlineDir `yaml:"dir,omitempty" json:"dir,omitempty"`
+}
+
 // Command is used to execute a command to generate a source from a docker image.
 type Command struct {
 	// Dir is the working directory to run the command in.
@@ -256,6 +301,7 @@ type Source struct {
 	HTTP        *SourceHTTP        `yaml:"http,omitempty" json:"http,omitempty"`
 	Context     *SourceContext     `yaml:"context,omitempty" json:"context,omitempty"`
 	Build       *SourceBuild       `yaml:"build,omitempty" json:"build,omitempty"`
+	Inline      *SourceInline      `yaml:"inline,omitempty" json:"inline,omitempty"`
 	// === End Source Variants ===
 
 	// Path is the path to the source after fetching it based on the identifier.

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -17,7 +17,7 @@ import (
 func TestHandlerTargetForwarding(t *testing.T) {
 	runTest := func(t *testing.T, f gwclient.BuildFunc) {
 		t.Helper()
-		ctx := startTestSpan(t)
+		ctx := startTestSpan(baseCtx, t)
 		testEnv.RunTest(ctx, t, f)
 	}
 

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -27,8 +27,8 @@ const (
 	phonyRef = "dalec/integration/frontend/phony"
 )
 
-func startTestSpan(t *testing.T) context.Context {
-	ctx, span := otel.Tracer("").Start(baseCtx, t.Name())
+func startTestSpan(ctx context.Context, t *testing.T) context.Context {
+	ctx, span := otel.Tracer("").Start(ctx, t.Name())
 	t.Cleanup(func() {
 		if t.Failed() {
 			span.SetStatus(codes.Error, "test failed")
@@ -145,8 +145,9 @@ type dirStatAsStringer []*types.Stat
 
 func (d dirStatAsStringer) String() string {
 	var buf bytes.Buffer
+	buf.WriteString("\n")
 	for _, s := range d {
-		fmt.Fprintf(&buf, "%s %s\n", s.GetPath(), fs.FileMode(s.Mode))
+		fmt.Fprintf(&buf, "%s %s %d %d\n", s.GetPath(), fs.FileMode(s.Mode), s.Uid, s.Gid)
 	}
 	return buf.String()
 }

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -16,7 +16,7 @@ func TestSources(t *testing.T) {
 func testCmdSource(t *testing.T) {
 	t.Parallel()
 
-	ctx := startTestSpan(t)
+	ctx := startTestSpan(baseCtx, t)
 
 	sourceName := "checkcmd"
 	spec := &dalec.Spec{

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -2,18 +2,13 @@ package test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/Azure/dalec"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 )
 
-func TestSources(t *testing.T) {
-	t.Run("cmd source", testCmdSource)
-}
-
-func testCmdSource(t *testing.T) {
+func TestSourceCmd(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -59,8 +59,8 @@ func testCmdSource(t *testing.T) {
 			return nil, err
 		}
 
-		checkFile(ctx, t, filepath.Join(sourceName, "foo"), res, []byte("foo bar\n"))
-		checkFile(ctx, t, filepath.Join(sourceName, "hello"), res, []byte("hello\n"))
+		checkFile(ctx, t, "foo", res, []byte("foo bar\n"))
+		checkFile(ctx, t, "hello", res, []byte("hello\n"))
 
 		return gwclient.NewResult(), nil
 	})

--- a/test/var_passthrough_test.go
+++ b/test/var_passthrough_test.go
@@ -40,11 +40,12 @@ func getBuildPlatform(ctx context.Context, t *testing.T) *platforms.Platform {
 func TestPassthroughVars(t *testing.T) {
 	runTest := func(t *testing.T, f gwclient.BuildFunc) {
 		t.Helper()
-		ctx := startTestSpan(t)
+		ctx := startTestSpan(baseCtx, t)
 		testEnv.RunTest(ctx, t, f)
 	}
 
-	var buildPlatform = getBuildPlatform(startTestSpan(t), t)
+	ctx := startTestSpan(baseCtx, t)
+	var buildPlatform = getBuildPlatform(ctx, t)
 	log.Println(platforms.Format(*buildPlatform))
 
 	tests := []struct {


### PR DESCRIPTION
This allows you to specify files or trees inline in yaml spec.

Example:

```yaml
sources:
  someFile:
    inline:
      file:
      contents: "hello!"
  someDir:
    inline:
      dir:
        files:
          foo:
            contents: "I am foo!"
```

You can also set permissions and ownership.