### PR TITLE
fix: Don't emit rpm spec fields if empty in dalec spec

### DIFF
--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -294,7 +294,7 @@ func (w *specWrapper) BuildSteps() fmt.Stringer {
 func (w *specWrapper) PreUn() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
+	if w.Artifacts.Systemd.IsEmpty() {
 		return b
 	}
 
@@ -311,7 +311,7 @@ func (w *specWrapper) PreUn() fmt.Stringer {
 func (w *specWrapper) Post() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
+	if w.Artifacts.Systemd.IsEmpty() {
 		return b
 	}
 
@@ -330,7 +330,7 @@ func (w *specWrapper) Post() fmt.Stringer {
 func (w *specWrapper) PostUn() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
+	if w.Artifacts.Systemd.IsEmpty() {
 		return b
 	}
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -294,11 +294,7 @@ func (w *specWrapper) BuildSteps() fmt.Stringer {
 func (w *specWrapper) PreUn() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if w.Spec.Artifacts.Systemd == nil {
-		return b
-	}
-
-	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
+	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
 		return b
 	}
 
@@ -315,11 +311,7 @@ func (w *specWrapper) PreUn() fmt.Stringer {
 func (w *specWrapper) Post() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if w.Spec.Artifacts.Systemd == nil {
-		return b
-	}
-
-	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
+	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
 		return b
 	}
 
@@ -338,11 +330,7 @@ func (w *specWrapper) Post() fmt.Stringer {
 func (w *specWrapper) PostUn() fmt.Stringer {
 	b := &strings.Builder{}
 
-	if w.Spec.Artifacts.Systemd == nil {
-		return b
-	}
-
-	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
+	if dalec.SystemdIsEmpty(w.Artifacts.Systemd) {
 		return b
 	}
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -14,6 +14,7 @@ import (
 )
 
 const gomodsName = "__gomods"
+const containerSuffix = "/container"
 
 var specTmpl = template.Must(template.New("spec").Parse(strings.TrimSpace(`
 Summary: {{.Description}}
@@ -302,6 +303,10 @@ func (w *specWrapper) PreUn() fmt.Stringer {
 		return b
 	}
 
+	if strings.HasSuffix(w.Target, containerSuffix) {
+		return b
+	}
+
 	b.WriteString("%preun\n")
 	keys := dalec.SortMapKeys(w.Spec.Artifacts.Systemd.Units)
 	for _, servicePath := range keys {
@@ -320,6 +325,10 @@ func (w *specWrapper) Post() fmt.Stringer {
 	}
 
 	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
+		return b
+	}
+
+	if strings.HasSuffix(w.Target, containerSuffix) {
 		return b
 	}
 
@@ -343,6 +352,10 @@ func (w *specWrapper) PostUn() fmt.Stringer {
 	}
 
 	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
+		return b
+	}
+
+	if strings.HasSuffix(w.Target, containerSuffix) {
 		return b
 	}
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -14,7 +14,6 @@ import (
 )
 
 const gomodsName = "__gomods"
-const containerSuffix = "/container"
 
 var specTmpl = template.Must(template.New("spec").Parse(strings.TrimSpace(`
 Summary: {{.Description}}
@@ -303,10 +302,6 @@ func (w *specWrapper) PreUn() fmt.Stringer {
 		return b
 	}
 
-	if strings.HasSuffix(w.Target, containerSuffix) {
-		return b
-	}
-
 	b.WriteString("%preun\n")
 	keys := dalec.SortMapKeys(w.Spec.Artifacts.Systemd.Units)
 	for _, servicePath := range keys {
@@ -325,10 +320,6 @@ func (w *specWrapper) Post() fmt.Stringer {
 	}
 
 	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
-		return b
-	}
-
-	if strings.HasSuffix(w.Target, containerSuffix) {
 		return b
 	}
 
@@ -352,10 +343,6 @@ func (w *specWrapper) PostUn() fmt.Stringer {
 	}
 
 	if len(w.Spec.Artifacts.Systemd.Units) == 0 {
-		return b
-	}
-
-	if strings.HasSuffix(w.Target, containerSuffix) {
 		return b
 	}
 

--- a/spec.go
+++ b/spec.go
@@ -682,3 +682,15 @@ type CheckOutputError struct {
 func (c *CheckOutputError) Error() string {
 	return fmt.Sprintf("expected %q %s %q, got %q", c.Path, c.Kind, c.Expected, c.Actual)
 }
+
+func SystemdIsEmpty(s *SystemdConfiguration) bool {
+	if s == nil {
+		return true
+	}
+
+	if len(s.Units) == 0 {
+		return true
+	}
+
+	return false
+}

--- a/spec.go
+++ b/spec.go
@@ -683,7 +683,7 @@ func (c *CheckOutputError) Error() string {
 	return fmt.Sprintf("expected %q %s %q, got %q", c.Path, c.Kind, c.Expected, c.Actual)
 }
 
-func SystemdIsEmpty(s *SystemdConfiguration) bool {
+func (s *SystemdConfiguration) IsEmpty() bool {
 	if s == nil {
 		return true
 	}


### PR DESCRIPTION
This PR prevents the fields `%post`, `%preun`, and `%postun` from being written to the rpm SPEC unless they are specified in the dalec spec.

This is a short-term solution to the problem specified in #298. Please see that issue for more details on the long-term solution. A short summary of the problem follows:

What is happening is that the presence of the `%post`, `%preun`, or `%postun` causes `/bin/sh` to be baked into the dependencies of the rpm. This makes sense because a shell is needed to execute the postinstall scripts, and would be needed to run pre- or post- uninstall scripts.

_without %post_:
```
$ rpm -q --requires /tmp/out/RPMS/x86_64/oras-v1.2.0-1.cm2.x86_64.rpm
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
```

_with %post_:
```
$ rpm -q --requires /tmp/out/RPMS/x86_64/oras-v1.2.0-1.cm2.x86_64.rpm
/bin/sh
/bin/sh
/bin/sh
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
```

The `bash` package supplies `/bin/sh`, and all of its dependencies are installed into the container as well. So the distroless minimal image is used, but it has a bunch of extra stuff installed.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
