### PR TITLE
Add support for passing build args to signers

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -426,7 +426,7 @@
 		"PackageConfig": {
 			"properties": {
 				"signer": {
-					"$ref": "#/$defs/Frontend",
+					"$ref": "#/$defs/PackageSigner",
 					"description": "Signer is the configuration to use for signing packages"
 				}
 			},
@@ -477,6 +477,34 @@
 			"additionalProperties": false,
 			"type": "object",
 			"description": "PackageDependencies is a list of dependencies for a package."
+		},
+		"PackageSigner": {
+			"properties": {
+				"image": {
+					"type": "string",
+					"description": "Image specifies the frontend image to forward the build to.\nThis can be left unspecified *if* the original frontend has builtin support for the distro.\n\nIf the original frontend does not have builtin support for the distro, this must be specified or the build will fail.\nIf this is specified then it MUST be used.",
+					"examples": [
+						"docker.io/my/frontend:latest"
+					]
+				},
+				"cmdline": {
+					"type": "string",
+					"description": "CmdLine is the command line to use to forward the build to the frontend.\nBy default the frontend image's entrypoint/cmd is used."
+				},
+				"args": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"description": "Args are passed along to the signer frontend as build args"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"image"
+			],
+			"description": "PackageSigner is the configuration for defining how to sign a package"
 		},
 		"PatchSpec": {
 			"properties": {

--- a/helpers.go
+++ b/helpers.go
@@ -340,7 +340,7 @@ func (s *Spec) GetSymlinks(target string) map[string]SymlinkTarget {
 	return lm
 }
 
-func (s *Spec) GetSigner(targetKey string) (*Frontend, bool) {
+func (s *Spec) GetSigner(targetKey string) (*PackageSigner, bool) {
 	if s.Targets != nil {
 		if t, ok := s.Targets[targetKey]; ok && hasValidSigner(t.PackageConfig) {
 			return t.PackageConfig.Signer, true

--- a/spec.go
+++ b/spec.go
@@ -523,10 +523,17 @@ type Target struct {
 	PackageConfig *PackageConfig `yaml:"package_config,omitempty" json:"package_config,omitempty"`
 }
 
+// PackageSigner is the configuration for defining how to sign a package
+type PackageSigner struct {
+	*Frontend `yaml:",inline" json:",inline"`
+	// Args are passed along to the signer frontend as build args
+	Args map[string]string `yaml:"args,omitempty" json:"args,omitempty"`
+}
+
 // PackageConfig encapsulates the configuration for artifact targets
 type PackageConfig struct {
 	// Signer is the configuration to use for signing packages
-	Signer *Frontend `yaml:"signer,omitempty" json:"signer,omitempty"`
+	Signer *PackageSigner `yaml:"signer,omitempty" json:"signer,omitempty"`
 }
 
 // TestSpec is used to execute tests against a container with the package installed in it.

--- a/test/fixtures/signer/main.go
+++ b/test/fixtures/signer/main.go
@@ -74,6 +74,19 @@ func main() {
 			File(llb.Mkfile("/target", 0o600, []byte(target))).
 			File(llb.Mkfile("/config.json", 0o600, configBytes))
 
+		// For any build-arg seen, write a file to /env/<KEY> with the contents
+		// being the value of the arg.
+		for k, v := range c.BuildOpts().Opts {
+			_, key, ok := strings.Cut(k, "build-arg:")
+			if !ok {
+				// not a build arg
+				continue
+			}
+			output = output.
+				File(llb.Mkdir("/env", 0o755)).
+				File(llb.Mkfile("/env/"+key, 0o600, []byte(v)))
+		}
+
 		def, err := output.Marshal(ctx)
 		if err != nil {
 			return nil, err

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/dalec"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/stretchr/testify/assert"
 )
 
 func distroSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) func(ctx context.Context, gwc gwclient.Client) (*gwclient.Result, error) {
@@ -29,6 +30,11 @@ func distroSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) func(
 
 		if !strings.Contains(string(cfg), "linux") {
 			t.Fatal(fmt.Errorf("configuration incorrect"))
+		}
+
+		for k, v := range spec.PackageConfig.Signer.Args {
+			dt := readFile(ctx, t, "/env/"+k, res)
+			assert.Equal(t, v, string(dt))
 		}
 
 		return gwclient.NewResult(), nil

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -276,8 +276,10 @@ echo "$BAR" > bar.txt
 				Targets: map[string]dalec.Target{
 					"windowscross": {
 						PackageConfig: &dalec.PackageConfig{
-							Signer: &dalec.Frontend{
-								Image: phonySignerRef,
+							Signer: &dalec.PackageSigner{
+								Frontend: &dalec.Frontend{
+									Image: phonySignerRef,
+								},
 							},
 						},
 					},

--- a/website/docs/signing.md
+++ b/website/docs/signing.md
@@ -11,6 +11,7 @@ tagged, the following can be added to the spec to trigger the signing
 operation:
 
 ```yaml
+name: my-package
 targets: # Distro specific build requirements
   mariner2:
     package_config:
@@ -42,3 +43,113 @@ provided as the build context.
 identical to the input `llb.State` in every way *except* that the
 desired artifacts will be signed.
 
+A signer can also be configured at the root of the spec if there is no target
+specific customization required or you are only building for one target.
+
+Example:
+
+```yaml
+name: my-package
+package_config:
+  signer:
+    image: "ref/to/signing:image"
+    cmdline: "/signer"
+```
+
+## Build Time customization
+
+Signing artifacts may require passing through build-time customizations.
+This can be done through 3 mechanisms:
+
+1. [Secrets](#secrets)
+2. [Named contexts](#named-contexts)
+3. [Build arguments](#build-arguments)
+
+With all methods of build-time customization, the signer needs to be coded
+such that it is going to consume the customizations that are passed in, as such
+all such customizations are signer specific.
+
+### Secrets
+
+Secrets are passed through from the client (such as the docker CLI or buildx).
+These secrets are always available to the signer.
+see Docker's [secrets](https://docs.docker.com/build/building/secrets/)
+documentation for more details on on how secrets can be passed into a build
+using the docker CLI.
+
+*Note*: The docker documentation is using Dockerfiles in their examples which
+are irrelevant for Dalec signing, however the CLI examples for how to pass in
+those secrets is useful.
+
+No changes to the spec yaml are required to use secrets with a signer, except
+that the signer itself needs to be setup to consume the secret(s).
+
+### Named Contexts
+
+Named contexts are passed into the build by the client. All named contexts are
+available to the signer.
+
+A named context is just like a regular
+[build context](https://docs.docker.com/build/building/context/) except that it
+is given a custom name where as the regular build context is specifically named
+`context`. In the scope of Dalec signing, the regular build context is the
+packages that Dalec is giving to the signer to sign.
+A named context can be used to provide extra data or configuration to the signer.
+
+Example usage with Docker:
+
+```console
+$ docker build --build-context my-signing-config=./signing-config-dir ...
+```
+
+Here `my-singing-config` is the name you want to give to the context which the
+signer may use to pull in the context. The `./signing-config-dir` is the data
+being given as the context, in this case a local directory. This could be a
+directory, a git ref, an HTTP url, etc. See the linked docker build context
+documentation above for more details on what can be specified.
+
+Multiple named contexts may be provided.
+
+No changes to the spec yaml are required to use named contexts with a signer,
+except that the signer itself needs to be setup to consume the named
+context(s).
+
+### Build Arguments
+
+Buid arguments are key/value pairs that can be supplied in the yaml spec which
+will be forwarded to the signer.
+
+Taking the original example above we can add build by adding an `args` with
+a string-to-string mapping like so:
+
+```yaml
+targets: # Distro specific build requirements
+  mariner2:
+    package_config:
+      signer:
+        image: "ref/to/signing:image"
+        cmdline: "/signer"
+        args:
+            SOME_KEY: SOME_VALUE
+            SOME_OTHER_KEY: SOME_OTHER_VALUE
+```
+
+The values of these arguments can also be taken from the client using variable
+substitution like in other parts of the spec.
+To use variable substituion, the args must be declared at the root of the spec:
+
+```yaml
+args:
+  SOME_SIGNING_ARG: ""
+  SOME_OTHER_SIGNING_ARG: "default_value"
+
+targets: # Distro specific build requirements
+  mariner2:
+    package_config:
+      signer:
+        image: "ref/to/signing:image"
+        cmdline: "/signer"
+        args:
+            SOME_KEY: "${SOME_SIGNING_ARG}"
+            SOME_OTHER_KEY: "${SOME_OTHER_SIGNING_ARG}"
+```


### PR DESCRIPTION
I considered extending this to allow this for any kind of frontend (and as such sticking it into the `dalec.Frontend` type), however there really shouldn't be different vars passed to target frontends. Hence why I am restricting this to just signers for now.

If we decide to later we can add this more generically, however it will be much more difficult to take it away if we decide it was a bad idea.

Related to #263
