### PR TITLE
Validate rpm fields

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -659,7 +659,7 @@
 				},
 				"version": {
 					"type": "string",
-					"description": "Version setst he version of the package."
+					"description": "Version sets the version of the package."
 				},
 				"revision": {
 					"oneOf": [

--- a/frontend/mariner2/handle_rpm.go
+++ b/frontend/mariner2/handle_rpm.go
@@ -33,6 +33,10 @@ func tdnfCacheMountWithPrefix(prefix string) llb.RunOption {
 }
 
 func handleRPM(ctx context.Context, client gwclient.Client, spec *dalec.Spec) (gwclient.Reference, *image.Image, error) {
+	if err := rpm.ValidateSpec(spec); err != nil {
+		return nil, nil, fmt.Errorf("rpm: invalid spec: %w", err)
+	}
+
 	pg := dalec.ProgressGroup("Building mariner2 rpm: " + spec.Name)
 	sOpt, err := frontend.SourceOptFromClient(ctx, client)
 	if err != nil {

--- a/frontend/rpm/handle_buildroot.go
+++ b/frontend/rpm/handle_buildroot.go
@@ -42,6 +42,9 @@ func BuildrootHandler(target string) frontend.BuildFunc {
 
 // SpecToBuildrootLLB converts a dalec.Spec to an rpm buildroot
 func SpecToBuildrootLLB(spec *dalec.Spec, target string, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	if err := ValidateSpec(spec); err != nil {
+		return llb.Scratch(), fmt.Errorf("invalid spec: %w", err)
+	}
 	opts = append(opts, dalec.ProgressGroup("Create RPM buildroot"))
 	sources, err := Dalec2SourcesLLB(spec, sOpt, opts...)
 	if err != nil {

--- a/frontend/rpm/handle_rpm.go
+++ b/frontend/rpm/handle_rpm.go
@@ -1,6 +1,9 @@
 package rpm
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/Azure/dalec"
 	"github.com/moby/buildkit/client/llb"
 )
@@ -34,4 +37,27 @@ func Build(topDir, workerImg llb.State, specPath string, opts ...llb.Constraints
 		dalec.WithConstraints(opts...),
 	).
 		AddMount("/build/out", llb.Scratch())
+}
+
+var errMissingRequiredField = errors.New("missing required field")
+
+// ValidateSpec makes sure all the necessary fields are present in the spec to make rpmbuild work
+// This validation is specific to rpmbuild.
+func ValidateSpec(spec *dalec.Spec) (out error) {
+	if spec.Name == "" {
+		out = errors.Join(out, fmt.Errorf("%w: name", errMissingRequiredField))
+	}
+	if spec.Version == "" {
+		out = errors.Join(out, fmt.Errorf("%w: version", errMissingRequiredField))
+	}
+	if spec.Revision == "" {
+		out = errors.Join(out, fmt.Errorf("%w: revision", errMissingRequiredField))
+	}
+	if spec.Description == "" {
+		out = errors.Join(out, fmt.Errorf("%w: description", errMissingRequiredField))
+	}
+	if spec.Website == "" {
+		out = errors.Join(out, fmt.Errorf("%w: website", errMissingRequiredField))
+	}
+	return out
 }

--- a/frontend/rpm/handle_spec.go
+++ b/frontend/rpm/handle_spec.go
@@ -39,6 +39,9 @@ func SpecHandler(target string) frontend.BuildFunc {
 }
 
 func Dalec2SpecLLB(spec *dalec.Spec, in llb.State, target, dir string, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	if err := ValidateSpec(spec); err != nil {
+		return llb.Scratch(), fmt.Errorf("invalid spec: %w", err)
+	}
 	opts = append(opts, dalec.ProgressGroup("Generate RPM spec"))
 	buf := bytes.NewBuffer(nil)
 	info, _ := debug.ReadBuildInfo()

--- a/spec.go
+++ b/spec.go
@@ -18,7 +18,7 @@ type Spec struct {
 	// Website is the URL to store in the metadata of the package.
 	Website string `yaml:"website" json:"website"`
 
-	// Version setst he version of the package.
+	// Version sets the version of the package.
 	Version string `yaml:"version" json:"version" jsonschema:"required"`
 	// Revision sets the package revision.
 	// This will generally get merged into the package version when generating the package.


### PR DESCRIPTION
These fields are required to build an rpm.
When the fields are not there rpmbuild gives an error about the fields,
but those field names are different so its confusing to the user.

This checks those fields early so we can give a better error message.