### PR TITLE
Add ability to specify shared state and config directories

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -57,6 +57,20 @@
 					},
 					"type": "object",
 					"description": "Manpages is the list of manpages to include in the package."
+				},
+				"configDirectories": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "ConfigDirectories is a list of directories the RPM should under %{_sysconfigdir}\t."
+				},
+				"sharedStateDirectories": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "SharedStateDirectories is a list of directories the RPM should under %{%_sharedstatedir}\t."
 				}
 			},
 			"additionalProperties": false,

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -63,14 +63,14 @@
 						"type": "string"
 					},
 					"type": "array",
-					"description": "ConfigDirectories is a list of directories the RPM should under %{_sysconfigdir}\t."
+					"description": "ConfigDirectories is a list of directories the RPM should place under %{_sysconfigdir}\t."
 				},
 				"sharedStateDirectories": {
 					"items": {
 						"type": "string"
 					},
 					"type": "array",
-					"description": "SharedStateDirectories is a list of directories the RPM should under %{%_sharedstatedir}\t."
+					"description": "SharedStateDirectories is a list of directories the RPM should place under %{%_sharedstatedir}\t."
 				}
 			},
 			"additionalProperties": false,

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -42,6 +42,17 @@
 			"type": "object",
 			"description": "ArtifactConfig is the configuration for a given artifact type."
 		},
+		"ArtifactDirConfig": {
+			"properties": {
+				"mode": {
+					"type": "integer",
+					"description": "Mode is used to set the file permission bits of the final created directory to the specified mode.\nMode is the octal permissions to set on the dir."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "ArtifactDirConfig contains information about the directory to be created"
+		},
 		"Artifacts": {
 			"properties": {
 				"binaries": {
@@ -58,19 +69,9 @@
 					"type": "object",
 					"description": "Manpages is the list of manpages to include in the package."
 				},
-				"configDirectories": {
-					"items": {
-						"type": "string"
-					},
-					"type": "array",
-					"description": "ConfigDirectories is a list of directories the RPM should place under %{_sysconfigdir}\t."
-				},
-				"sharedStateDirectories": {
-					"items": {
-						"type": "string"
-					},
-					"type": "array",
-					"description": "SharedStateDirectories is a list of directories the RPM should place under %{%_sharedstatedir}\t."
+				"createDirectories": {
+					"$ref": "#/$defs/CreateArtifactDirectories",
+					"description": "Directories is a list of various directories that should be created by the RPM."
 				}
 			},
 			"additionalProperties": false,
@@ -237,6 +238,31 @@
 				"steps"
 			],
 			"description": "Command is used to execute a command to generate a source from a docker image."
+		},
+		"CreateArtifactDirectories": {
+			"properties": {
+				"Config": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactDirConfig"
+					},
+					"type": "object",
+					"description": "Config is a list of directories the RPM should place under %{_sysconfigdir} (i.e. /etc)"
+				},
+				"State": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactDirConfig"
+					},
+					"type": "object",
+					"description": "State is a list of directories the RPM should place under %{%_sharedstatedir} (i.e. /var/lib)."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"Config",
+				"State"
+			],
+			"description": "CreateArtifactDirectories describes various directories that should be created on install."
 		},
 		"FileCheckOutput": {
 			"properties": {

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -246,14 +246,14 @@
 						"$ref": "#/$defs/ArtifactDirConfig"
 					},
 					"type": "object",
-					"description": "Config is a list of directories the RPM should place under %{_sysconfigdir} (i.e. /etc)"
+					"description": "Config is a list of directories the RPM should place under the system config directory (i.e. /etc)"
 				},
 				"State": {
 					"additionalProperties": {
 						"$ref": "#/$defs/ArtifactDirConfig"
 					},
 					"type": "object",
-					"description": "State is a list of directories the RPM should place under %{%_sharedstatedir} (i.e. /var/lib)."
+					"description": "State is a list of directories the RPM should place under the common directory for shared state and libs (i.e. /var/lib)."
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -326,6 +326,17 @@ func (w *specWrapper) Install() fmt.Stringer {
 		copyArtifact(`%{buildroot}/%{_mandir}`, p, cfg)
 	}
 
+	sort.Strings(w.Spec.Artifacts.ConfigDirectories)
+	for _, p := range w.Spec.Artifacts.ConfigDirectories {
+		dir := filepath.Join(`%{buildroot}/%{_sysconfdir}`, p)
+		fmt.Fprintln(b, "mkdir -p", dir)
+	}
+
+	sort.Strings(w.Spec.Artifacts.SharedStateDirectories)
+	for _, p := range w.Spec.Artifacts.SharedStateDirectories {
+		dir := filepath.Join(`%{buildroot}/%{_sharedstatedir}`, p)
+		fmt.Fprintln(b, "mkdir -p", dir)
+	}
 	return b
 }
 
@@ -346,6 +357,18 @@ func (w *specWrapper) Files() fmt.Stringer {
 
 	if len(w.Spec.Artifacts.Manpages) > 0 {
 		fmt.Fprintln(b, `%{_mandir}/*/*`)
+	}
+
+	sort.Strings(w.Spec.Artifacts.ConfigDirectories)
+	for _, p := range w.Spec.Artifacts.ConfigDirectories {
+		dir := strings.Join([]string{`%dir`, filepath.Join(`%{_sysconfdir}`, p)}, " ")
+		fmt.Fprintln(b, dir)
+	}
+
+	sort.Strings(w.Spec.Artifacts.SharedStateDirectories)
+	for _, p := range w.Spec.Artifacts.SharedStateDirectories {
+		dir := strings.Join([]string{`%dir`, filepath.Join(`%{_sharedstatedir}`, p)}, " ")
+		fmt.Fprintln(b, dir)
 	}
 	return b
 }

--- a/spec.go
+++ b/spec.go
@@ -127,7 +127,12 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
+	// ConfigDirectories is a list of directories the RPM should under %{_sysconfigdir}	.
+	ConfigDirectories []string `yaml:"configDirectories,omitempty" json:"configDirectories,omitempty"`
+	// SharedStateDirectories is a list of directories the RPM should under %{%_sharedstatedir}	.
+	SharedStateDirectories []string `yaml:"sharedStateDirectories,omitempty" json:"sharedStateDirectories,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, configs, etc)
+
 }
 
 // ArtifactConfig is the configuration for a given artifact type.

--- a/spec.go
+++ b/spec.go
@@ -127,9 +127,9 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
-	// ConfigDirectories is a list of directories the RPM should under %{_sysconfigdir}	.
+	// ConfigDirectories is a list of directories the RPM should place under %{_sysconfigdir}	.
 	ConfigDirectories []string `yaml:"configDirectories,omitempty" json:"configDirectories,omitempty"`
-	// SharedStateDirectories is a list of directories the RPM should under %{%_sharedstatedir}	.
+	// SharedStateDirectories is a list of directories the RPM should place under %{%_sharedstatedir}	.
 	SharedStateDirectories []string `yaml:"sharedStateDirectories,omitempty" json:"sharedStateDirectories,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, configs, etc)
 

--- a/spec.go
+++ b/spec.go
@@ -135,9 +135,9 @@ type Artifacts struct {
 // CreateArtifactDirectories describes various directories that should be created on install.
 // CreateArtifactDirectories represents different directory paths that are common to RPM systems.
 type CreateArtifactDirectories struct {
-	// Config is a list of directories the RPM should place under %{_sysconfigdir} (i.e. /etc)
+	// Config is a list of directories the RPM should place under the system config directory (i.e. /etc)
 	Config map[string]ArtifactDirConfig
-	// State is a list of directories the RPM should place under %{%_sharedstatedir} (i.e. /var/lib).
+	// State is a list of directories the RPM should place under the common directory for shared state and libs (i.e. /var/lib).
 	State map[string]ArtifactDirConfig
 }
 

--- a/spec.go
+++ b/spec.go
@@ -127,12 +127,25 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
-	// ConfigDirectories is a list of directories the RPM should place under %{_sysconfigdir}	.
-	ConfigDirectories []string `yaml:"configDirectories,omitempty" json:"configDirectories,omitempty"`
-	// SharedStateDirectories is a list of directories the RPM should place under %{%_sharedstatedir}	.
-	SharedStateDirectories []string `yaml:"sharedStateDirectories,omitempty" json:"sharedStateDirectories,omitempty"`
+	// Directories is a list of various directories that should be created by the RPM.
+	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, configs, etc)
+}
 
+// CreateArtifactDirectories describes various directories that should be created on install.
+// CreateArtifactDirectories represents different directory paths that are common to RPM systems.
+type CreateArtifactDirectories struct {
+	// Config is a list of directories the RPM should place under %{_sysconfigdir} (i.e. /etc)
+	Config map[string]ArtifactDirConfig
+	// State is a list of directories the RPM should place under %{%_sharedstatedir} (i.e. /var/lib).
+	State map[string]ArtifactDirConfig
+}
+
+// ArtifactDirConfig contains information about the directory to be created
+type ArtifactDirConfig struct {
+	// Mode is used to set the file permission bits of the final created directory to the specified mode.
+	// Mode is the octal permissions to set on the dir.
+	Mode fs.FileMode `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
 // ArtifactConfig is the configuration for a given artifact type.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ability to specify directories that should be created for %{_sharedstatedir} and  %{_sysconfdir}

This will ensure they are created during the install phase and that they show up in the files section of the resulting RPM spec.

In the spec, this would look like:

```
artifacts:
  createDirectories:
    config:
      kubernetes: 
        mode: 0755
      kubernetes/manifests: {}
    state:
      kubelet: {}
```

This would result in:

```
%install
mkdir -m 755 -p "%{buildroot}/%{_sysconfdir}/kubernetes"
mkdir -p "%{buildroot}/%{_sysconfdir}/kubernetes/manifests"
mkdir -p "%{buildroot}/%{_sharedstatedir}/kubelet"

%files
%dir %{_sysconfdir}/kubernetes
%dir %{_sysconfdir}/kubernetes/manifests
%dir %{_sharedstatedir}/kubelet
```


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #239

**Special notes for your reviewer**:
