### PR TITLE
docs: update available targets on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ To print a list of available build targets:
 
 ```console
 $ BUILDX_EXPERIMENTAL=1 docker build --print=targets -f test/fixtures/moby-runc.yml .
+debug/gomods                 Outputs all the gomodule dependencies for the spec
 debug/resolve                Outputs the resolved dalec spec file with build args applied.
-mariner2                     Alias for target mariner2/container
-mariner2/container (default) Builds a container with the RPM installed.
+debug/sources                Outputs all sources from a dalec spec file.
+mariner2/container (default) Builds a container image for mariner2.
+mariner2/container/depsonly  Builds a container image with only the runtime dependencies installed.
 mariner2/rpm                 Builds an rpm and src.rpm for mariner2.
-mariner2/rpm/buildroot       Outputs an rpm buildroot suitable for passing to rpmbuild.
-mariner2/rpm/sources         Outputs all the sources specified in the spec file.
-mariner2/rpm/spec            Outputs the generated RPM spec file
+mariner2/rpm/debug/buildroot Outputs an rpm buildroot suitable for passing to rpmbuild.
+mariner2/rpm/debug/sources   Outputs all the sources specified in the spec file in the format given to rpmbuild.
+mariner2/rpm/debug/spec      Outputs the generated RPM spec file
 ```
 
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,13 @@
 # Support
 
-## How to file issues and get help  
+## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing
+issues before filing new issues to avoid duplicates.  For new issues, file your bug or
 feature request as a new Issue.
 
 For help and questions about using this project, please use Github Discussions.
 
-## Microsoft Support Policy  
+## Microsoft Support Policy
 
 Support for this **PROJECT or PRODUCT** is limited to the resources listed above.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updating result of running `BUILDX_EXPERIMENTAL=1 docker build --print=targets -f test/fixtures/moby-runc.yml .`

Is it possible to maybe create a target maybe in the `docker-bake.hcl` or something easier to remember for this command?
