### PR TITLE
add initial support for SOURCE_DATE_EPOCH

### DIFF
--- a/load.go
+++ b/load.go
@@ -19,6 +19,8 @@ func knownArg(key string) bool {
 		return true
 	case "DALEC_DISABLE_DIFF_MERGE":
 		return true
+	case "SOURCE_DATE_EPOCH":
+		return true
 	}
 
 	return platformArg(key)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds initial support for `SOURCE_DATE_EPOCH`, technically this variable was already able to be injected in Dalec specs as one of the requirements to add this is to explicit require the `args/envs`.  It seems like `SOURCE_DATE_EPOCH` env var is auto injected by docker/buildx so no need to explicit `--build-arg`. The difference I could notice is that now with change applied the build will not fail as unknow arg for `SOURCE_DATE_EPOCH` var but it still requires the spec to set this variable to be used.
```yml
# syntax=ghcr.io/azure/dalec/frontend:latest
args:
  SOURCE_DATE_EPOCH: # [Required] Needs to explicit call for variable to be usable within spec

name: go-md2man
version: 2.0.3
packager: Dalec Example
...
sources:
...
build:
  env:
    SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH} # [Required] Needs to explicit set variable to be usable within build scope
  steps:
    - command: |
        set -x
        echo "${SOURCE_DATE_EPOCH} # If any of the required fields is missing value will be empty.
        exit 1
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #54

**Special notes for your reviewer**:
