### PR TITLE
rpm: Fix use of inccorrect field for runtime constraints

### DIFF
--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -114,7 +114,7 @@ func (w *specWrapper) Requires() fmt.Stringer {
 
 	runtimeKeys := dalec.SortMapKeys(deps.Runtime)
 	for _, name := range runtimeKeys {
-		constraints := deps.Build[name]
+		constraints := deps.Runtime[name]
 		// satisifes is only for build deps, not runtime deps
 		// TODO: consider if it makes sense to support sources satisfying runtime deps
 		writeDep(b, "Requires", name, constraints)

--- a/frontend/rpm/template_test.go
+++ b/frontend/rpm/template_test.go
@@ -412,3 +412,51 @@ func TestTemplate_Artifacts(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+func TestTemplate_Requires(t *testing.T) {
+	t.Parallel()
+
+	spec := &dalec.Spec{
+		Dependencies: &dalec.PackageDependencies{
+			// note: I've prefixed these packages with a/b/c for sorting purposes
+			// Since the underlying code will sort packages this just makes it
+			// simpler to read for tests.
+			Build: map[string][]string{
+				"a-lib-no-constraints": {},
+				"b-lib-one-constraints": {
+					"< 2.0",
+				},
+				"c-lib-multiple-constraints": {
+					"< 2.0",
+					">= 1.0",
+				},
+			},
+			Runtime: map[string][]string{
+				"a-no-constraints": {},
+				"b-one-constraints": {
+					"< 2.0",
+				},
+				"c-multiple-constraints": {
+					"< 2.0",
+					">= 1.0",
+				},
+			},
+		},
+	}
+
+	w := &specWrapper{Spec: spec}
+
+	got := w.Requires().String()
+	want := `BuildRequires: a-lib-no-constraints
+BuildRequires: b-lib-one-constraints < 2.0
+BuildRequires: c-lib-multiple-constraints < 2.0
+BuildRequires: c-lib-multiple-constraints >= 1.0
+
+Requires: a-no-constraints
+Requires: b-one-constraints < 2.0
+Requires: c-multiple-constraints < 2.0
+Requires: c-multiple-constraints >= 1.0
+`
+
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
When building the rpm spec we were using the wrong set of constraints for runtime dependencies.
This was likely just a bad copy/paste.

Added tests for this.