### PR TITLE
fix: Ensure container targets use signed artifact

### DIFF
--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -26,7 +26,7 @@ func handleContainer(w worker) gwclient.BuildFunc {
 
 			pg := dalec.ProgressGroup("Building " + targetKey + " container: " + spec.Name)
 
-			rpmDir, err := specToRpmLLB(w, client, spec, sOpt, targetKey, pg)
+			rpmDir, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error creating rpm: %w", err)
 			}

--- a/frontend/request.go
+++ b/frontend/request.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -119,7 +118,7 @@ func marshalDockerfile(ctx context.Context, dt []byte, opts ...llb.ConstraintsOp
 	return st.Marshal(ctx)
 }
 
-func ForwardToSigner(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, cfg *dalec.Frontend, s llb.State) (llb.State, error) {
+func ForwardToSigner(ctx context.Context, client gwclient.Client, cfg *dalec.Frontend, s llb.State) (llb.State, error) {
 	const (
 		sourceKey  = "source"
 		contextKey = "context"

--- a/frontend/windows/handle_container.go
+++ b/frontend/windows/handle_container.go
@@ -52,18 +52,9 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 		pg := dalec.ProgressGroup("Build windows container: " + spec.Name)
 		worker := workerImg(sOpt, pg)
 
-		bin, err := buildBinaries(spec, worker, sOpt, targetKey)
+		bin, err := buildBinaries(ctx, spec, worker, client, sOpt, targetKey)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to build binary %w", err)
-		}
-
-		if signer, ok := spec.GetSigner(targetKey); ok {
-			signed, err := frontend.ForwardToSigner(ctx, client, platform, signer, bin)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			bin = signed
 		}
 
 		baseImgName := getBaseOutputImage(spec, targetKey, defaultBaseImage)


### PR DESCRIPTION
I don't have a good test case for this right now.
I'll open an issue because ideally we can ensure that this doesn't regress in the future.
