### PR TITLE
Actually use test depdenencies

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -395,7 +395,7 @@
 						"type": "string"
 					},
 					"type": "array",
-					"description": "Test lists any extra packages required for running tests"
+					"description": "Test lists any extra packages required for running tests\nThese packages are only installed for tests which have steps that require\nrunning a command in the built container.\nSee [TestSpec] for more information."
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/mariner2/handle_rpm.go
+++ b/frontend/mariner2/handle_rpm.go
@@ -89,16 +89,21 @@ func installBuildDeps(spec *dalec.Spec, targetKey string, opts ...llb.Constraint
 		if len(deps) == 0 {
 			return in
 		}
-
 		opts = append(opts, dalec.ProgressGroup("Install build deps"))
-		return in.
-			Run(
-				shArgs(fmt.Sprintf("tdnf install --releasever=2.0 -y %s", strings.Join(deps, " "))),
-				defaultTdnfCacheMount(),
-				dalec.WithConstraints(opts...),
-			).
-			Root()
+		return in.Run(
+			installPackgesRunOpts("/", deps, false),
+			defaultTdnfCacheMount(),
+			dalec.WithConstraints(opts...),
+		).Root()
 	}
+}
+
+func installPackgesRunOpts(root string, packages []string, cleanup bool) llb.RunOption {
+	cmd := fmt.Sprintf("set -e; tdnf install --installroot=%q --releasever=2.0 -y %s", root, strings.Join(packages, " "))
+	if cleanup {
+		cmd += fmt.Sprintf("; rm -rf %q", filepath.Join(root, "/var/lib/rpm"))
+	}
+	return shArgs(cmd)
 }
 
 func specToRpmLLB(spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -3,6 +3,7 @@ package dalec
 import (
 	"encoding/json"
 	"path"
+	"slices"
 	"sort"
 	"sync/atomic"
 
@@ -279,14 +280,25 @@ func (s *Spec) GetBuildDeps(targetKey string) []string {
 		}
 	}
 
-	var out []string
-	for p := range deps.Build {
-		out = append(out, p)
+	return SortMapKeys(deps.Build)
+}
+
+func (s *Spec) GetTestDeps(targetKey string) []string {
+	var deps *PackageDependencies
+	if t, ok := s.Targets[targetKey]; ok {
+		deps = t.Dependencies
 	}
 
-	sort.Strings(out)
-	return out
+	if deps == nil {
+		deps = s.Dependencies
+		if deps == nil {
+			return nil
+		}
+	}
 
+	out := slices.Clone(deps.Test)
+	slices.Sort(out)
+	return out
 }
 
 func (s *Spec) GetSymlinks(target string) map[string]SymlinkTarget {

--- a/spec.go
+++ b/spec.go
@@ -319,6 +319,9 @@ type PackageDependencies struct {
 	Recommends map[string][]string `yaml:"recommends,omitempty" json:"recommends,omitempty"`
 
 	// Test lists any extra packages required for running tests
+	// These packages are only installed for tests which have steps that require
+	// running a command in the built container.
+	// See [TestSpec] for more information.
 	Test []string `yaml:"test,omitempty" json:"test,omitempty"`
 }
 

--- a/test/fixtures/moby-runc.yml
+++ b/test/fixtures/moby-runc.yml
@@ -34,9 +34,10 @@ targets: # Distro specific build requirements
         pkgconfig:
         tar:
       runtime:
-        /bin/sh:
         libseccomp:
           - ">= 2.3"
+      test:
+        - /bin/sh
     tests:
       - name: mariner rpm manifest files
         files:


### PR DESCRIPTION
We were never installing test dependencies before. Installing test deps requires some careful handling to not modify containers too much and as such should be used only when necessary.

Test dependencies do not alter the output container, only the container under test, and only when there are commands that need to be run in the container since the built-in test handlers do not require any extra tooling.
