### PR TITLE
Remove GOROOT=/usr/lib/golang hack

### DIFF
--- a/docs/examples/go-md2man-1.yml
+++ b/docs/examples/go-md2man-1.yml
@@ -19,7 +19,6 @@ dependencies:
 
 build:
   env:
-    GOROOT: /usr/lib/golang # Note: This is needed due to a bug in the golang package for mariner
     CGO_ENABLED: "0"
   steps:
     - command: |

--- a/docs/examples/go-md2man-2.yml
+++ b/docs/examples/go-md2man-2.yml
@@ -37,7 +37,6 @@ dependencies:
 
 build:
   env:
-    GOROOT: /usr/lib/golang # Note: This is needed due to a bug in the golang package for mariner
     CGO_ENABLED: "0"
   steps:
     - command: |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -148,7 +148,6 @@ dependencies:
 
 build:
   env:
-    GOROOT: /usr/lib/golang # Note: This is needed due to a bug in the golang package for mariner
     CGO_ENABLED: "0"
   steps:
     - command: |
@@ -231,7 +230,6 @@ dependencies:
 
 build:
   env:
-    GOROOT: /usr/lib/golang # Note: This is needed due to a bug in the golang package for mariner
     CGO_ENABLED: "0"
   steps:
     - command: |

--- a/test/fixtures/frontend.yml
+++ b/test/fixtures/frontend.yml
@@ -38,7 +38,6 @@ build:
     GOGC: off
     GOFLAGS: -trimpath
     GOPATH: /go
-    GOROOT: /usr/lib/golang
   steps:
     - command: |
         export GOMODCACHE="$(pwd)/gomodcache"

--- a/test/fixtures/moby-runc.yml
+++ b/test/fixtures/moby-runc.yml
@@ -70,12 +70,10 @@ build:
     CGO_ENABLED: 1
     GOGC: off
     GOFLAGS: -trimpath
-    GOROOT: /usr/lib/golang
   steps:
     - command: |
         set -e
         cd src
-        export GOROOT=/usr/lib/golang
         make man runc BUILDTAGS=seccomp
 artifacts:
   binaries:


### PR DESCRIPTION
Supposedly this was fixed in the mariner go packages (though I've not verified that). In any case, I believe the main reason the bug in the packages was exposed was due to the way the mariner toolkit was executing the package builds.

This is no longer a problem for us, so removing these.

Closes #24