### PR TITLE
docs: update signing details

### DIFF
--- a/website/docs/signing.md
+++ b/website/docs/signing.md
@@ -1,5 +1,7 @@
 # Signing Packages
 
+***Note:*** Avalible on dalec release `v0.3.0+`
+
 Packages can be automatically signed using Dalec. To do this, you will
 need to provide a signing frontend. There is an example in the test
 code `test/signer/main.go`. Once that signing image has been built and
@@ -14,6 +16,9 @@ targets: # Distro specific build requirements
         image: "ref/to/signing:image"
         cmdline: "/signer"
 ```
+
+These are the targets that can leverage signing:
+`windowscross/container`, `windowscross/zip`, `mariner2/rpm`.
 
 This will send the artifacts (`.rpm`, `.deb`, or `.exe`) to the
 signing frontend as the build context.

--- a/website/docs/signing.md
+++ b/website/docs/signing.md
@@ -1,6 +1,8 @@
 # Signing Packages
 
-***Note:*** Avalible on dalec release `v0.3.0+`
+:::note
+Available with Dalec release `v0.3.0` and later.
+:::
 
 Packages can be automatically signed using Dalec. To do this, you will
 need to provide a signing frontend. There is an example in the test
@@ -17,8 +19,13 @@ targets: # Distro specific build requirements
         cmdline: "/signer"
 ```
 
-These are the targets that can leverage signing:
-`windowscross/container`, `windowscross/zip`, `mariner2/rpm`.
+At this time, these targets can leverage package signing:
+
+- `windowscross/zip`
+- `mariner2/rpm`
+- `windowscross/container`
+
+For container targets, only the artifacts within the container get signed.
 
 This will send the artifacts (`.rpm`, `.deb`, or `.exe`) to the
 signing frontend as the build context.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating docs in reference to singing,

This is a bit contradicting to Original PR in [dalec-build-defs](https://github.com/Azure/dalec-build-defs/pull/66#issue-2275877981), were shown example uses `mariner2/container` target and leverages signing!

Not sure what is the correct, if the example is wrong or we are missing the the signing frontend call during `mariner2/container` call.
