### PR TITLE
Add support for validating HTTP by digest

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -547,7 +547,12 @@
 		"SourceHTTP": {
 			"properties": {
 				"url": {
-					"type": "string"
+					"type": "string",
+					"description": "URL is the URL to download the file from."
+				},
+				"digest": {
+					"type": "string",
+					"description": "Digest is the digest of the file to download.\nThis is used to verify the integrity of the file.\nForm: \u003calgorithm\u003e:\u003cdigest\u003e"
 				}
 			},
 			"additionalProperties": false,
@@ -555,7 +560,7 @@
 			"required": [
 				"url"
 			],
-			"description": "No longer supports `.git` URLs as git repos."
+			"description": "SourceHTTP is used to download a file from an HTTP(s) URL."
 		},
 		"SourceInline": {
 			"properties": {

--- a/load.go
+++ b/load.go
@@ -150,6 +150,9 @@ func (s *Source) validate(failContext ...string) (retErr error) {
 		count++
 	}
 	if s.HTTP != nil {
+		if err := s.HTTP.validate(); err != nil {
+			retErr = goerrors.Join(retErr, err)
+		}
 		count++
 	}
 	if s.Context != nil {

--- a/source.go
+++ b/source.go
@@ -127,8 +127,23 @@ func (src *SourceDockerImage) AsState(name string, path string, sOpt SourceOpts,
 func (src *SourceHTTP) AsState(name string, opts ...llb.ConstraintsOpt) (llb.State, error) {
 	httpOpts := []llb.HTTPOption{withConstraints(opts)}
 	httpOpts = append(httpOpts, llb.Filename(name))
+	if src.Digest != "" {
+		httpOpts = append(httpOpts, llb.Checksum(src.Digest))
+	}
 	st := llb.HTTP(src.URL, httpOpts...)
 	return st, nil
+}
+
+func (src *SourceHTTP) validate() error {
+	if src.URL == "" {
+		return errors.New("http source must have a URL")
+	}
+	if src.Digest != "" {
+		if err := src.Digest.Validate(); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
 }
 
 // InvalidSourceError is an error type returned when a source is invalid.

--- a/source_test.go
+++ b/source_test.go
@@ -175,6 +175,27 @@ func TestSourceHTTP(t *testing.T) {
 	if op.Attrs[httpFilename] != "test" {
 		t.Errorf("expected http.filename %q, got %q", xFilename, op.Attrs[httpFilename])
 	}
+
+	t.Run("with digest", func(t *testing.T) {
+		dgst := digest.Canonical.FromBytes(nil)
+		src.HTTP.Digest = dgst
+
+		ops := getSourceOp(ctx, t, src)
+		op := ops[0].GetSource()
+
+		if len(op.Attrs) != 2 {
+			t.Errorf("expected 2 attribute, got %d", len(op.Attrs))
+		}
+
+		if op.Attrs[httpFilename] != "test" {
+			t.Errorf("expected http.filename %q, got %q", xFilename, op.Attrs[httpFilename])
+		}
+
+		const httpChecksum = "http.checksum"
+		if op.Attrs[httpChecksum] != dgst.String() {
+			t.Errorf("expected http.checksum %q, got %q", dgst.String(), op.Attrs[httpChecksum])
+		}
+	})
 }
 
 func toImageRef(ref string) string {

--- a/spec.go
+++ b/spec.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/opencontainers/go-digest"
 )
 
 // Spec is the specification for a package build.
@@ -173,10 +175,14 @@ type SourceGit struct {
 	KeepGitDir bool   `yaml:"keepGitDir" json:"keepGitDir"`
 }
 
-// No longer supports `.git` URLs as git repos. That has to be done with
-// `SourceGit`
+// SourceHTTP is used to download a file from an HTTP(s) URL.
 type SourceHTTP struct {
+	// URL is the URL to download the file from.
 	URL string `yaml:"url" json:"url"`
+	// Digest is the digest of the file to download.
+	// This is used to verify the integrity of the file.
+	// Form: <algorithm>:<digest>
+	Digest digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
 }
 
 // SourceContext is used to generate a source from a build context. The path to

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Azure/dalec"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/opencontainers/go-digest"
 )
 
 func TestSourceCmd(t *testing.T) {
@@ -137,5 +139,48 @@ func TestSourceBuild(t *testing.T) {
 			doBuildTest(t, "file", newBuildSpec("foo", fileSrc))
 			doBuildTest(t, "dir", newBuildSpec("foo", dirSrc("foo")))
 		})
+	})
+}
+
+func TestSourceHTTP(t *testing.T) {
+	t.Parallel()
+
+	url := "https://raw.githubusercontent.com/Azure/dalec/0ae22acf69ab6ef0a0503affed1a8952c9dd1384/README.md"
+	const badDigest = digest.Digest("sha256:000084c7170b4cfbad0690412259b5e252f84c0ccff79aaca023beb3f3ed0000")
+	const goodDigest = digest.Digest("sha256:b0fa84c7170b4cfbad0690412259b5e252f84c0ccff79aaca023beb3f3ed6380")
+
+	newSpec := func(url string, digest digest.Digest) *dalec.Spec {
+		return &dalec.Spec{
+			Sources: map[string]dalec.Source{
+				"test": {
+					HTTP: &dalec.SourceHTTP{
+						URL:    url,
+						Digest: digest,
+					},
+				},
+			},
+		}
+	}
+
+	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) (*gwclient.Result, error) {
+		bad := newSolveRequest(withBuildTarget("debug/sources"), withSpec(ctx, t, newSpec(url, badDigest)))
+		bad.Evaluate = true
+		_, err := gwc.Solve(ctx, bad)
+		if err == nil {
+			t.Fatal("expected digest mismatch, but received none")
+		}
+
+		if !strings.Contains(err.Error(), "digest mismatch") {
+			t.Fatalf("expected digest mismatch, got: %v", err)
+		}
+
+		good := newSolveRequest(withBuildTarget("debug/sources"), withSpec(ctx, t, newSpec(url, goodDigest)))
+		good.Evaluate = true
+		_, err = gwc.Solve(ctx, good)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return gwclient.NewResult(), nil
 	})
 }


### PR DESCRIPTION
This is needed to ensure the integrity of http sources.

Closes #64 (or at least to the best we can possibly handle in dalec).