### PR TITLE
rpm: Don't emit optional fields when empty

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -933,9 +933,7 @@
 				"website",
 				"version",
 				"revision",
-				"license",
-				"vendor",
-				"packager"
+				"license"
 			],
 			"description": "Spec is the specification for a package build."
 		},

--- a/frontend/rpm/rpmbuild.go
+++ b/frontend/rpm/rpmbuild.go
@@ -56,8 +56,8 @@ func ValidateSpec(spec *dalec.Spec) (out error) {
 	if spec.Description == "" {
 		out = errors.Join(out, fmt.Errorf("%w: description", errMissingRequiredField))
 	}
-	if spec.Website == "" {
-		out = errors.Join(out, fmt.Errorf("%w: website", errMissingRequiredField))
+	if spec.License == "" {
+		out = errors.Join(out, fmt.Errorf("%w: license", errMissingRequiredField))
 	}
 	return out
 }

--- a/spec.go
+++ b/spec.go
@@ -70,9 +70,9 @@ type Spec struct {
 	// License is the license of the package.
 	License string `yaml:"license" json:"license"`
 	// Vendor is the vendor of the package.
-	Vendor string `yaml:"vendor" json:"vendor"`
+	Vendor string `yaml:"vendor,omitempty" json:"vendor,omitempty"`
 	// Packager is the name of the person,team,company that packaged the package.
-	Packager string `yaml:"packager" json:"packager"`
+	Packager string `yaml:"packager,omitempty" json:"packager,omitempty"`
 
 	// Artifacts is the list of artifacts to include in the package.
 	Artifacts Artifacts `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -331,6 +331,7 @@ echo "$BAR" > bar.txt
 				Description: "foo bar baz",
 				Website:     "https://foo.bar.baz",
 				Revision:    "1",
+				License:     "MIT",
 				PackageConfig: &dalec.PackageConfig{
 					Signer: &dalec.PackageSigner{
 						Frontend: &dalec.Frontend{


### PR DESCRIPTION
This also cleans up some of the rpm spec template layout for easier reading.

Closes #276