### PR TITLE
Fix test platforms

### DIFF
--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -47,7 +47,7 @@ func handleRPM(w worker) gwclient.BuildFunc {
 			if err != nil {
 				return nil, nil, err
 			}
-			return ref, nil, nil
+			return ref, &dalec.DockerImageSpec{}, nil
 		})
 	}
 }

--- a/frontend/debug/handle_gomod.go
+++ b/frontend/debug/handle_gomod.go
@@ -55,6 +55,6 @@ func Gomods(ctx context.Context, client gwclient.Client) (*client.Result, error)
 		if err != nil {
 			return nil, nil, err
 		}
-		return ref, nil, nil
+		return ref, &dalec.DockerImageSpec{}, nil
 	})
 }

--- a/frontend/debug/handle_resolve.go
+++ b/frontend/debug/handle_resolve.go
@@ -36,6 +36,6 @@ func Resolve(ctx context.Context, client gwclient.Client) (*gwclient.Result, err
 			return nil, nil, err
 		}
 
-		return ref, nil, err
+		return ref, &dalec.DockerImageSpec{}, err
 	})
 }

--- a/frontend/debug/handle_sources.go
+++ b/frontend/debug/handle_sources.go
@@ -40,6 +40,6 @@ func Sources(ctx context.Context, client gwclient.Client) (*client.Result, error
 		if err != nil {
 			return nil, nil, err
 		}
-		return ref, nil, nil
+		return ref, &dalec.DockerImageSpec{}, nil
 	})
 }

--- a/frontend/rpm/handle_buildroot.go
+++ b/frontend/rpm/handle_buildroot.go
@@ -48,7 +48,7 @@ func HandleBuildroot(wf WorkerFunc) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			return ref, nil, nil
+			return ref, &dalec.DockerImageSpec{}, nil
 		})
 	}
 }

--- a/frontend/rpm/handle_sources.go
+++ b/frontend/rpm/handle_sources.go
@@ -49,7 +49,7 @@ func HandleSources(wf WorkerFunc) gwclient.BuildFunc {
 			if err != nil {
 				return nil, nil, err
 			}
-			return ref, nil, nil
+			return ref, &dalec.DockerImageSpec{}, nil
 		})
 	}
 }

--- a/frontend/rpm/handle_spec.go
+++ b/frontend/rpm/handle_spec.go
@@ -38,7 +38,7 @@ func HandleSpec() gwclient.BuildFunc {
 				return nil, nil, err
 			}
 			ref, err := res.SingleRef()
-			return ref, nil, err
+			return ref, &dalec.DockerImageSpec{}, err
 		})
 	}
 

--- a/frontend/windows/handle_zip.go
+++ b/frontend/windows/handle_zip.go
@@ -57,7 +57,7 @@ func handleZip(ctx context.Context, client gwclient.Client) (*gwclient.Result, e
 			return nil, nil, err
 		}
 		ref, err := res.SingleRef()
-		return ref, nil, err
+		return ref, &dalec.DockerImageSpec{}, err
 	})
 }
 

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -390,7 +390,7 @@ func verifySigning(ctx context.Context, t *testing.T, res *gwclient.Result) {
 func prepareSigningState(ctx context.Context, t *testing.T, gwc gwclient.Client, spec *dalec.Spec, extraSrOpts ...srOpt) llb.State {
 	zipper := getZipperState(ctx, t, gwc)
 
-	srOpts := []srOpt{withSpec(ctx, t, spec), withBuildTarget("windowscross/zip")}
+	srOpts := []srOpt{withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"), withWindowsAmd64}
 	srOpts = append(srOpts, extraSrOpts...)
 
 	sr := newSolveRequest(srOpts...)


### PR DESCRIPTION
This fixes 2 things:

1. Always return a non-nil image config for build artifacts regardless of if they are an image [1].
2. Tests: set platform on returned llb.State [2]


### [1] Stop returning nil image config
This can cause some issues in buildkit libs and also yields a cryptic
error on the docker CLI for these non-container targets when the build
is not outputing tot he local dir.

One specific case right now is the dockerui client which drives all the
build targets will panic on the windowscross/zip target when using
windows as a target platform.

In the past this has also caused panics in dockerd and buildkit. These
have been fixed upstream and were considered security issues due to a
frontend being able to panic dockerd, but I don't think we should
continue doing this.

Something to consider in the future is to either replace our usage of
dockerui to drive builds (not great because it is the canonical
implementation for interacting with docker) and also returning a custom
OCI artifact type for these non-container builds OR we could work
upstream to make dockerui support a more generic type.

### [2] Set platform on returned llb state
In my case I am trying to run tests from a Mac connecting to a
linux/amd64 machine over SSH.
The windows signing tests end up failing due to the platform missing
from the `llb.State` generated for the the unzipper intermediate state.
It tries to run a command in the unzip state but fails due to the
architecture not being compataible.

Before this change `reqToState` is returning an `llb.State` without a
platform set on it. Subsequent `.Run()` calls on that state will
default to the platform of the client (darwin/arm64).

This changes extracts the first (and should be only in the case of our
tests) platform from the returned result and adds that to the returned
`llb.State`.