### PR TITLE
Fix filepath handling for a few types

### DIFF
--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -485,7 +485,8 @@ func (w *specWrapper) Files() fmt.Stringer {
 	configKeys := dalec.SortMapKeys(w.Spec.Artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
-		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, filepath.Base(c))
+		// TODO: handle case where c is overridden by name
+		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, cfg.Name)
 		fullDirective := strings.Join([]string{`%config(noreplace)`, fullPath}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -345,7 +345,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 		fmt.Fprintln(b, "mkdir -p", targetDir)
 
 		var targetPath string
-		file := resolveFileName(p, cfg)
+		file := cfg.ResolveName(p)
 		if !strings.Contains(file, "*") {
 			targetPath = filepath.Join(targetDir, file)
 		} else {
@@ -448,7 +448,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	binKeys := dalec.SortMapKeys(w.Spec.Artifacts.Binaries)
 	for _, p := range binKeys {
 		cfg := w.Spec.Artifacts.Binaries[p]
-		full := filepath.Join(`%{_bindir}/`, cfg.SubPath, resolveFileName(p, cfg))
+		full := filepath.Join(`%{_bindir}/`, cfg.SubPath, cfg.ResolveName(p))
 		fmt.Fprintln(b, full)
 	}
 
@@ -473,7 +473,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	configKeys := dalec.SortMapKeys(w.Spec.Artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
-		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, resolveFileName(c, cfg))
+		fullPath := filepath.Join(`%{_sysconfdir}`, cfg.SubPath, cfg.ResolveName(c))
 		fullDirective := strings.Join([]string{`%config(noreplace)`, fullPath}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
@@ -492,7 +492,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	docKeys := dalec.SortMapKeys(w.Spec.Artifacts.Docs)
 	for _, d := range docKeys {
 		cfg := w.Spec.Artifacts.Docs[d]
-		path := filepath.Join(`%{_docdir}`, w.Name, cfg.SubPath, resolveFileName(d, cfg))
+		path := filepath.Join(`%{_docdir}`, w.Name, cfg.SubPath, cfg.ResolveName(d))
 		fullDirective := strings.Join([]string{`%doc`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
 
@@ -501,7 +501,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	licenseKeys := dalec.SortMapKeys(w.Spec.Artifacts.Licenses)
 	for _, l := range licenseKeys {
 		cfg := w.Spec.Artifacts.Licenses[l]
-		path := filepath.Join(`%{_licensedir}`, w.Name, cfg.SubPath, resolveFileName(l, cfg))
+		path := filepath.Join(`%{_licensedir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
 		fullDirective := strings.Join([]string{`%license`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
@@ -518,12 +518,4 @@ func WriteSpec(spec *dalec.Spec, target string, w io.Writer) error {
 		return fmt.Errorf("error executing spec template: %w", err)
 	}
 	return nil
-}
-
-func resolveFileName(path string, cfg dalec.ArtifactConfig) string {
-	file := filepath.Base(path)
-	if cfg.Name != "" {
-		file = cfg.Name
-	}
-	return file
 }

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -226,7 +226,7 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("test doc templaing using artifact config", func(t *testing.T) {
+	t.Run("test doc templating using artifact config", func(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Name: "test-pkg",
@@ -247,7 +247,7 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("test doc templaing using defaults", func(t *testing.T) {
+	t.Run("test doc templating using defaults", func(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Name: "test-pkg",
@@ -265,7 +265,7 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("test doc templaing using defaults and longer path", func(t *testing.T) {
+	t.Run("test doc templating using defaults and longer path", func(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Name: "test-pkg",
@@ -283,7 +283,7 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("test license templaing using defaults", func(t *testing.T) {
+	t.Run("test license templating using defaults", func(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Name: "test-pkg",
@@ -301,7 +301,7 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("test license templaing using ArtifactConfig", func(t *testing.T) {
+	t.Run("test license templating using ArtifactConfig", func(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Name: "test-pkg",
@@ -318,6 +318,45 @@ func TestTemplate_Artifacts(t *testing.T) {
 		got := w.Files().String()
 		want := `%files
 %license %{_licensedir}/test-pkg/licenses/LICENSE.md
+`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("test config file templating using ArtifactConfig", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{
+			Name: "test-pkg",
+			Artifacts: dalec.Artifacts{
+				ConfigFiles: map[string]dalec.ArtifactConfig{
+					"/src/config.env": {
+						Name:    "config",
+						SubPath: "sysconfig",
+					},
+				},
+			},
+		}}
+
+		got := w.Files().String()
+		want := `%files
+%config(noreplace) %{_sysconfdir}/sysconfig/config
+`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("test config file templating using defaults", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{
+			Name: "test-pkg",
+			Artifacts: dalec.Artifacts{
+				ConfigFiles: map[string]dalec.ArtifactConfig{
+					"/src/config.env": {},
+				},
+			},
+		}}
+
+		got := w.Files().String()
+		want := `%files
+%config(noreplace) %{_sysconfdir}/config.env
 `
 		assert.Equal(t, want, got)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR corrects a few unexpected results when generating a package 


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #265 

**Special notes for your reviewer**:
55ff43e7480aadaafb09a3da77e49c47a97a2fae refactors a bit to create a new function that will use filepath.Base as default and replace it with cfg.Name if provided

507e531af5ff3c547b6c88e7643111cbbb81e634 changes how license and doc files are handled, because currently they need to be at the root of the buildroot unless a subpath was specified
