### PR TITLE
Remove some dependabot jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,10 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: docker
-    directory: /frontend/mariner2
-    schedule:
-      interval: weekly
-
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Remove some dependabot jobs
    
1. We don't have the image at frontend/mariner2 anymore, so that is not needed at all
2. For go deps, ignore major/minor version updates which can all be
    tricky for transative (or shared) upstream dependencies.