### PR TITLE
Revert use of "weak" progress groups.

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -209,7 +209,7 @@ func ProgressGroup(name string) llb.ConstraintsOpt {
 	return constraintsOptFunc(func(c *llb.Constraints) {
 		if c.Metadata.ProgressGroup != nil {
 			id := c.Metadata.ProgressGroup.Id
-			llb.ProgressGroup(id, name, true).SetConstraintsOption(c)
+			llb.ProgressGroup(id, name, false).SetConstraintsOption(c)
 			return
 		}
 


### PR DESCRIPTION
Using weak progress groups seems to hide all the output from the progress group.
Need to understand more of how to use weak groups, for now use non-weak ones for everything so we can get helpful output.