### PR TITLE
Allow fields starting with `x-` in the spec

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -290,6 +290,33 @@ targets:
             image: docker.io/my/custom:mariner2
 ```
 
+### Metadata
+
+You can include client-side metadata in the spec file.
+This may be useful when you want to parse the spec file and do something with your own tooling.
+
+Any field at the top-level that begins with `x-` will be ignored by the dalec parser.
+Any unknown fields besides those that start with `x-` will cause the parser to fail.
+
+```yaml
+soruces:
+  src:
+    http:
+      url: https://example.com/foo.tar.gz
+
+x-my-custom-field: "foo"
+```
+
+As an example use-case, you may want to use this to store the targeted image name for a CI/CD pipeline.
+
+```yaml
+x-image-name: "my-package-image:1.0.0"
+```
+
+Your CI/CD tooling can then parse the spec file and use the `x-image-name` field to tag the built image.
+
+To re-itterate: the `x-` fields are ignored by the dalec parser and are only for client-side use.
+
 ## Additional Reading
 
 * Details on editor support in [editor-support.md](editor-support.md)

--- a/load.go
+++ b/load.go
@@ -317,7 +317,7 @@ func stripXFields(dt []byte) ([]byte, error) {
 	}
 
 	for k := range obj {
-		if strings.HasPrefix(k, "x-") {
+		if strings.HasPrefix(k, "x-") || strings.HasPrefix(k, "X-") {
 			delete(obj, k)
 		}
 	}

--- a/load_test.go
+++ b/load_test.go
@@ -410,6 +410,7 @@ sources:
         contents: "Hello world!"
 x-some-field: "some value"
 x-some-other-field: "some other value"
+X-capitalized-other-field: "some other value capitalized X key"
 `)
 
 		spec, err := LoadSpec(dt)


### PR DESCRIPTION
This allows clients to store extra data in the spec without having to loosen up unmarshalling validations.

No "x-" field is explicitly added to the spec because frontends should not be interpreting this field.
Instead the fields are stripped from the input before unmarshalling to `Spec`.