### PR TITLE
Make systemd unit enable optional

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -995,11 +995,7 @@
 				}
 			},
 			"additionalProperties": false,
-			"type": "object",
-			"required": [
-				"name",
-				"enable"
-			]
+			"type": "object"
 		},
 		"Target": {
 			"properties": {

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -419,7 +419,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 			copyArtifact(`%{buildroot}/%{_unitdir}`, p, cfg.Artifact())
 
 			verb := "disable"
-			if cfg.Enable {
+			if dalec.OptionEquals(true, cfg.Enable) {
 				verb = "enable"
 			}
 

--- a/helpers.go
+++ b/helpers.go
@@ -397,3 +397,24 @@ func SortedMapValues[T any](m map[string]T) []T {
 
 	return out
 }
+
+// OptionTrue returns a pointer to a bool with the value true.
+func OptionTrue() *bool {
+	b := true
+	return &b
+}
+
+// OptionFalse returns a pointer to a bool with the value false.
+func OptionFalse() *bool {
+	b := false
+	return &b
+}
+
+// OptionEquals returns true if the given value is equal to the value of the given pointer.
+func OptionEquals[T comparable](v T, ptr *T) bool {
+	if ptr == nil {
+		return false
+	}
+
+	return v == *ptr
+}

--- a/spec.go
+++ b/spec.go
@@ -152,11 +152,11 @@ type SystemdUnitConfig struct {
 	// Name is the name systemd unit should be copied under.
 	// Nested paths are not supported. It is the user's responsibility
 	// to name the service with the appropriate extension, i.e. .service, .timer, etc.
-	Name string `yaml:"name,omitempty" json:"name"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// Enable is used to enable the systemd unit on install
 	// This determines what will be written to a systemd preset file
-	Enable bool `yaml:"enable,omitempty" json:"enable"`
+	Enable *bool `yaml:"enable,omitempty" json:"enable,omitempty"`
 }
 
 func (s SystemdUnitConfig) Artifact() ArtifactConfig {

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -414,7 +414,7 @@ WantedBy=multi-user.target
 				Systemd: &dalec.SystemdConfiguration{
 					Units: map[string]dalec.SystemdUnitConfig{
 						"src/simple.service": {
-							Enable: true,
+							Enable: dalec.OptionTrue(),
 						},
 					},
 				},
@@ -539,7 +539,7 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 					Units: map[string]dalec.SystemdUnitConfig{
 						"src/foo.service": {},
 						"src/foo.socket": {
-							Enable: true,
+							Enable: dalec.OptionTrue(),
 						},
 					},
 					Dropins: map[string]dalec.SystemdDropinConfig{


### PR DESCRIPTION
Deb based distros enable systemd units by default as opposed to mariner (and other rpm distros) which do not enable by default.

By making the systemd unit's enable field optional we can choose to use the default for a distro when the enable field is unset.
