### PR TITLE
[WIP] add prebuild work images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,6 +61,16 @@ variable "RUNC_REVISION" {
     default = "1"
 }
 
+target "dalec-workers" {
+    name = "dalec-${distro}-worker"
+    matrix = {
+        distro = ["mariner2", "azlinux3"]
+    }
+    dockerfile = "specs/dalec-${distro}-worker.yml"
+    target = "${distro}/container"
+    tags = ["dalec-${distro}-worker:test", "ghcr.io/azure/dalec/dalec-${distro}-worker:latest"]
+}
+
 target "runc" {
     name = "runc-${distro}-${replace(tgt, "/", "-")}"
     dockerfile = "test/fixtures/moby-runc.yml"
@@ -175,7 +185,7 @@ dependencies:
     runtime:
         patch: []
         bash: []
-    EOT 
+    EOT
     args = {
         "BUILDKIT_SYNTAX" = FRONTEND_REF
     }

--- a/frontend/azlinux/azlinux3.go
+++ b/frontend/azlinux/azlinux3.go
@@ -16,7 +16,7 @@ const (
 	AzLinux3TargetKey     = "azlinux3"
 	tdnfCacheNameAzlinux3 = "azlinux3-tdnf-cache"
 
-	azlinux3Ref           = "azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0"
+	azlinux3Ref           = "ghcr.io/azure/dalec/dalec-azlinux3-worker:latest"
 	azlinux3DistrolessRef = "azurelinuxpreview.azurecr.io/public/azurelinux/distroless/base:3.0"
 )
 

--- a/frontend/azlinux/mariner2.go
+++ b/frontend/azlinux/mariner2.go
@@ -16,7 +16,7 @@ const (
 	Mariner2TargetKey     = "mariner2"
 	tdnfCacheNameMariner2 = "mariner2-tdnf-cache"
 
-	mariner2Ref           = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
+	mariner2Ref           = "ghcr.io/azure/dalec/dalec-mariner2-worker:latest"
 	mariner2DistrolessRef = "mcr.microsoft.com/cbl-mariner/distroless/base:2.0"
 )
 

--- a/specs/dalec-azlinux3-worker.yml
+++ b/specs/dalec-azlinux3-worker.yml
@@ -1,0 +1,23 @@
+# syntax=ghcr.io/azure/dalec/frontend:latest
+
+name: dalec-azlinux3-worker
+description: Pre-built dalec azlinux3 worker base image
+website: https://www.github.com/Azure/dalec
+version: 0.0.1
+revision: 1
+vendor: Microsoft
+
+packager: Microsoft <support@microsoft.com>
+license: Apache 2.0
+
+dependencies:
+  runtime:
+    "rpm-build": []
+    "mariner-rpm-macros": []
+    "build-essential": []
+    "ca-certificates": []
+
+targets:
+    azlinux3:
+        image:
+            base: azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0

--- a/specs/dalec-mariner2-worker.yml
+++ b/specs/dalec-mariner2-worker.yml
@@ -1,0 +1,24 @@
+# syntax=ghcr.io/azure/dalec/frontend:latest
+
+name: dalec-mariner2-worker
+description: Pre-built dalec mariner2 worker base image
+website: https://www.github.com/Azure/dalec
+version: 0.0.1
+revision: 1
+vendor: Microsoft
+
+packager: Microsoft <support@microsoft.com>
+license: Apache 2.0
+
+dependencies:
+  runtime:
+    "systemd-rpm-macros" : []
+    "rpm-build": []
+    "mariner-rpm-macros" : []
+    "build-essential" : []
+    "ca-certificates" : []
+
+targets:
+    mariner2:
+        image:
+            base: mcr.microsoft.com/cbl-mariner/base/core:2.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Initial work to add pre-build images for mariner, azlinux worker images.

Fixes # https://github.com/Azure/dalec/issues/177

Questions:
1. Would these work images need to be versioned? If so, would these follow same versioning of `dalec` tags?
2. Would we need to add a ci for these images?
