### PR TITLE
Add support for generating go module deps

### DIFF
--- a/docs/examples/go-md2man-1.yml
+++ b/docs/examples/go-md2man-1.yml
@@ -1,6 +1,7 @@
 # syntax=ghcr.io/azure/dalec/frontend:latest
 name: go-md2man
 version: 2.0.3
+revision: "1"
 packager: Dalec Example
 vendor: Dalec Example
 license: MIT

--- a/docs/examples/go-md2man-2.yml
+++ b/docs/examples/go-md2man-2.yml
@@ -1,6 +1,7 @@
 # syntax=ghcr.io/azure/dalec/frontend:latest
 name: go-md2man
 version: 2.0.3
+revision: "1"
 packager: Dalec Example
 vendor: Dalec Example
 license: MIT
@@ -9,27 +10,11 @@ website: https://github.com/cpuguy83/go-md2man
 
 sources:
   src:
+    generate:
+      - gomod: {}
     git:
       url: https://github.com/cpuguy83/go-md2man.git
       commit: "v2.0.3"
-  gomods: # This is required when the build environment does not allow network access. This downloads all the go modules.
-    path: /build/gomodcache # This is the path we will be extracing after running the command below.
-    image:
-      ref: mcr.microsoft.com/oss/go/microsoft/golang:1.21
-      cmd:
-        dir: /build/src
-        mounts:
-          # Mount a source (inline, under `spec`), so our command has access to it.
-          - dest: /build/src
-            spec:
-              git:
-                url: https://github.com/cpuguy83/go-md2man.git
-                commit: "v2.0.3"
-        steps:
-          - command: go mod download
-            env:
-              # This variable controls where the go modules are downloaded to.
-              GOMODCACHE: /build/gomodcache
 
 dependencies:
   build:
@@ -40,7 +25,6 @@ build:
     CGO_ENABLED: "0"
   steps:
     - command: |
-        export GOMODCACHE="$(pwd)/gomods"
         cd src
         go build -o go-md2man .
 

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -291,6 +291,12 @@
 			],
 			"description": "Frontend encapsulates the configuration for a frontend to forward a build target to."
 		},
+		"GeneratorGomod": {
+			"properties": {},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "GeneratorGomod is used to generate a go module cache from go module sources"
+		},
 		"ImageConfig": {
 			"properties": {
 				"entrypoint": {
@@ -466,6 +472,13 @@
 					},
 					"type": "array",
 					"description": "Excludes is a list of paths underneath `Path` to exclude, everything else is included"
+				},
+				"generate": {
+					"items": {
+						"$ref": "#/$defs/SourceGenerator"
+					},
+					"type": "array",
+					"description": "Generate is the list generators to run on the source.\n\nGenerators are used to generate additional sources from this source.\nAs an example the `godmod` generator can be used to generate a go module cache from a go source.\nHow a genator operates is dependent on the actual generator.\nGeneators may also cauuse modifications to the build environment.\n\nCurrently only one generator is supported: \"gomod\""
 				}
 			},
 			"additionalProperties": false,
@@ -523,6 +536,24 @@
 			"required": [
 				"ref"
 			]
+		},
+		"SourceGenerator": {
+			"properties": {
+				"subpath": {
+					"type": "string",
+					"description": "Subpath is the path inside a source to run the generator from."
+				},
+				"gomod": {
+					"$ref": "#/$defs/GeneratorGomod",
+					"description": "Gomod is the go module generator."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"gomod"
+			],
+			"description": "SourceGenerator holds the configuration for a source generator."
 		},
 		"SourceGit": {
 			"properties": {

--- a/frontend/debug/handle_gomod.go
+++ b/frontend/debug/handle_gomod.go
@@ -1,0 +1,60 @@
+package debug
+
+import (
+	"context"
+
+	"github.com/Azure/dalec"
+	"github.com/Azure/dalec/frontend"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const keyGomodWorker = "context:gomod-worker"
+
+// Gomods outputs all the gomodule dependencies for the spec
+func Gomods(ctx context.Context, client gwclient.Client) (*client.Result, error) {
+	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
+		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		inputs, err := client.Inputs(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Allow the client to override the worker image
+		// This is useful for keeping pre-built worker image, especially for CI.
+		worker, ok := inputs[keyGomodWorker]
+		if !ok {
+			worker = llb.Image("alpine:latest", llb.WithMetaResolver(client)).
+				Run(llb.Shlex("apk add --no-cache go git ca-certificates patch")).Root()
+		}
+
+		st, err := spec.GomodDeps(sOpt, worker)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		res, err := client.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, nil, err
+		}
+		return ref, nil, nil
+	})
+}

--- a/frontend/debug/handler.go
+++ b/frontend/debug/handler.go
@@ -21,6 +21,10 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 		Name:        "sources",
 		Description: "Outputs all sources from a dalec spec file.",
 	})
+	r.Add("gomods", Gomods, &targets.Target{
+		Name:        "gomods",
+		Description: "Outputs all the gomodule dependencies for the spec",
+	})
 
 	return r.Handle(ctx, client)
 }

--- a/frontend/mariner2/handler.go
+++ b/frontend/mariner2/handler.go
@@ -2,9 +2,13 @@ package mariner2
 
 import (
 	"context"
+	"errors"
+	"slices"
 
+	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/frontend"
 	"github.com/Azure/dalec/frontend/rpm"
+	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	bktargets "github.com/moby/buildkit/frontend/subrequests/targets"
 )
@@ -20,7 +24,8 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 		Name:        "rpm",
 		Description: "Builds an rpm and src.rpm for mariner2.",
 	})
-	mux.Add("rpm/debug", rpm.HandleDebug(), nil)
+
+	mux.Add("rpm/debug", handleDebug, nil)
 
 	mux.Add("container", handleContainer, &bktargets.Target{
 		Name:        "container",
@@ -34,4 +39,24 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 	})
 
 	return mux.Handle(ctx, client)
+}
+
+func handleDebug(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
+	return rpm.HandleDebug(getSpecWorker)(ctx, client)
+}
+
+func getSpecWorker(resolver llb.ImageMetaResolver, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	st := getWorkerImage(resolver, opts...)
+	if spec.HasGomods() {
+		deps := spec.GetBuildDeps(targetKey)
+		hasGolang := func(s string) bool {
+			return s == "golang" || s == "msft-golang"
+		}
+
+		if !slices.ContainsFunc(deps, hasGolang) {
+			return llb.Scratch(), errors.New("spec contains go modules but does not have golang in build deps")
+		}
+		st = st.With(installBuildDeps(spec, targetKey, opts...))
+	}
+	return st, nil
 }

--- a/frontend/rpm/handle_buildroot.go
+++ b/frontend/rpm/handle_buildroot.go
@@ -11,7 +11,9 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func HandleBuildroot() gwclient.BuildFunc {
+type WorkerFunc func(resolver llb.ImageMetaResolver, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error)
+
+func HandleBuildroot(wf WorkerFunc) gwclient.BuildFunc {
 	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 		return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
 			sOpt, err := frontend.SourceOptFromClient(ctx, client)
@@ -19,7 +21,12 @@ func HandleBuildroot() gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			st, err := SpecToBuildrootLLB(spec, sOpt, targetKey)
+			worker, err := wf(sOpt.Resolver, spec, targetKey)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			st, err := SpecToBuildrootLLB(worker, spec, sOpt, targetKey)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -47,13 +54,13 @@ func HandleBuildroot() gwclient.BuildFunc {
 }
 
 // SpecToBuildrootLLB converts a dalec.Spec to an rpm buildroot
-func SpecToBuildrootLLB(spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
+func SpecToBuildrootLLB(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
 	if err := ValidateSpec(spec); err != nil {
 		return llb.Scratch(), fmt.Errorf("invalid spec: %w", err)
 	}
 	opts = append(opts, dalec.ProgressGroup("Create RPM buildroot"))
 
-	sources, err := Dalec2SourcesLLB(spec, sOpt, opts...)
+	sources, err := Dalec2SourcesLLB(worker, spec, sOpt, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}

--- a/frontend/rpm/handler.go
+++ b/frontend/rpm/handler.go
@@ -9,16 +9,16 @@ import (
 )
 
 // HandleDebug returns a build function that adds support for some debugging targets for RPM builds.
-func HandleDebug() gwclient.BuildFunc {
+func HandleDebug(wf WorkerFunc) gwclient.BuildFunc {
 	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 		var r frontend.BuildMux
 
-		r.Add("buildroot", HandleBuildroot(), &targets.Target{
+		r.Add("buildroot", HandleBuildroot(wf), &targets.Target{
 			Name:        "buildroot",
 			Description: "Outputs an rpm buildroot suitable for passing to rpmbuild.",
 		})
 
-		r.Add("sources", HandleSources(), &targets.Target{
+		r.Add("sources", HandleSources(wf), &targets.Target{
 			Name:        "sources",
 			Description: "Outputs all the sources specified in the spec file in the format given to rpmbuild.",
 		})

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -1,0 +1,208 @@
+package rpm
+
+import (
+	"bufio"
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Azure/dalec"
+)
+
+func TestTemplateSources(t *testing.T) {
+	t.Run("no sources", func(t *testing.T) {
+		w := &specWrapper{Spec: &dalec.Spec{}}
+		s, err := w.Sources()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s.String() != "" {
+			t.Fatalf("unexpected sources: %s", s.String())
+		}
+	})
+
+	// Each source entry is prefixed by comments documenting how the source was generated
+	// This gets the source documentation and turns it into the expected comment string
+	srcDoc := func(name string, src dalec.Source) string {
+		rdr, err := src.Doc(name)
+		if err != nil {
+			return ""
+		}
+		buf := bytes.NewBuffer(nil)
+		scanner := bufio.NewScanner(rdr)
+		for scanner.Scan() {
+			buf.WriteString("# ")
+			buf.WriteString(scanner.Text())
+			buf.WriteString("\n")
+		}
+		return buf.String()
+	}
+
+	t.Run("one source file", func(t *testing.T) {
+		w := &specWrapper{Spec: &dalec.Spec{
+			Sources: map[string]dalec.Source{
+				"src1": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{},
+					},
+				},
+			},
+		}}
+
+		out, err := w.Sources()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedDoc := srcDoc("src1", w.Spec.Sources["src1"])
+
+		s := out.String()
+		if !strings.HasPrefix(s, expectedDoc) {
+			t.Errorf("Expected doc:\n%q\n\n, got:\n%q\n", expectedDoc, s)
+		}
+
+		// File sources are not (currently) compressed, so the source is the file itself
+		expected := "Source0: src1\n"
+		actual := s[len(expectedDoc):] // trim off the doc from the output
+		if actual != expected {
+			t.Fatalf("unexpected sources: expected %q, got: %q", expected, actual)
+		}
+	})
+
+	t.Run("one source dir", func(t *testing.T) {
+		w := &specWrapper{Spec: &dalec.Spec{
+			Sources: map[string]dalec.Source{
+				"src1": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{},
+					},
+				},
+			},
+		}}
+
+		out, err := w.Sources()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedDoc := srcDoc("src1", w.Spec.Sources["src1"])
+
+		s := out.String()
+		if !strings.HasPrefix(s, expectedDoc) {
+			t.Errorf("Expected doc:\n%q\n\n, got:\n%q\n", expectedDoc, s)
+		}
+
+		expected := "Source0: src1.tar.gz\n"
+		actual := s[len(expectedDoc):] // trim off the doc from the output
+		if actual != expected {
+			t.Fatalf("unexpected sources: expected %q, got: %q", expected, actual)
+		}
+
+		t.Run("with gomod", func(t *testing.T) {
+			src := w.Spec.Sources["src1"]
+			src.Generate = []*dalec.SourceGenerator{
+				{Gomod: &dalec.GeneratorGomod{}},
+			}
+			w.Spec.Sources["src1"] = src
+
+			out2, err := w.Sources()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			s2 := out2.String()
+			if !strings.HasPrefix(s2, s) {
+				t.Fatalf("expected output to start with %q, got %q", s, out2.String())
+			}
+
+			s2 = strings.TrimPrefix(out2.String(), s)
+			expected := "Source1: " + gomodsName + ".tar.gz\n"
+			if s2 != expected {
+				t.Fatalf("unexpected sources: expected %q, got: %q", expected, s2)
+			}
+		})
+	})
+
+	t.Run("multiple sources", func(t *testing.T) {
+		w := &specWrapper{Spec: &dalec.Spec{
+			Sources: map[string]dalec.Source{
+				"src1": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{},
+					},
+				},
+				"src2": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{},
+					},
+				},
+				"src3": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{},
+					},
+				},
+				"src4": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{},
+					},
+					Generate: []*dalec.SourceGenerator{
+						{Gomod: &dalec.GeneratorGomod{}},
+					},
+				},
+				"src5": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{},
+					},
+					Generate: []*dalec.SourceGenerator{
+						{Gomod: &dalec.GeneratorGomod{}},
+					},
+				},
+			},
+		}}
+
+		out, err := w.Sources()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		s := out.String()
+
+		// Note: order (in the produced output) should be deterministic here regardless of map ordering (especially since maps are randomized).
+		ordered := dalec.SortMapKeys(w.Spec.Sources)
+		for i, name := range ordered {
+			src := w.Spec.Sources[name]
+			expectedDoc := srcDoc(name, src)
+
+			if !strings.HasPrefix(s, expectedDoc) {
+				t.Errorf("%s: Expected doc:\n%q\n\n, got:\n%q\n", name, expectedDoc, s)
+			}
+
+			s = s[len(expectedDoc):] // trim off the doc from the output
+			suffix := "\n"
+			if dalec.SourceIsDir(src) {
+				suffix = ".tar.gz\n"
+			}
+
+			expected := "Source" + strconv.Itoa(i) + ": " + name + suffix
+			if s[:len(expected)] != expected {
+				t.Fatalf("%s: unexpected sources: expected %q, got: %q", name, expected, s[:len(expected)])
+			}
+
+			// Trim off the rest of the bits we've checked for the next loop iteration
+			s = s[len(expected):]
+		}
+
+		// Now we should have one more entry for gomods.
+		// Note there are 2 gomod sources but they should be combined into one entry.
+
+		expected := "Source5: " + gomodsName + ".tar.gz\n"
+		if s != expected {
+			t.Fatalf("gomod: unexpected sources: expected %q, got: %q", expected, s)
+		}
+		s = s[len(expected):]
+		if s != "" {
+			t.Fatalf("unexpected trailing sources: %q", s)
+		}
+	})
+}

--- a/generator_gomod.go
+++ b/generator_gomod.go
@@ -1,0 +1,93 @@
+package dalec
+
+import (
+	"github.com/moby/buildkit/client/llb"
+	"github.com/pkg/errors"
+)
+
+const (
+	gomodCacheDir = "/go/pkg/mod"
+)
+
+func (s *Source) isGomod() bool {
+	for _, gen := range s.Generate {
+		if gen.Gomod != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// HasGomods returns true if any of the sources in the spec are a go module.
+func (s *Spec) HasGomods() bool {
+	for _, src := range s.Sources {
+		if src.isGomod() {
+			return true
+		}
+	}
+	return false
+}
+
+func withGomod(g *SourceGenerator, srcSt, worker llb.State, opts ...llb.ConstraintsOpt) func(llb.State) llb.State {
+	return func(in llb.State) llb.State {
+		const workDir = "/work/src"
+		var srcMount llb.RunOption
+		if g.Subpath != "" {
+			srcMount = llb.AddMount(workDir, srcSt, llb.SourcePath(g.Subpath))
+		} else {
+			srcMount = llb.AddMount(workDir, srcSt)
+		}
+		return worker.Run(
+			shArgs("go mod download"),
+			llb.AddEnv("GOMODCACHE", gomodCacheDir),
+			llb.Dir(workDir),
+			srcMount,
+			WithConstraints(opts...),
+		).AddMount(gomodCacheDir, in)
+	}
+}
+
+func (s *Spec) gomodSources() map[string]Source {
+	sources := map[string]Source{}
+	for name, src := range s.Sources {
+		if src.isGomod() {
+			sources[name] = src
+		}
+	}
+	return sources
+}
+
+// GomodDeps returns an [llb.State] containing all the go module dependencies for the spec
+// for any sources that have a gomod generator specified.
+// If there are no sources with a gomod generator, this will return a nil state.
+func (s *Spec) GomodDeps(sOpt SourceOpts, worker llb.State, opts ...llb.ConstraintsOpt) (*llb.State, error) {
+	sources := s.gomodSources()
+
+	deps := llb.Scratch()
+
+	// Get the patched sources for the go modules
+	// This is needed in case a patch includes changes to go.mod or go.sum
+	patched, err := s.getPatchedSources(sOpt, worker, func(name string) bool {
+		_, ok := sources[name]
+		return ok
+	}, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get patched sources")
+	}
+
+	sorted := SortMapKeys(patched)
+
+	for _, key := range sorted {
+		src := s.Sources[key]
+
+		opts := append(opts, ProgressGroup("Fetch go module dependencies for source: "+key))
+		deps = deps.With(func(in llb.State) llb.State {
+			for _, gen := range src.Generate {
+				in = in.With(withGomod(gen, patched[key], worker, opts...))
+			}
+			return in
+		})
+	}
+
+	return &deps, nil
+}

--- a/load.go
+++ b/load.go
@@ -130,6 +130,12 @@ func (s *Source) validate(failContext ...string) (retErr error) {
 		}
 	}()
 
+	for _, g := range s.Generate {
+		if err := g.Validate(); err != nil {
+			retErr = goerrors.Join(retErr, err)
+		}
+	}
+
 	if s.DockerImage != nil {
 		if s.DockerImage.Ref == "" {
 			retErr = goerrors.Join(retErr, fmt.Errorf("docker image source variant must have a ref"))
@@ -479,5 +485,14 @@ func (c *FileCheckOutput) processBuildArgs(lex *shell.Lex, args map[string]strin
 		return err
 	}
 	c.CheckOutput = check
+	return nil
+}
+
+func (g *SourceGenerator) Validate() error {
+	if g.Gomod == nil {
+		// Gomod is the only valid generator type
+		// An empty generator is invalid
+		return fmt.Errorf("no generator type specified")
+	}
 	return nil
 }

--- a/load_test.go
+++ b/load_test.go
@@ -212,6 +212,26 @@ func TestSourceValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			title:     "has invalid genator config",
+			expectErr: true,
+			src: Source{
+				Inline: &SourceInline{
+					File: &SourceInlineFile{},
+				},
+				Generate: []*SourceGenerator{{}},
+			},
+		},
+		{
+			title:     "has valid genator",
+			expectErr: false,
+			src: Source{
+				Inline: &SourceInline{
+					File: &SourceInlineFile{},
+				},
+				Generate: []*SourceGenerator{{Gomod: &GeneratorGomod{}}},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/spec.go
+++ b/spec.go
@@ -280,6 +280,30 @@ type Source struct {
 	Includes []string `yaml:"includes,omitempty" json:"includes,omitempty"`
 	// Excludes is a list of paths underneath `Path` to exclude, everything else is included
 	Excludes []string `yaml:"excludes,omitempty" json:"excludes,omitempty"`
+
+	// Generate is the list generators to run on the source.
+	//
+	// Generators are used to generate additional sources from this source.
+	// As an example the `godmod` generator can be used to generate a go module cache from a go source.
+	// How a genator operates is dependent on the actual generator.
+	// Geneators may also cauuse modifications to the build environment.
+	//
+	// Currently only one generator is supported: "gomod"
+	Generate []*SourceGenerator `yaml:"generate,omitempty" json:"generate,omitempty"`
+}
+
+// GeneratorGomod is used to generate a go module cache from go module sources
+type GeneratorGomod struct {
+}
+
+// SourceGenerator holds the configuration for a source generator.
+// This can be used inside of a [Source] to generate additional sources from the given source.
+type SourceGenerator struct {
+	// Subpath is the path inside a source to run the generator from.
+	Subpath string `yaml:"subpath,omitempty" json:"subpath,omitempty"`
+
+	// Gomod is the go module generator.
+	Gomod *GeneratorGomod `yaml:"gomod" json:"gomod"`
 }
 
 // PackageDependencies is a list of dependencies for a package.

--- a/test/fixtures/frontend.yml
+++ b/test/fixtures/frontend.yml
@@ -12,20 +12,8 @@ license: Apache 2.0
 sources:
   src:
     context: {}
-  gomodcache:
-    path: /build/gomodcache
-    image:
-      ref: mcr.microsoft.com/oss/go/microsoft/golang:1.21
-      cmd:
-        dir: /build/src
-        mounts:
-          - dest: /build/src
-            spec:
-              context: {}
-        steps:
-          - command: go mod download
-            env:
-              GOMODCACHE: /build/gomodcache
+    generate:
+      - gomod: {}
 
 dependencies:
   build:
@@ -40,7 +28,6 @@ build:
     GOPATH: /go
   steps:
     - command: |
-        export GOMODCACHE="$(pwd)/gomodcache"
         cd src
         go build -o ../frontend ./cmd/frontend
 

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -161,7 +161,7 @@ func (d dirStatAsStringer) String() string {
 type srOpt func(*gwclient.SolveRequest)
 
 func newSolveRequest(opts ...srOpt) gwclient.SolveRequest {
-	sr := gwclient.SolveRequest{}
+	sr := gwclient.SolveRequest{Evaluate: true}
 	for _, opt := range opts {
 		opt(&sr)
 	}


### PR DESCRIPTION
This adds a new `Generate` field on `Source` which is a list of
generator configs.
Today the only type of generator we support is for go modules but we'll
likely need to add support for other things, e.g. Rust cargo deps.

Multiple geneator configs are allowed in the case of a source with
multiple go modules defined in it.

Closes #180
