### PR TITLE
Disable network access during rpmbuild

### DIFF
--- a/frontend/rpm/handle_rpm.go
+++ b/frontend/rpm/handle_rpm.go
@@ -30,6 +30,7 @@ func Build(topDir, workerImg llb.State, specPath string, opts ...llb.Constraints
 		llb.AddMount("/build/top", topDir),
 		llb.AddMount("/build/tmp", llb.Scratch(), llb.Tmpfs()),
 		llb.Dir("/build/top"),
+		llb.Network(llb.NetModeNone),
 		dalec.WithConstraints(opts...),
 	).
 		AddMount("/build/out", llb.Scratch())

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -18,11 +18,17 @@ import (
 )
 
 var (
-	baseCtx = context.Background()
-	testEnv *testenv.BuildxEnv
+	baseCtx          = context.Background()
+	testEnv          *testenv.BuildxEnv
+	externalTestHost = os.Getenv("TEST_DALEC_EXTERNAL_HOST")
 )
 
 func TestMain(m *testing.M) {
+	if externalTestHost == "" {
+		externalTestHost = "https://github.com"
+	}
+	flag.StringVar(&externalTestHost, "external-test-host", externalTestHost, "http server to use for validating network access")
+
 	flag.Parse()
 
 	if testing.Short() {


### PR DESCRIPTION
Generally the build phase should be completely isolated, this makes sure that consumers of the srpm can reliably rebuild packages.

This may be somewhat controversial.
If we need to we can add a toggle for this later.
Mainly I don't want to release anything now that allows internet access only to take it away later (which will be much harder after anyone starts adopting dalec).
