### PR TITLE
Fix systemd artifact install to account for artifact name

### DIFF
--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -601,8 +601,9 @@ func (w *specWrapper) Files() fmt.Stringer {
 	if w.Spec.Artifacts.Systemd != nil {
 		serviceKeys := dalec.SortMapKeys(w.Spec.Artifacts.Systemd.Units)
 		for _, p := range serviceKeys {
-			serviceName := filepath.Base(p)
-			unitPath := filepath.Join(`%{_unitdir}/`, serviceName)
+			cfg := w.Spec.Artifacts.Systemd.Units[p]
+			a := cfg.Artifact()
+			unitPath := filepath.Join(`%{_unitdir}/`, a.SubPath, a.ResolveName(p))
 			fmt.Fprintln(b, unitPath)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If a different name is provided for a systemd unit artifact the unit is not being installed under that name currently. This PR fixes the bug.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
