### PR TITLE
mariner2: Use empty rootfs for default container

### DIFF
--- a/frontend/mariner2/handle_depsonly.go
+++ b/frontend/mariner2/handle_depsonly.go
@@ -26,7 +26,7 @@ func handleDepsOnly(ctx context.Context, client gwclient.Client) (*gwclient.Resu
 		if err != nil {
 			return nil, nil, err
 		}
-		st, err := specToContainerLLB(spec, targetKey, baseImg, rpmDir, sOpt, pg)
+		st, err := specToContainerLLB(ctx, spec, targetKey, baseImg, rpmDir, sOpt, pg)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Before this we were using the distroless image's rootfs as the base for the output container.
With this change an empty rootfs is used unless the spec has an image specified.

Closes #51