### PR TITLE
Add support to spec for config files from sources

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -42,24 +42,6 @@
 			"type": "object",
 			"description": "ArtifactConfig is the configuration for a given artifact type."
 		},
-		"ArtifactConfigFileConfig": {
-			"properties": {
-				"subpath": {
-					"type": "string",
-					"description": "Subpath is the subpath to use in the package for the artifact type.\n\nAs an example, binaries are typically placed in /usr/bin when installed.\nIf you want to nest them in a subdirectory, you can specify it here."
-				},
-				"name": {
-					"type": "string",
-					"description": "Name is file or dir name to use for the artifact in the package.\nIf empty, the file or dir name from the produced artifact will be used."
-				},
-				"replace": {
-					"type": "boolean"
-				}
-			},
-			"additionalProperties": false,
-			"type": "object",
-			"description": "ArtifactConfigFileConfig is the configuration give for Artifact Config Files."
-		},
 		"ArtifactDirConfig": {
 			"properties": {
 				"mode": {
@@ -89,14 +71,14 @@
 				},
 				"createDirectories": {
 					"$ref": "#/$defs/CreateArtifactDirectories",
-					"description": "Directories is a list of various directories that should be created by the RPM."
+					"description": "Directories is a list of various directories that should be created by the package."
 				},
 				"configFiles": {
 					"additionalProperties": {
-						"$ref": "#/$defs/ArtifactConfigFileConfig"
+						"$ref": "#/$defs/ArtifactConfig"
 					},
 					"type": "object",
-					"description": "ConfigFiles is a list of files that should be marked as config files in the RPM."
+					"description": "ConfigFiles is a list of files that should be marked as config files in the package."
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -353,7 +353,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 	configKeys := dalec.SortMapKeys(w.Spec.Artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
-		copyArtifact(`%{buildroot}/%{_sysconfdir}`, c, cfg.ArtifactConfig)
+		copyArtifact(`%{buildroot}/%{_sysconfdir}`, c, cfg)
 	}
 	return b
 }
@@ -394,12 +394,8 @@ func (w *specWrapper) Files() fmt.Stringer {
 	configKeys := dalec.SortMapKeys(w.Spec.Artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
-		directive := `%config%`
-		if !cfg.ReplaceOnUpdate {
-			directive = `%config(noreplace)`
-		}
 		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, filepath.Base(c))
-		fullDirective := strings.Join([]string{directive, fullPath}, " ")
+		fullDirective := strings.Join([]string{`%config(noreplace)`, fullPath}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
 

--- a/spec.go
+++ b/spec.go
@@ -127,10 +127,10 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
-	// Directories is a list of various directories that should be created by the RPM.
+	// Directories is a list of various directories that should be created by the package.
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
-	// ConfigFiles is a list of files that should be marked as config files in the RPM.
-	ConfigFiles map[string]ArtifactConfigFileConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
+	// ConfigFiles is a list of files that should be marked as config files in the package.
+	ConfigFiles map[string]ArtifactConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, etc)
 }
 
@@ -161,13 +161,6 @@ type ArtifactConfig struct {
 	// Name is file or dir name to use for the artifact in the package.
 	// If empty, the file or dir name from the produced artifact will be used.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
-}
-
-// ArtifactConfigFileConfig is the configuration give for Artifact Config Files.
-// This is used to customize the settings for a config entry in the resulting artifact.
-type ArtifactConfigFileConfig struct {
-	ArtifactConfig
-	ReplaceOnUpdate bool `yaml:"replace,omitempty" json:"replace,omitempty"`
 }
 
 // IsEmpty is used to determine if there are any artifacts to include in the package.

--- a/test/mariner2_test.go
+++ b/test/mariner2_test.go
@@ -491,13 +491,10 @@ echo "$BAR" > bar.txt
 			},
 			Build: dalec.ArtifactBuild{},
 			Artifacts: dalec.Artifacts{
-				ConfigFiles: map[string]dalec.ArtifactConfigFileConfig{
+				ConfigFiles: map[string]dalec.ArtifactConfig{
 					"src1": {},
 					"src2": {
-						ArtifactConfig: dalec.ArtifactConfig{
-							SubPath: "sysconfig",
-						},
-						ReplaceOnUpdate: false,
+						SubPath: "sysconfig",
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ability to define config files for the resulting artifact and the relevant %config entries in the %files section, It also supports the optional inclusion of the %config(noreplace) with a boolean in the config.

This also updates the spec to add this (and directories) to the IsEmpty method for the Artifact.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #246 

**Special notes for your reviewer**:
