### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -5,6 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -42,4 +47,4 @@ jobs:
             --set frontend.platform=linux/amd64,linux/arm64 \
             frontend
         env:
-          FRONTEND_REF: ghcr.io/${{ github.repository }}/frontend:${{ github.event.inputs.tag }}
+          FRONTEND_REF: ghcr.io/${{ github.repository }}/frontend:${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  trimTagRef:
+    runs-on: ubuntu-latest
+    outputs:
+      TRIMMED_REF_NAME: ${{ steps.trim.outputs.TRIMMED_REF_NAME }}
+    steps:
+      - name: Trim tag ref
+        id: trim
+        run: echo "TRIMMED_REF_NAME=${REF_NAME#v}" >> "$GITHUB_OUTPUT" && cat "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+
+  build:
+    needs: trimTagRef
+    uses: ./.github/workflows/frontend-image.yml
+    with:
+      tag: ${{needs.trimTagRef.outputs.TRIMMED_REF_NAME}}


### PR DESCRIPTION
When the repo is tagged (and that tag looks like a version number), the release workflow is triggered and will start a frontend build with the git tag (minus the leading `v`) as image tag.

Example (after a few tests) is here: https://github.com/cpuguy83/dalec-test-fork/actions/runs/8012326758
Which produced https://github.com/cpuguy83/dalec-test-fork/pkgs/container/dalec-test-fork%2Ffrontend/182474475?tag=0.1.5

<img width="1084" alt="image" src="https://github.com/Azure/dalec/assets/799078/b2eba0e9-065e-4bed-82ad-0ad18d204b6d">
