### PR TITLE
Add handling for docs files and license files

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -80,18 +80,18 @@
 					"type": "object",
 					"description": "ConfigFiles is a list of files that should be marked as config files in the package."
 				},
-				"docFiles": {
-					"items": {
-						"type": "string"
+				"docs": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactConfig"
 					},
-					"type": "array",
+					"type": "object",
 					"description": "DocFiles is a list of doc files included in the package"
 				},
-				"licenseFiles": {
-					"items": {
-						"type": "string"
+				"licenses": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactConfig"
 					},
-					"type": "array",
+					"type": "object",
 					"description": "LicenseFiles is a list of doc files included in the package"
 				}
 			},

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -79,6 +79,13 @@
 					},
 					"type": "object",
 					"description": "ConfigFiles is a list of files that should be marked as config files in the package."
+				},
+				"docFiles": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "Docs is a list of doc files included in the package"
 				}
 			},
 			"additionalProperties": false,

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -85,7 +85,14 @@
 						"type": "string"
 					},
 					"type": "array",
-					"description": "Docs is a list of doc files included in the package"
+					"description": "DocFiles is a list of doc files included in the package"
+				},
+				"licenseFiles": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "LicenseFiles is a list of doc files included in the package"
 				}
 			},
 			"additionalProperties": false,

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -85,14 +85,14 @@
 						"$ref": "#/$defs/ArtifactConfig"
 					},
 					"type": "object",
-					"description": "DocFiles is a list of doc files included in the package"
+					"description": "Docs is a list of doc files included in the package"
 				},
 				"licenses": {
 					"additionalProperties": {
 						"$ref": "#/$defs/ArtifactConfig"
 					},
 					"type": "object",
-					"description": "LicenseFiles is a list of doc files included in the package"
+					"description": "Licenses is a list of doc files included in the package"
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -356,6 +356,28 @@ func (w *specWrapper) Install() fmt.Stringer {
 		copyArtifact(`%{buildroot}/%{_sysconfdir}`, c, cfg)
 	}
 
+	docKeys := dalec.SortMapKeys(w.Spec.Artifacts.Docs)
+	for _, d := range docKeys {
+		cfg := w.Spec.Artifacts.Docs[d]
+		// if the subpath is set we need to copy this and for the
+		// files section, we need to spell out the path
+		if cfg.SubPath != "" {
+			root := filepath.Join(`%{buildroot}/%{_docdir}`, w.Name)
+			copyArtifact(root, d, cfg)
+		}
+	}
+
+	licenseKeys := dalec.SortMapKeys(w.Spec.Artifacts.Licenses)
+	for _, l := range licenseKeys {
+		cfg := w.Spec.Artifacts.Licenses[l]
+		// if the subpath is set we need to copy this and for the
+		// files section, we need to spell out the path
+		if cfg.SubPath != "" {
+			root := filepath.Join(`%{buildroot}/%{_licensedir}`, w.Name)
+			copyArtifact(root, l, cfg)
+		}
+	}
+
 	return b
 }
 
@@ -400,15 +422,26 @@ func (w *specWrapper) Files() fmt.Stringer {
 		fmt.Fprintln(b, fullDirective)
 	}
 
-	sort.Strings(w.Spec.Artifacts.DocFiles)
-	for _, d := range w.Spec.Artifacts.DocFiles {
-		fullDirective := strings.Join([]string{`%doc`, filepath.Base(d)}, " ")
+	docKeys := dalec.SortMapKeys(w.Spec.Artifacts.Docs)
+	for _, d := range docKeys {
+		cfg := w.Spec.Artifacts.Docs[d]
+		path := filepath.Base(d)
+		if cfg.SubPath != "" {
+			path = filepath.Join(`%{_docdir}`, w.Name, cfg.SubPath, filepath.Base(d))
+		}
+		fullDirective := strings.Join([]string{`%doc`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
+
 	}
 
-	sort.Strings(w.Spec.Artifacts.LicenseFiles)
-	for _, l := range w.Spec.Artifacts.LicenseFiles {
-		fullDirective := strings.Join([]string{`%license`, filepath.Base(l)}, " ")
+	licenseKeys := dalec.SortMapKeys(w.Spec.Artifacts.Licenses)
+	for _, l := range licenseKeys {
+		cfg := w.Spec.Artifacts.Licenses[l]
+		path := filepath.Base(l)
+		if cfg.SubPath != "" {
+			path = filepath.Join(`%{_licensedir}`, w.Name, cfg.SubPath, filepath.Base(l))
+		}
+		fullDirective := strings.Join([]string{`%license`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -406,6 +406,12 @@ func (w *specWrapper) Files() fmt.Stringer {
 		fmt.Fprintln(b, fullDirective)
 	}
 
+	sort.Strings(w.Spec.Artifacts.LicenseFiles)
+	for _, l := range w.Spec.Artifacts.LicenseFiles {
+		fullDirective := strings.Join([]string{`%license`, filepath.Base(l)}, " ")
+		fmt.Fprintln(b, fullDirective)
+	}
+
 	return b
 }
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -355,6 +355,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
 		copyArtifact(`%{buildroot}/%{_sysconfdir}`, c, cfg)
 	}
+
 	return b
 }
 
@@ -396,6 +397,12 @@ func (w *specWrapper) Files() fmt.Stringer {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
 		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, filepath.Base(c))
 		fullDirective := strings.Join([]string{`%config(noreplace)`, fullPath}, " ")
+		fmt.Fprintln(b, fullDirective)
+	}
+
+	sort.Strings(w.Spec.Artifacts.DocFiles)
+	for _, d := range w.Spec.Artifacts.DocFiles {
+		fullDirective := strings.Join([]string{`%doc`, filepath.Base(d)}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
 

--- a/spec.go
+++ b/spec.go
@@ -132,9 +132,9 @@ type Artifacts struct {
 	// ConfigFiles is a list of files that should be marked as config files in the package.
 	ConfigFiles map[string]ArtifactConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
 	// DocFiles is a list of doc files included in the package
-	DocFiles []string `yaml:"docFiles,omitempty" json:"docFiles,omitempty"`
+	Docs map[string]ArtifactConfig `yaml:"docs,omitempty" json:"docs,omitempty"`
 	// LicenseFiles is a list of doc files included in the package
-	LicenseFiles []string `yaml:"licenseFiles,omitempty" json:"licenseFiles,omitempty"`
+	Licenses map[string]ArtifactConfig `yaml:"licenses,omitempty" json:"licenses,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, etc)
 }
 
@@ -181,10 +181,10 @@ func (a *Artifacts) IsEmpty() bool {
 	if len(a.ConfigFiles) > 0 {
 		return false
 	}
-	if len(a.DocFiles) > 0 {
+	if len(a.Docs) > 0 {
 		return false
 	}
-	if len(a.LicenseFiles) > 0 {
+	if len(a.Licenses) > 0 {
 		return false
 	}
 	return true

--- a/spec.go
+++ b/spec.go
@@ -184,6 +184,9 @@ func (a *Artifacts) IsEmpty() bool {
 	if len(a.DocFiles) > 0 {
 		return false
 	}
+	if len(a.LicenseFiles) > 0 {
+		return false
+	}
 	return true
 }
 

--- a/spec.go
+++ b/spec.go
@@ -131,8 +131,10 @@ type Artifacts struct {
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.
 	ConfigFiles map[string]ArtifactConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
-	// Docs is a list of doc files included in the package
+	// DocFiles is a list of doc files included in the package
 	DocFiles []string `yaml:"docFiles,omitempty" json:"docFiles,omitempty"`
+	// LicenseFiles is a list of doc files included in the package
+	LicenseFiles []string `yaml:"licenseFiles,omitempty" json:"licenseFiles,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, etc)
 }
 

--- a/spec.go
+++ b/spec.go
@@ -131,9 +131,9 @@ type Artifacts struct {
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.
 	ConfigFiles map[string]ArtifactConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
-	// DocFiles is a list of doc files included in the package
+	// Docs is a list of doc files included in the package
 	Docs map[string]ArtifactConfig `yaml:"docs,omitempty" json:"docs,omitempty"`
-	// LicenseFiles is a list of doc files included in the package
+	// Licenses is a list of doc files included in the package
 	Licenses map[string]ArtifactConfig `yaml:"licenses,omitempty" json:"licenses,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, etc)
 }

--- a/spec.go
+++ b/spec.go
@@ -131,6 +131,8 @@ type Artifacts struct {
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.
 	ConfigFiles map[string]ArtifactConfig `yaml:"configFiles,omitempty" json:"configFiles,omitempty"`
+	// Docs is a list of doc files included in the package
+	DocFiles []string `yaml:"docFiles,omitempty" json:"docFiles,omitempty"`
 	// TODO: other types of artifacts (systtemd units, libexec, etc)
 }
 
@@ -175,6 +177,9 @@ func (a *Artifacts) IsEmpty() bool {
 		return false
 	}
 	if len(a.ConfigFiles) > 0 {
+		return false
+	}
+	if len(a.DocFiles) > 0 {
 		return false
 	}
 	return true

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -527,7 +527,7 @@ echo "$BAR" > bar.txt
 		})
 	})
 
-	t.Run("docs are handled correctly", func(t *testing.T) {
+	t.Run("docs and licenses are handled correctly", func(t *testing.T) {
 		t.Parallel()
 		spec := &dalec.Spec{
 			Name:        "test-docs-handled",
@@ -555,19 +555,31 @@ echo "$BAR" > bar.txt
 						},
 					},
 				},
+				"src3": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "message=hello",
+							Permissions: 0o700,
+						},
+					},
+				},
 			},
 			Artifacts: dalec.Artifacts{
 				DocFiles: []string{
 					"src1",
 					"src2",
 				},
+				LicenseFiles: []string{
+					"src3",
+				},
 			},
 			Tests: []*dalec.TestSpec{
 				{
 					Name: "Doc files should be created in correct place",
 					Files: map[string]dalec.FileCheckOutput{
-						"/usr/share/doc/test-docs-handled/src1": {},
-						"/usr/share/doc/test-docs-handled/src2": {},
+						"/usr/share/doc/test-docs-handled/src1":      {},
+						"/usr/share/doc/test-docs-handled/src2":      {},
+						"/usr/share/licenses/test-docs-handled/src3": {},
 					},
 				},
 			},

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -563,23 +563,37 @@ echo "$BAR" > bar.txt
 						},
 					},
 				},
+				"src4": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "message=hello",
+							Permissions: 0o700,
+						},
+					},
+				},
 			},
 			Artifacts: dalec.Artifacts{
-				DocFiles: []string{
-					"src1",
-					"src2",
+				Docs: map[string]dalec.ArtifactConfig{
+					"src1": {},
+					"src2": {
+						SubPath: "subpath",
+					},
 				},
-				LicenseFiles: []string{
-					"src3",
+				Licenses: map[string]dalec.ArtifactConfig{
+					"src3": {},
+					"src4": {
+						SubPath: "license-subpath",
+					},
 				},
 			},
 			Tests: []*dalec.TestSpec{
 				{
 					Name: "Doc files should be created in correct place",
 					Files: map[string]dalec.FileCheckOutput{
-						"/usr/share/doc/test-docs-handled/src1":      {},
-						"/usr/share/doc/test-docs-handled/src2":      {},
-						"/usr/share/licenses/test-docs-handled/src3": {},
+						"/usr/share/doc/test-docs-handled/src1":                      {},
+						"/usr/share/doc/test-docs-handled/subpath/src2":              {},
+						"/usr/share/licenses/test-docs-handled/src3":                 {},
+						"/usr/share/licenses/test-docs-handled/license-subpath/src4": {},
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ability to add files to the package and have them represented by the `%doc` directive or the %license directive within the %files list.

There isn't a corresponding install entry, because RPM handles this already:

> When the package is installed, RPM creates a directory in the documentation directory named the same as the package and copies the file there

The same happens with license files. 

I thought that a slice of strings made more sense than using ArtifactConfig here, since we don't really need to provide any other real options. It seems like you can specify a full path with the %doc directive (%license as well), but I think we can go with this for now? It feels cleaner/more organized. 


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
fixes #241 

**Special notes for your reviewer**:
