### PR TITLE
Fix cmd mounts

### DIFF
--- a/load.go
+++ b/load.go
@@ -143,6 +143,9 @@ func (s *Source) validate(failContext ...string) (retErr error) {
 
 		if s.DockerImage.Cmd != nil {
 			for _, mnt := range s.DockerImage.Cmd.Mounts {
+				if mnt.Dest == s.Path {
+					return errors.Wrap(errInvalidMountConfig, "")
+				}
 				if err := mnt.Spec.validate("docker image source with ref", "'"+s.DockerImage.Ref+"'"); err != nil {
 					retErr = goerrors.Join(retErr, err)
 				}

--- a/load_test.go
+++ b/load_test.go
@@ -236,6 +236,68 @@ func TestSourceValidation(t *testing.T) {
 				Generate: []*SourceGenerator{{Gomod: &GeneratorGomod{}}},
 			},
 		},
+		{
+			title:     "docker images with cmd source must specify a path to extract",
+			expectErr: true,
+			src: Source{
+				Path: "",
+				DockerImage: &SourceDockerImage{
+					Ref: "notexists:latest",
+					Cmd: &Command{
+						Steps: []*BuildStep{
+							{Command: ":"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title:     "cmd souce mount dest must not be /",
+			expectErr: true,
+			src: Source{
+				Path: "/foo",
+				DockerImage: &SourceDockerImage{
+					Ref: "notexists:latest",
+					Cmd: &Command{
+						Steps: []*BuildStep{
+							{Command: ":"},
+						},
+						Mounts: []SourceMount{
+							{
+								Dest: "/",
+								Spec: Source{
+									Inline: &SourceInline{
+										File: &SourceInlineFile{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title:     "cmd source mount dest must not be a descendent of the extracted source path",
+			expectErr: true,
+			src: Source{
+				Path: "/foo",
+				DockerImage: &SourceDockerImage{
+					Ref: "notexists:latest",
+					Cmd: &Command{
+						Mounts: []SourceMount{
+							{
+								Dest: "/foo",
+								Spec: Source{
+									Inline: &SourceInline{
+										File: &SourceInlineFile{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/source.go
+++ b/source.go
@@ -200,6 +200,13 @@ func generateSourceFromImage(st llb.State, cmd *Command, sOpts SourceOpts, subPa
 		return llb.Scratch(), fmt.Errorf("no steps defined for image source")
 	}
 
+	if subPath == "" {
+		// TODO: We should log a warning here since extracing an entire image while also running a command is
+		// probably not what the user really wanted to do here.
+		// The buildkit client provides functionality to do this we just need to wire it in.
+		subPath = "/"
+	}
+
 	for k, v := range cmd.Env {
 		st = st.AddEnv(k, v)
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -1041,3 +1041,43 @@ func (stubMetaResolver) ResolveImageConfig(ctx context.Context, ref string, opt 
 	}
 	return ref, "", dt, nil
 }
+
+func Test_pathHasPrefix(t *testing.T) {
+	type testCase struct {
+		path   string
+		prefix string
+		expect bool
+	}
+	cases := []testCase{
+		{"/foo", "/foobar", false},
+		{"/foo", "/foo", true},
+		{"/foo/", "/foo", true},
+		{"/foo/", "/foo/", true},
+		{"//foo", "/foo", true},
+		{"//foo/", "/foo", true},
+		{"/foo/bar", "/foo", true},
+		{"/foo/bar/", "/foo", true},
+		{"/foo/bar/", "/foo/", true},
+		{"/foo/bar", "/foo/", true},
+		{"/foo/bar", "/bar", false},
+		{"/foo/bar", "/foo/bar/baz", false},
+		{"/foo/bar/baz", "/foo/bar", true},
+		{"/foo//bar", "/foo", true},
+		{"/foo//bar/", "/foo", true},
+		{"/foo//bar/", "/foo/", true},
+		{"/foo//bar/", "/foo//", true},
+	}
+
+	// Replace / char which is special for go tests with something less special.
+	forTestName := func(s string) string {
+		return strings.Replace(s, "/", "__", -1)
+	}
+
+	for _, tc := range cases {
+		name := fmt.Sprintf("path=%s,prefix=%s", forTestName(tc.path), forTestName(tc.prefix))
+		t.Run(name, func(t *testing.T) {
+			hasPrefix := pathHasPrefix(tc.path, tc.prefix)
+			assert.Equal(t, hasPrefix, tc.expect)
+		})
+	}
+}

--- a/source_test.go
+++ b/source_test.go
@@ -916,6 +916,7 @@ func checkCmd(t *testing.T, ops []*pb.Op, src *Source, expectMounts [][]expectMo
 	if len(ops) != len(src.DockerImage.Cmd.Steps) {
 		t.Fatalf("unexpected number of ops, expected %d, got %d\n\n%v", len(src.DockerImage.Cmd.Steps), len(ops), ops)
 	}
+
 	for i, step := range src.DockerImage.Cmd.Steps {
 		exec := ops[i].GetExec()
 		if exec == nil {
@@ -941,6 +942,10 @@ func checkCmd(t *testing.T, ops []*pb.Op, src *Source, expectMounts [][]expectMo
 
 		for _, expectMount := range expectMounts[i] {
 			checkContainsMount(t, exec.Mounts, expectMount)
+		}
+
+		if exec.Mounts[0].Input == pb.Empty {
+			t.Fatal("rootfs mount cannot be empty")
 		}
 	}
 }


### PR DESCRIPTION
Adds additional validations to sources to prevent hitting cryptic errors, or worse unexpected data in a specified source.