### PR TITLE
Support SystemD Drop Ins

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -94,12 +94,9 @@
 					"type": "object",
 					"description": "Licenses is a list of doc files included in the package"
 				},
-				"systemdUnits": {
-					"additionalProperties": {
-						"$ref": "#/$defs/SystemdUnitConfig"
-					},
-					"type": "object",
-					"description": "SystemdUnits is a list of systemd units to include in the package."
+				"systemd": {
+					"$ref": "#/$defs/SystemdConfiguration",
+					"description": "SystemdConfigurations is the list of systemd units and dropin files for the package"
 				}
 			},
 			"additionalProperties": false,
@@ -920,6 +917,46 @@
 				"path"
 			],
 			"description": "SymlinkTarget specifies the properties of a symlink"
+		},
+		"SystemdConfiguration": {
+			"properties": {
+				"units": {
+					"additionalProperties": {
+						"$ref": "#/$defs/SystemdUnitConfig"
+					},
+					"type": "object",
+					"description": "SystemdUnits is a list of systemd units to include in the package."
+				},
+				"SystemdDropins": {
+					"additionalProperties": {
+						"$ref": "#/$defs/SystemdDropinConfig"
+					},
+					"type": "object",
+					"description": "SystemdDropins is a list of systemd drop in files that should be included in the package"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"SystemdDropins"
+			]
+		},
+		"SystemdDropinConfig": {
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name is file or dir name to use for the artifact in the package.\nIf empty, the file or dir name from the produced artifact will be used."
+				},
+				"unit": {
+					"type": "string",
+					"description": "Unit is the name of the systemd unit that the dropin files should be copied under."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"unit"
+			]
 		},
 		"SystemdUnitConfig": {
 			"properties": {

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -96,7 +96,7 @@
 				},
 				"systemd": {
 					"$ref": "#/$defs/SystemdConfiguration",
-					"description": "SystemdConfigurations is the list of systemd units and dropin files for the package"
+					"description": "Systemd is the list of systemd units and dropin files for the package"
 				}
 			},
 			"additionalProperties": false,
@@ -925,21 +925,18 @@
 						"$ref": "#/$defs/SystemdUnitConfig"
 					},
 					"type": "object",
-					"description": "SystemdUnits is a list of systemd units to include in the package."
+					"description": "Units is a list of systemd units to include in the package."
 				},
-				"SystemdDropins": {
+				"dropins": {
 					"additionalProperties": {
 						"$ref": "#/$defs/SystemdDropinConfig"
 					},
 					"type": "object",
-					"description": "SystemdDropins is a list of systemd drop in files that should be included in the package"
+					"description": "Dropins is a list of systemd drop in files that should be included in the package"
 				}
 			},
 			"additionalProperties": false,
-			"type": "object",
-			"required": [
-				"SystemdDropins"
-			]
+			"type": "object"
 		},
 		"SystemdDropinConfig": {
 			"properties": {

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -362,4 +362,53 @@ func TestTemplate_Artifacts(t *testing.T) {
 `
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("test systemd dropin templating", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{
+			Artifacts: dalec.Artifacts{
+				SystemdConfigurations: &dalec.SystemdConfiguration{
+					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+						"src/blah.config": {
+							Unit: "foo.service",
+						},
+					},
+				},
+			},
+		}}
+
+		got := w.Files().String()
+		want := `%files
+%dir %{_unitdir}/foo.service.d
+%{_unitdir}/foo.service.d/blah.config
+`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("test systemd dropin templating two files and mixed config", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{
+			Artifacts: dalec.Artifacts{
+				SystemdConfigurations: &dalec.SystemdConfiguration{
+					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+						"src/blah.config": {
+							Unit: "foo.service",
+						},
+						"src/env.config": {
+							Unit: "foo.service",
+							Name: "test.conf",
+						},
+					},
+				},
+			},
+		}}
+
+		got := w.Files().String()
+		want := `%files
+%dir %{_unitdir}/foo.service.d
+%{_unitdir}/foo.service.d/blah.config
+%{_unitdir}/foo.service.d/test.conf
+`
+		assert.Equal(t, want, got)
+	})
 }

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -213,8 +213,8 @@ func TestTemplate_Artifacts(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Units: map[string]dalec.SystemdUnitConfig{
 						"test.service": {},
 					},
 				},
@@ -367,8 +367,8 @@ func TestTemplate_Artifacts(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Dropins: map[string]dalec.SystemdDropinConfig{
 						"src/blah.config": {
 							Unit: "foo.service",
 						},
@@ -389,8 +389,8 @@ func TestTemplate_Artifacts(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Dropins: map[string]dalec.SystemdDropinConfig{
 						"src/blah.config": {
 							Unit: "foo.service",
 						},

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -213,8 +213,10 @@ func TestTemplate_Artifacts(t *testing.T) {
 		t.Parallel()
 		w := &specWrapper{Spec: &dalec.Spec{
 			Artifacts: dalec.Artifacts{
-				SystemdUnits: map[string]dalec.SystemdUnitConfig{
-					"test.service": {},
+				SystemdConfigurations: &dalec.SystemdConfiguration{
+					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+						"test.service": {},
+					},
 				},
 			},
 		}}

--- a/spec.go
+++ b/spec.go
@@ -136,16 +136,16 @@ type Artifacts struct {
 	Docs map[string]ArtifactConfig `yaml:"docs,omitempty" json:"docs,omitempty"`
 	// Licenses is a list of doc files included in the package
 	Licenses map[string]ArtifactConfig `yaml:"licenses,omitempty" json:"licenses,omitempty"`
-	// SystemdConfigurations is the list of systemd units and dropin files for the package
-	SystemdConfigurations *SystemdConfiguration `yaml:"systemd,omitempty" json:"systemd,omitempty"`
-	// TODO: other types of artifacts (systtemd units, libexec, etc)
+	// Systemd is the list of systemd units and dropin files for the package
+	Systemd *SystemdConfiguration `yaml:"systemd,omitempty" json:"systemd,omitempty"`
+	// TODO: other types of artifacts (libexec, etc)
 }
 
 type SystemdConfiguration struct {
-	// SystemdUnits is a list of systemd units to include in the package.
-	SystemdUnits map[string]SystemdUnitConfig `yaml:"units,omitempty" json:"units,omitempty"`
-	// SystemdDropins is a list of systemd drop in files that should be included in the package
-	SystemdDropins map[string]SystemdDropinConfig `yaml:"dropins,omitempty" json:"dropins,omitempty`
+	// Units is a list of systemd units to include in the package.
+	Units map[string]SystemdUnitConfig `yaml:"units,omitempty" json:"units,omitempty"`
+	// Dropins is a list of systemd drop in files that should be included in the package
+	Dropins map[string]SystemdDropinConfig `yaml:"dropins,omitempty" json:"dropins,omitempty"`
 }
 
 type SystemdUnitConfig struct {
@@ -171,7 +171,7 @@ type SystemdDropinConfig struct {
 	// If empty, the file or dir name from the produced artifact will be used.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 	// Unit is the name of the systemd unit that the dropin files should be copied under.
-	Unit string `yaml:"unit" json:"unit"`
+	Unit string `yaml:"unit" json:"unit"` // the unit named foo.service maps to the directory foo.service.d
 }
 
 func (s SystemdDropinConfig) Artifact() ArtifactConfig {
@@ -249,8 +249,8 @@ func (a *Artifacts) IsEmpty() bool {
 		return false
 	}
 
-	if a.SystemdConfigurations != nil &&
-		(len(a.SystemdConfigurations.SystemdUnits) > 0 || len(a.SystemdConfigurations.SystemdDropins) > 0) {
+	if a.Systemd != nil &&
+		(len(a.Systemd.Units) > 0 || len(a.Systemd.Dropins) > 0) {
 		return false
 	}
 

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -378,9 +378,11 @@ WantedBy=multi-user.target
 				},
 			},
 			Artifacts: dalec.Artifacts{
-				SystemdUnits: map[string]dalec.SystemdUnitConfig{
-					"src/simple.service": {
-						Enable: true,
+				SystemdConfigurations: &dalec.SystemdConfiguration{
+					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+						"src/simple.service": {
+							Enable: true,
+						},
 					},
 				},
 			},
@@ -407,7 +409,11 @@ WantedBy=multi-user.target
 		})
 
 		// Test to ensure disabling works by default
-		spec.Artifacts.SystemdUnits["src/simple.service"] = dalec.SystemdUnitConfig{}
+		spec.Artifacts.SystemdConfigurations = &dalec.SystemdConfiguration{
+			SystemdUnits: map[string]dalec.SystemdUnitConfig{
+				"src/simple.service": {},
+			},
+		}
 		spec.Tests = []*dalec.TestSpec{
 			{
 				Name: "Check service files",
@@ -484,10 +490,12 @@ WantedBy=sockets.target
 				},
 			},
 			Artifacts: dalec.Artifacts{
-				SystemdUnits: map[string]dalec.SystemdUnitConfig{
-					"src/foo.service": {},
-					"src/foo.socket": {
-						Enable: true,
+				SystemdConfigurations: &dalec.SystemdConfiguration{
+					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+						"src/foo.service": {},
+						"src/foo.socket": {
+							Enable: true,
+						},
 					},
 				},
 			},

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -378,8 +378,8 @@ WantedBy=multi-user.target
 				},
 			},
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Units: map[string]dalec.SystemdUnitConfig{
 						"src/simple.service": {
 							Enable: true,
 						},
@@ -409,8 +409,8 @@ WantedBy=multi-user.target
 		})
 
 		// Test to ensure disabling works by default
-		spec.Artifacts.SystemdConfigurations = &dalec.SystemdConfiguration{
-			SystemdUnits: map[string]dalec.SystemdUnitConfig{
+		spec.Artifacts.Systemd = &dalec.SystemdConfiguration{
+			Units: map[string]dalec.SystemdUnitConfig{
 				"src/simple.service": {},
 			},
 		}
@@ -496,14 +496,14 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 				},
 			},
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdUnits: map[string]dalec.SystemdUnitConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Units: map[string]dalec.SystemdUnitConfig{
 						"src/foo.service": {},
 						"src/foo.socket": {
 							Enable: true,
 						},
 					},
-					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+					Dropins: map[string]dalec.SystemdDropinConfig{
 						"src/foo.conf": {
 							Unit: "foo.service",
 						},
@@ -567,8 +567,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 				},
 			},
 			Artifacts: dalec.Artifacts{
-				SystemdConfigurations: &dalec.SystemdConfiguration{
-					SystemdDropins: map[string]dalec.SystemdDropinConfig{
+				Systemd: &dalec.SystemdConfiguration{
+					Dropins: map[string]dalec.SystemdDropinConfig{
 						"src/foo.conf": {
 							Unit: "foo.service",
 						},

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -490,6 +490,12 @@ WantedBy=sockets.target
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
 								`,
 								},
+								"env.conf": {
+									Contents: `
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+								`,
+								},
 							},
 						},
 					},
@@ -506,6 +512,9 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 					Dropins: map[string]dalec.SystemdDropinConfig{
 						"src/foo.conf": {
 							Unit: "foo.service",
+						},
+						"src/env.conf": {
+							Unit: "foo.socket",
 						},
 					},
 				},
@@ -524,6 +533,10 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 							Permissions: 0644,
 						},
 						"/usr/lib/systemd/system/foo.service.d/foo.conf": {
+							CheckOutput: dalec.CheckOutput{Contains: []string{"Environment"}},
+							Permissions: 0644,
+						},
+						"/usr/lib/systemd/system/foo.socket.d/env.conf": {
 							CheckOutput: dalec.CheckOutput{Contains: []string{"Environment"}},
 							Permissions: 0644,
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for specifying systemd dropin config files. As part of this, I refactored the existing systemd block to nest units and dropins under a `systemd` field. 


This PR adds tests both to both the unit tests for template.go and for the az_linux tests. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #271

**Special notes for your reviewer**:
