### PR TITLE
feat: Add known build arg to disable signing

### DIFF
--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -73,13 +73,19 @@ func specToRpmLLB(ctx context.Context, w worker, client gwclient.Client, spec *d
 	specPath := filepath.Join("SPECS", spec.Name, spec.Name+".spec")
 	st := rpm.Build(br, base, specPath, opts...)
 
-	if signer, ok := spec.GetSigner(targetKey); ok {
-		signed, err := frontend.ForwardToSigner(ctx, client, signer, st)
-		if err != nil {
-			return llb.Scratch(), err
-		}
-		st = signed
+	if frontend.SigningDisabled(client) {
+		return st, nil
 	}
 
-	return st, nil
+	signer := spec.GetSigner(targetKey)
+	if signer == nil {
+		return st, nil
+	}
+
+	signed, err := frontend.ForwardToSigner(ctx, client, signer, st)
+	if err != nil {
+		return llb.Scratch(), err
+	}
+
+	return signed, nil
 }

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -73,19 +73,5 @@ func specToRpmLLB(ctx context.Context, w worker, client gwclient.Client, spec *d
 	specPath := filepath.Join("SPECS", spec.Name, spec.Name+".spec")
 	st := rpm.Build(br, base, specPath, opts...)
 
-	if frontend.SigningDisabled(client) {
-		return st, nil
-	}
-
-	signer := spec.GetSigner(targetKey)
-	if signer == nil {
-		return st, nil
-	}
-
-	signed, err := frontend.ForwardToSigner(ctx, client, signer, st)
-	if err != nil {
-		return llb.Scratch(), err
-	}
-
-	return signed, nil
+	return frontend.MaybeSign(ctx, client, st, spec, targetKey)
 }

--- a/frontend/request.go
+++ b/frontend/request.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/dalec"
 	"github.com/goccy/go-yaml"
@@ -132,6 +133,21 @@ func toDockerfile(ctx context.Context, bctx llb.State, dt []byte, spec *dalec.So
 func marshalDockerfile(ctx context.Context, dt []byte, opts ...llb.ConstraintsOpt) (*llb.Definition, error) {
 	st := llb.Scratch().File(llb.Mkfile(dockerui.DefaultDockerfileName, 0600, dt), opts...)
 	return st.Marshal(ctx)
+}
+
+func SigningDisabled(client gwclient.Client) bool {
+	bopts := client.BuildOpts().Opts
+	v, ok := bopts["build-arg:DALEC_SKIP_SIGNING"]
+	if !ok {
+		return false
+	}
+
+	isDisabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+
+	return isDisabled
 }
 
 func ForwardToSigner(ctx context.Context, client gwclient.Client, cfg *dalec.PackageSigner, s llb.State) (llb.State, error) {

--- a/frontend/windows/handle_zip.go
+++ b/frontend/windows/handle_zip.go
@@ -156,21 +156,7 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 		dalec.WithConstraints(opts...),
 	).AddMount(outputDir, llb.Scratch())
 
-	if frontend.SigningDisabled(client) {
-		return st, nil
-	}
-
-	signer := spec.GetSigner(targetKey)
-	if signer == nil {
-		return st, nil
-	}
-
-	signed, err := frontend.ForwardToSigner(ctx, client, signer, st)
-	if err != nil {
-		return llb.Scratch(), err
-	}
-
-	return signed, nil
+	return frontend.MaybeSign(ctx, client, st, spec, targetKey)
 }
 
 func getZipLLB(worker llb.State, name string, artifacts llb.State) llb.State {

--- a/helpers.go
+++ b/helpers.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/moby/buildkit/client/llb"
@@ -369,6 +370,12 @@ func InstallPostSymlinks(post *PostInstall, rootfsPath string) llb.RunOption {
 }
 
 func (s *Spec) GetSigner(targetKey string) (*PackageSigner, bool) {
+	if skipVal, ok := s.Args["DALEC_SKIP_SIGNING"]; ok {
+		if shouldSkip, err := strconv.ParseBool(skipVal); err == nil && shouldSkip {
+			return nil, false
+		}
+	}
+
 	if s.Targets != nil {
 		if t, ok := s.Targets[targetKey]; ok && hasValidSigner(t.PackageConfig) {
 			return t.PackageConfig.Signer, true

--- a/helpers.go
+++ b/helpers.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
-	"strconv"
 	"sync/atomic"
 
 	"github.com/moby/buildkit/client/llb"
@@ -369,24 +368,18 @@ func InstallPostSymlinks(post *PostInstall, rootfsPath string) llb.RunOption {
 	})
 }
 
-func (s *Spec) GetSigner(targetKey string) (*PackageSigner, bool) {
-	if skipVal, ok := s.Args["DALEC_SKIP_SIGNING"]; ok {
-		if shouldSkip, err := strconv.ParseBool(skipVal); err == nil && shouldSkip {
-			return nil, false
-		}
-	}
-
+func (s *Spec) GetSigner(targetKey string) *PackageSigner {
 	if s.Targets != nil {
 		if t, ok := s.Targets[targetKey]; ok && hasValidSigner(t.PackageConfig) {
-			return t.PackageConfig.Signer, true
+			return t.PackageConfig.Signer
 		}
 	}
 
 	if hasValidSigner(s.PackageConfig) {
-		return s.PackageConfig.Signer, true
+		return s.PackageConfig.Signer
 	}
 
-	return nil, false
+	return nil
 }
 
 func hasValidSigner(pc *PackageConfig) bool {

--- a/load.go
+++ b/load.go
@@ -19,6 +19,8 @@ func knownArg(key string) bool {
 		return true
 	case "DALEC_DISABLE_DIFF_MERGE":
 		return true
+	case "DALEC_SKIP_SIGNING":
+		return true
 	case "SOURCE_DATE_EPOCH":
 		return true
 	}

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -394,6 +394,17 @@ echo "$BAR" > bar.txt
 			}
 			runTest(t, distroSigningTest(t, spec, testConfig.SignTarget))
 		})
+
+		t.Run("with skip signing", func(t *testing.T) {
+			t.Parallel()
+
+			spec := newSpec()
+			spec.Args = map[string]string{
+				"DALEC_SKIP_SIGNING": "1",
+			}
+
+			runTest(t, distroSkipSigningTest(t, spec, testConfig.SignTarget))
+		})
 	})
 
 	t.Run("test systemd unit", func(t *testing.T) {

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -399,10 +399,6 @@ echo "$BAR" > bar.txt
 			t.Parallel()
 
 			spec := newSpec()
-			spec.Args = map[string]string{
-				"DALEC_SKIP_SIGNING": "1",
-			}
-
 			runTest(t, distroSkipSigningTest(t, spec, testConfig.SignTarget))
 		})
 	})

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -82,6 +82,25 @@ func readFile(ctx context.Context, t *testing.T, name string, res *gwclient.Resu
 	return dt
 }
 
+func maybeReadFile(ctx context.Context, name string, res *gwclient.Result) ([]byte, error) {
+	ref, err := res.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	dt, err := ref.ReadFile(ctx, gwclient.ReadRequest{
+		Filename: name,
+	})
+	if err != nil {
+		stat, _ := ref.ReadDir(ctx, gwclient.ReadDirRequest{
+			Path: filepath.Dir(name),
+		})
+		return nil, fmt.Errorf("error reading file %q: %v, dir contents: \n%s", name, err, dirStatAsStringer(stat))
+	}
+
+	return dt, nil
+}
+
 func statFile(ctx context.Context, t *testing.T, name string, res *gwclient.Result) {
 	t.Helper()
 

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -191,6 +191,12 @@ func withPlatform(platform platforms.Platform) srOpt {
 	}
 }
 
+func withBuildArg(k, v string) srOpt {
+	return func(sr *gwclient.SolveRequest) {
+		sr.FrontendOpt["build-arg:"+k] = v
+	}
+}
+
 func withSpec(ctx context.Context, t *testing.T, spec *dalec.Spec) srOpt {
 	return func(sr *gwclient.SolveRequest) {
 		specToSolveRequest(ctx, t, spec, sr)

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -36,3 +36,17 @@ func distroSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) teste
 		}
 	}
 }
+
+func distroSkipSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) testenv.TestFunc {
+	return func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(buildTarget))
+		res := solveT(ctx, t, gwc, sr)
+
+		if _, err := maybeReadFile(ctx, "/target", res); err == nil {
+			t.Fatalf("signer signed even though signing was disabled")
+		}
+		if _, err := maybeReadFile(ctx, "/config.json", res); err == nil {
+			t.Fatalf("signer signed even though signing was disabled")
+		}
+	}
+}

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -39,7 +39,7 @@ func distroSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) teste
 
 func distroSkipSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string) testenv.TestFunc {
 	return func(ctx context.Context, gwc gwclient.Client) {
-		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(buildTarget))
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(buildTarget), withBuildArg("DALEC_SKIP_SIGNING", "1"))
 		res := solveT(ctx, t, gwc, sr)
 
 		if _, err := maybeReadFile(ctx, "/target", res); err == nil {

--- a/website/docs/signing.md
+++ b/website/docs/signing.md
@@ -31,6 +31,10 @@ For container targets, only the artifacts within the container get signed.
 This will send the artifacts (`.rpm`, `.deb`, or `.exe`) to the
 signing frontend as the build context.
 
+Once a `signer` section has been aded to the spec, signing will be automatic.
+In order to disable signing when building specs that have a `signer` section,
+use the build arg `DALEC_SKIP_SIGNING=1`.
+
 The contract between dalec and the signing image is:
 
 1. The signing image will contain both the signing frontend, and any


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the user to skip signing by adding `--build-arg DALEC_SKIP_SIGNING=1` to their `docker build` invocation. This is a partial resolution of #282. I will submit a separate PR that implements the remainder of #282.