### PR TITLE
Release multiple tags

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -41,10 +41,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          export FRONTEND_REF="$(tr '[:upper:]' '[:lower:]' <<<"${FRONTEND_REF}")"
+          set -eux -o pipefail
+
+          FRONTEND_REPO="$(tr '[:upper:]' '[:lower:]' <<<"${FRONTEND_REPO}")"
           docker buildx create --use
+          
+          set_tags=""
+          IFS=, read -ra SPLIT_TAGS <<<"${FRONTEND_TAGS}"
+          
+          for tag in "${SPLIT_TAGS[@]}"; do
+              set_tags+=" --set frontend.tags=${FRONTEND_REPO}:${tag}"
+          done
+          
           docker buildx bake --push \
-            --set frontend.platform=linux/amd64,linux/arm64 \
-            frontend
+              frontend \
+                  --set frontend.platform=linux/amd64,linux/arm64 \
+                  ${set_tags}
         env:
-          FRONTEND_REF: ghcr.io/${{ github.repository }}/frontend:${{ inputs.tag }}
+          FRONTEND_REPO: ghcr.io/${{ github.repository }}/frontend
+          FRONTEND_TAGS: ${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,31 @@ permissions:
   packages: write
 
 jobs:
-  trimTagRef:
+  tagList:
     runs-on: ubuntu-latest
     outputs:
-      TRIMMED_REF_NAME: ${{ steps.trim.outputs.TRIMMED_REF_NAME }}
+      tags: ${{ steps.tags.outputs.OUTPUT_TAGS }}
     steps:
-      - name: Trim tag ref
-        id: trim
-        run: echo "TRIMMED_REF_NAME=${REF_NAME#v}" >> "$GITHUB_OUTPUT" && cat "$GITHUB_OUTPUT"
+      - name: Get image tag list
+        id: tags
+        run: |
+          set -eux -o pipefail
+
+          # Remove leading "v" from tag name
+          TRIMMED_REF_NAME="${REF_NAME#v}"
+
+          # Creates a comma separated list of tags
+          # - latest
+          # - <major>.<minor>
+          # - <major>.<minor>.<patch>
+          OUTPUT_TAGS="latest,${TRIMMED_REF_NAME%.*},${TRIMMED_REF_NAME}"
+          
+          echo "OUTPUT_TAGS=${OUTPUT_TAGS}" >> "$GITHUB_OUTPUT" && cat "$GITHUB_OUTPUT"
         env:
           REF_NAME: ${{ github.ref_name }}
-
+        shell: bash
   build:
-    needs: trimTagRef
+    needs: tagList
     uses: ./.github/workflows/frontend-image.yml
     with:
-      tag: ${{needs.trimTagRef.outputs.TRIMMED_REF_NAME}}
+      tag: ${{needs.tagList.outputs.tags}}


### PR DESCRIPTION
- Modify the fronted job to support a comma separated tag list
- Modify release workflow to send multiple tags to the build job:
  - `latest`
  - `<major>.<minor>`
  - `<major>.<minor>.<patch>`