### PR TITLE
feat: add support for datadir in rpm spec

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -69,7 +69,7 @@
 					"type": "object",
 					"description": "Manpages is the list of manpages to include in the package."
 				},
-				"data_files": {
+				"data_dirs": {
 					"additionalProperties": {
 						"$ref": "#/$defs/ArtifactConfig"
 					},

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -74,7 +74,7 @@
 						"$ref": "#/$defs/ArtifactConfig"
 					},
 					"type": "object",
-					"description": "DataFiles is a list of read-only architecture-independent data files, to be placed in /usr/share/"
+					"description": "DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/"
 				},
 				"createDirectories": {
 					"$ref": "#/$defs/CreateArtifactDirectories",

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -69,6 +69,13 @@
 					"type": "object",
 					"description": "Manpages is the list of manpages to include in the package."
 				},
+				"data_files": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactConfig"
+					},
+					"type": "object",
+					"description": "DataFiles is a list of read-only architecture-independent data files, to be placed in /usr/share/"
+				},
 				"createDirectories": {
 					"$ref": "#/$defs/CreateArtifactDirectories",
 					"description": "Directories is a list of various directories that should be created by the package."

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -404,6 +404,14 @@ func (w *specWrapper) Install() fmt.Stringer {
 		}
 	}
 
+	if w.Spec.Artifacts.DataFiles != nil {
+		dataFileKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataFiles)
+		for _, k := range dataFileKeys {
+			df := w.Spec.Artifacts.DataFiles[k]
+			copyArtifact(`%{buildroot}/%{_datadir}`, k, df)
+		}
+	}
+
 	configKeys := dalec.SortMapKeys(w.Spec.Artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := w.Spec.Artifacts.ConfigFiles[c]
@@ -489,6 +497,15 @@ func (w *specWrapper) Files() fmt.Stringer {
 		for _, p := range stateKeys {
 			dir := strings.Join([]string{`%dir`, filepath.Join(`%{_sharedstatedir}`, p)}, " ")
 			fmt.Fprintln(b, dir)
+		}
+	}
+
+	if w.Spec.Artifacts.DataFiles != nil {
+		dataKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataFiles)
+		for _, k := range dataKeys {
+			df := w.Spec.Artifacts.DataFiles[k]
+			fullPath := filepath.Join(`%{_datadir}`, df.SubPath, df.ResolveName(k))
+			fmt.Fprintln(b, fullPath)
 		}
 	}
 

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -404,10 +404,10 @@ func (w *specWrapper) Install() fmt.Stringer {
 		}
 	}
 
-	if w.Spec.Artifacts.DataFiles != nil {
-		dataFileKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataFiles)
+	if w.Spec.Artifacts.DataDirs != nil {
+		dataFileKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataDirs)
 		for _, k := range dataFileKeys {
-			df := w.Spec.Artifacts.DataFiles[k]
+			df := w.Spec.Artifacts.DataDirs[k]
 			copyArtifact(`%{buildroot}/%{_datadir}`, k, df)
 		}
 	}
@@ -500,10 +500,10 @@ func (w *specWrapper) Files() fmt.Stringer {
 		}
 	}
 
-	if w.Spec.Artifacts.DataFiles != nil {
-		dataKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataFiles)
+	if w.Spec.Artifacts.DataDirs != nil {
+		dataKeys := dalec.SortMapKeys(w.Spec.Artifacts.DataDirs)
 		for _, k := range dataKeys {
-			df := w.Spec.Artifacts.DataFiles[k]
+			df := w.Spec.Artifacts.DataDirs[k]
 			fullPath := filepath.Join(`%{_datadir}`, df.SubPath, df.ResolveName(k))
 			fmt.Fprintln(b, fullPath)
 		}

--- a/spec.go
+++ b/spec.go
@@ -129,7 +129,7 @@ type Artifacts struct {
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
 	// DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/
-	DataDirs map[string]ArtifactConfig `yaml:"data_files,omitempty" json:"data_files,omitempty"`
+	DataDirs map[string]ArtifactConfig `yaml:"data_dirs,omitempty" json:"data_dirs,omitempty"`
 	// Directories is a list of various directories that should be created by the package.
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.

--- a/spec.go
+++ b/spec.go
@@ -128,8 +128,8 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
-	// DataFiles is a list of read-only architecture-independent data files, to be placed in /usr/share/
-	DataFiles map[string]ArtifactConfig `yaml:"data_files,omitempty" json:"data_files,omitempty"`
+	// DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/
+	DataDirs map[string]ArtifactConfig `yaml:"data_files,omitempty" json:"data_files,omitempty"`
 	// Directories is a list of various directories that should be created by the package.
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.
@@ -247,7 +247,7 @@ func (a *Artifacts) IsEmpty() bool {
 	if a.Directories != nil && (len(a.Directories.Config) > 0 || len(a.Directories.State) > 0) {
 		return false
 	}
-	if len(a.DataFiles) > 0 {
+	if len(a.DataDirs) > 0 {
 		return false
 	}
 	if len(a.ConfigFiles) > 0 {

--- a/spec.go
+++ b/spec.go
@@ -128,6 +128,8 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
+	// DataFiles is a list of read-only architecture-independent data files, to be placed in /usr/share/
+	DataFiles map[string]ArtifactConfig `yaml:"data_files,omitempty" json:"data_files,omitempty"`
 	// Directories is a list of various directories that should be created by the package.
 	Directories *CreateArtifactDirectories `yaml:"createDirectories,omitempty" json:"createDirectories,omitempty"`
 	// ConfigFiles is a list of files that should be marked as config files in the package.

--- a/spec.go
+++ b/spec.go
@@ -247,6 +247,9 @@ func (a *Artifacts) IsEmpty() bool {
 	if a.Directories != nil && (len(a.Directories.Config) > 0 || len(a.Directories.State) > 0) {
 		return false
 	}
+	if len(a.DataFiles) > 0 {
+		return false
+	}
 	if len(a.ConfigFiles) > 0 {
 		return false
 	}

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -792,6 +792,18 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 						},
 					},
 				},
+				"another_data_dir": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"another_nested_data_file": {
+									Contents:    "this is a file which should end up at the path /usr/share/data_dir/nested_data_file\n",
+									Permissions: 0o400,
+								},
+							},
+						},
+					},
+				},
 				"data_file": {
 					Inline: &dalec.SourceInline{
 						File: &dalec.SourceInlineFile{
@@ -829,6 +841,9 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 				t.Fatal(err)
 			}
 			if err := validatePathAndPermissions(ctx, ref, "/usr/share/data_dir/nested_data_file", 0o400); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/usr/share/subpath/another_data_dir/another_nested_data_file", 0o400); err != nil {
 				t.Fatal(err)
 			}
 			if err := validatePathAndPermissions(ctx, ref, "/usr/share/data_file", 0o400); err != nil {

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -806,8 +806,11 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 				Binaries: map[string]dalec.ArtifactConfig{
 					"bin": {},
 				},
-				DataFiles: map[string]dalec.ArtifactConfig{
-					"data_dir":  {},
+				DataDirs: map[string]dalec.ArtifactConfig{
+					"data_dir": {},
+					"another_data_dir": {
+						SubPath: "subpath",
+					},
 					"data_file": {},
 				},
 			},

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -760,6 +760,80 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 		})
 	})
 
+	t.Run("test data file installation", func(t *testing.T) {
+		t.Parallel()
+		spec := &dalec.Spec{
+			Name:        "test-data-file-installation",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/azure/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Should install specified data files",
+			Sources: map[string]dalec.Source{
+				"bin": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/usr/bin/env bash\necho hello world",
+							Permissions: 0o700,
+						},
+					},
+				},
+				"data_dir": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"nested_data_file": {
+									Contents:    "this is a file which should end up at the path /usr/share/data_dir/nested_data_file\n",
+									Permissions: 0o400,
+								},
+							},
+						},
+					},
+				},
+				"data_file": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "This is a data file which should end up at /usr/share/data_file\n",
+							Permissions: 0o400,
+						},
+					},
+				},
+			},
+			Build: dalec.ArtifactBuild{},
+			Artifacts: dalec.Artifacts{
+				Binaries: map[string]dalec.ArtifactConfig{
+					"bin": {},
+				},
+				DataFiles: map[string]dalec.ArtifactConfig{
+					"data_dir":  {},
+					"data_file": {},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(withBuildTarget(testConfig.BuildTarget), withSpec(ctx, t, spec))
+			res := solveT(ctx, t, client, req)
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := validatePathAndPermissions(ctx, ref, "/usr/share/data_dir", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/usr/share/data_dir/nested_data_file", 0o400); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/usr/share/data_file", 0o400); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+
 	t.Run("test config files handled", func(t *testing.T) {
 		t.Parallel()
 		spec := &dalec.Spec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Users have requested the ability to put read-only architecture-independent data files under `/usr/share`.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Related #242 (does not completely resolve)

**Special notes for your reviewer**:
