### PR TITLE
azlinux/mariner: Use provided platform for outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ on:
       - go.mod
       - go.sum
 
+env:
+  # Used in tests to determine if certain tests should be skipped.
+  # Setting this ensures that they are *not* skipped and instead make sure CI
+  # is setup to be able to properly run all tests.
+  DALEC_CI: "1"
+
 permissions:
   contents: read
 
@@ -93,6 +99,8 @@ jobs:
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       - name: download deps
         run: go mod download
+      - name: Setup QEMU
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Run integaration tests
         run: go test -v -json ./test | go run ./cmd/test2json2gha
       - name: dump logs

--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -25,7 +25,7 @@ func handleContainer(w worker) gwclient.BuildFunc {
 
 			pg := dalec.ProgressGroup("Building " + targetKey + " container: " + spec.Name)
 
-			rpmDir, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg, dalec.WithPlatform(platform))
+			rpmDir, err := buildOutputRPM(ctx, w, client, spec, sOpt, targetKey, platform, pg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error creating rpm: %w", err)
 			}

--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -25,7 +25,7 @@ func handleContainer(w worker) gwclient.BuildFunc {
 
 			pg := dalec.ProgressGroup("Building " + targetKey + " container: " + spec.Name)
 
-			rpmDir, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg)
+			rpmDir, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, fmt.Errorf("error creating rpm: %w", err)
 			}
@@ -35,7 +35,7 @@ func handleContainer(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			st, err := specToContainerLLB(w, spec, targetKey, rpmDir, rpms, sOpt, pg)
+			st, err := specToContainerLLB(w, spec, targetKey, rpmDir, rpms, sOpt, pg, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/handle_depsonly.go
+++ b/frontend/azlinux/handle_depsonly.go
@@ -21,7 +21,7 @@ func handleDepsOnly(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			baseImg, err := w.Base(sOpt, pg)
+			baseImg, err := w.Base(sOpt, pg, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/handle_depsonly.go
+++ b/frontend/azlinux/handle_depsonly.go
@@ -36,7 +36,7 @@ func handleDepsOnly(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			st, err := specToContainerLLB(w, spec, targetKey, rpmDir, files, sOpt, pg)
+			st, err := specToContainerLLB(w, spec, targetKey, rpmDir, files, sOpt, pg, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/frontend"
 	"github.com/Azure/dalec/frontend/rpm"
+	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -151,6 +153,46 @@ func createBuildroot(w worker, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKe
 	return rpm.SpecToBuildrootLLB(native, spec, sOpt, targetKey, opts...)
 }
 
+func nativeGoMount(native llb.State, p *ocispecs.Platform) llb.RunOption {
+	const (
+		gorootPath      = "/usr/lib/golang"
+		goBinPath       = "/usr/bin/go"
+		internalBinPath = "/tmp/internal/dalec/bin"
+	)
+
+	runOpts := []llb.RunOption{
+		llb.AddMount(gorootPath, native, llb.SourcePath(gorootPath), llb.Readonly),
+		llb.AddEnv("GOARCH", p.Architecture),
+		dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+			if p.Variant != "" {
+				switch p.Architecture {
+				case "arm":
+					// GOARM cannot have the `v` prefix that would be in the platform struct
+					llb.AddEnv("GOARM", strings.TrimPrefix(p.Variant, "v")).SetRunOption(ei)
+				case "amd64":
+					// Unlike GOARM, GOAMD64 must have the `v` prefix (Which should be
+					// present in the platform struct)
+					llb.AddEnv("GOAMD64", p.Variant).SetRunOption(ei)
+				default:
+					// go does not support any other special sub-architectures currently.
+				}
+			}
+		}),
+	}
+
+	return dalec.WithRunOptions(runOpts...)
+}
+
+func hasGolangBuildDep(spec *dalec.Spec, targetKey string) bool {
+	deps := spec.GetBuildDeps(targetKey)
+	for pkg := range deps {
+		if pkg == "golang" || pkg == "msft-golang" {
+			return true
+		}
+	}
+	return false
+}
+
 func createRPM(w worker, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, platform *ocispecs.Platform, opts ...llb.ConstraintsOpt) (llb.State, error) {
 	br, err := createBuildroot(w, sOpt, spec, targetKey, opts...)
 	if err != nil {
@@ -162,9 +204,21 @@ func createRPM(w worker, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey stri
 		return llb.Scratch(), nil
 	}
 
+	var runOpts []llb.RunOption
+	if platform != nil {
+		if platforms.Only(platforms.DefaultSpec()).Match(*platform) && hasGolangBuildDep(spec, targetKey) {
+			native, err := rpmWorker(w, sOpt, spec, targetKey, nil, opts...)
+			if err != nil {
+				return llb.Scratch(), err
+			}
+
+			runOpts = append(runOpts, nativeGoMount(native, platform))
+		}
+	}
+
 	specPath := filepath.Join("SPECS", spec.Name, spec.Name+".spec")
 	opts = append(opts, dalec.ProgressGroup("Create RPM: "+spec.Name))
-	return rpm.Build(br, base, specPath, opts...), nil
+	return rpm.Build(br, base, specPath, runOpts, opts...), nil
 }
 
 func buildOutputRPM(ctx context.Context, w worker, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, platform *ocispecs.Platform, opts ...llb.ConstraintsOpt) (llb.State, error) {

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -26,7 +26,7 @@ func handleRPM(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			st, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg)
+			st, err := specToRpmLLB(ctx, w, client, spec, sOpt, targetKey, pg, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -14,10 +14,6 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-const (
-	tdnfCacheDir = "/var/cache/tdnf"
-)
-
 type worker interface {
 	Base(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error)
 	Install(pkgs []string, opts ...installOpt) llb.RunOption

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -101,7 +101,7 @@ func handleBaseImg(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			st, err := w.Base(sOpt)
+			st, err := w.Base(sOpt, dalec.WithPlatform(platform))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/install.go
+++ b/frontend/azlinux/install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/dalec"
 	"github.com/moby/buildkit/client/llb"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type installConfig struct {
@@ -23,13 +24,24 @@ type installConfig struct {
 	// Additional mounts to add to the tdnf install command (useful if installing RPMS which are mounted to a local directory)
 	mounts []llb.RunOption
 
+	// Instructs the installer to install packages for the specified platform
+	platform *ocispecs.Platform
+
 	constraints []llb.ConstraintsOpt
+
+	// This forces the use of tdnf
+	// Note this will almost certainly not work when platform is set.
+	tdnfOnly bool
 }
 
 type installOpt func(*installConfig)
 
 func noGPGCheck(cfg *installConfig) {
 	cfg.noGPGCheck = true
+}
+
+func tdnfOnly(cfg *installConfig) {
+	cfg.tdnfOnly = true
 }
 
 func withMounts(opts ...llb.RunOption) installOpt {
@@ -48,13 +60,19 @@ func atRoot(root string) installOpt {
 	}
 }
 
+func withPlatform(p *ocispecs.Platform) installOpt {
+	return func(cfg *installConfig) {
+		cfg.platform = p
+	}
+}
+
 func installWithConstraints(opts []llb.ConstraintsOpt) installOpt {
 	return func(cfg *installConfig) {
 		cfg.constraints = opts
 	}
 }
 
-func tdnfInstallFlags(cfg *installConfig) string {
+func dnfInstallFlags(cfg *installConfig) string {
 	var cmdOpts string
 
 	if cfg.noGPGCheck {
@@ -63,10 +81,28 @@ func tdnfInstallFlags(cfg *installConfig) string {
 
 	if cfg.root != "" {
 		cmdOpts += " --installroot=" + cfg.root
-		cmdOpts += " --setopt=reposdir=/etc/yum.repos.d"
+		cmdOpts += " --setopt reposdir=/etc/yum.repos.d"
+	}
+
+	if cfg.platform != nil {
+		// cmdOpts += " --ignorearch=true"
+		cmdOpts += " --forcearch=" + ociArchToOS(cfg.platform)
 	}
 
 	return cmdOpts
+}
+
+func ociArchToOS(p *ocispecs.Platform) string {
+	switch p.Architecture {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "aarch64"
+		// azlinux only supports amd64 and arm64
+		// We shouldn't need any other arches.
+	default:
+		return p.Architecture
+	}
 }
 
 func setInstallOptions(cfg *installConfig, opts []installOpt) {
@@ -111,9 +147,14 @@ rm -rf `+rpmdbDir+`
 
 const manifestSh = "manifest.sh"
 
-func tdnfInstall(cfg *installConfig, relVer string, pkgs []string) llb.RunOption {
-	cmdFlags := tdnfInstallFlags(cfg)
-	cmdArgs := fmt.Sprintf("set -ex; tdnf install -y --refresh --releasever=%s %s %s", relVer, cmdFlags, strings.Join(pkgs, " "))
+func dnfInstall(cfg *installConfig, relVer string, pkgs []string, cachePrefix string) llb.RunOption {
+	cmdFlags := dnfInstallFlags(cfg)
+
+	cmd := "dnf"
+	if cfg.tdnfOnly {
+		cmd = "tdnf"
+	}
+	cmdArgs := fmt.Sprintf("set -ex; %s install -y --refresh --releasever=%s %s %s", cmd, relVer, cmdFlags, strings.Join(pkgs, " "))
 
 	var runOpts []llb.RunOption
 
@@ -128,6 +169,7 @@ func tdnfInstall(cfg *installConfig, relVer string, pkgs []string) llb.RunOption
 
 	runOpts = append(runOpts, dalec.ShArgs(cmdArgs))
 	runOpts = append(runOpts, cfg.mounts...)
+	runOpts = append(runOpts, llb.AddMount("/var/cache/"+cmd, llb.Scratch(), llb.AsPersistentCacheDir(cachePrefix+"-"+cmd+"-"+"cache", llb.CacheMountLocked)))
 
 	return dalec.WithRunOptions(runOpts...)
 }

--- a/frontend/debug/handler.go
+++ b/frontend/debug/handler.go
@@ -25,6 +25,5 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 		Name:        "gomods",
 		Description: "Outputs all the gomodule dependencies for the spec",
 	})
-
 	return r.Handle(ctx, client)
 }

--- a/frontend/gateway.go
+++ b/frontend/gateway.go
@@ -17,10 +17,12 @@ import (
 )
 
 const (
-	requestIDKey               = "requestid"
-	dalecSubrequstForwardBuild = "dalec.forward.build"
+	// KeyRequestID is a key used in buildkit to performa subrequest
+	// This is exposed for convenience only.
+	KeyRequestID = "requestid"
 
-	gatewayFrontend = "gateway.v0"
+	dalecSubrequstForwardBuild = "dalec.forward.build"
+	gatewayFrontend            = "gateway.v0"
 )
 
 func getDockerfile(ctx context.Context, client gwclient.Client, build *dalec.SourceBuild, defPb *pb.Definition) ([]byte, error) {

--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -117,7 +117,7 @@ func (m *BuildMux) describe() (*gwclient.Result, error) {
 }
 
 func (m *BuildMux) handleSubrequest(ctx context.Context, client gwclient.Client, opts map[string]string) (*gwclient.Result, bool, error) {
-	switch opts[requestIDKey] {
+	switch opts[KeyRequestID] {
 	case "":
 		return nil, false, nil
 	case subrequests.RequestSubrequestsDescribe:
@@ -135,7 +135,7 @@ func (m *BuildMux) handleSubrequest(ctx context.Context, client gwclient.Client,
 		res, err := handleDefaultPlatform()
 		return res, true, err
 	default:
-		return nil, false, errors.Errorf("unsupported subrequest %q", opts[requestIDKey])
+		return nil, false, errors.Errorf("unsupported subrequest %q", opts[KeyRequestID])
 	}
 }
 
@@ -369,7 +369,7 @@ func (m *BuildMux) Handle(ctx context.Context, client gwclient.Client) (_ *gwcli
 		WithFields(logrus.Fields{
 			"handlers":  maps.Keys(m.handlers),
 			"target":    opts[keyTarget],
-			"requestid": opts[requestIDKey],
+			"requestid": opts[KeyRequestID],
 			"targetKey": GetTargetKey(client),
 		}))
 
@@ -403,7 +403,7 @@ func (m *BuildMux) Handle(ctx context.Context, client gwclient.Client) (_ *gwcli
 
 	// If this request was a request to list targets, we need to modify the response a bit
 	// Otherwise we can just return the result as is.
-	if opts[requestIDKey] == bktargets.SubrequestsTargetsDefinition.Name {
+	if opts[KeyRequestID] == bktargets.SubrequestsTargetsDefinition.Name {
 		return m.fixupListResult(matched, res)
 	}
 	return res, nil

--- a/frontend/rpm/handle_buildroot.go
+++ b/frontend/rpm/handle_buildroot.go
@@ -11,7 +11,7 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-type WorkerFunc func(resolver llb.ImageMetaResolver, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error)
+type WorkerFunc func(resolver llb.ImageMetaResolver, spec *dalec.Spec, targetKey string, platform *ocispecs.Platform, opts ...llb.ConstraintsOpt) (llb.State, error)
 
 func HandleBuildroot(wf WorkerFunc) gwclient.BuildFunc {
 	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
@@ -21,7 +21,9 @@ func HandleBuildroot(wf WorkerFunc) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			worker, err := wf(sOpt.Resolver, spec, targetKey)
+			// Note, we are not passing platform down here because everything should
+			// be able to work regardless of platform, so prefer the native platform.
+			worker, err := wf(sOpt.Resolver, spec, targetKey, platform)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/rpm/handle_sources.go
+++ b/frontend/rpm/handle_sources.go
@@ -21,11 +21,13 @@ func HandleSources(wf WorkerFunc) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			worker, err := wf(sOpt.Resolver, spec, targetKey)
+			worker, err := wf(sOpt.Resolver, spec, targetKey, platform)
 			if err != nil {
 				return nil, nil, err
 			}
 
+			// Note, we are not passing platform down here because everything should
+			// be able to work regardless of platform, so prefer the native platform.
 			sources, err := Dalec2SourcesLLB(worker, spec, sOpt)
 			if err != nil {
 				return nil, nil, err

--- a/frontend/rpm/rpmbuild.go
+++ b/frontend/rpm/rpmbuild.go
@@ -16,7 +16,7 @@ import (
 // It is expected to have rpmbuild and any other necessary build dependencies installed
 //
 // `specPath` is the path to the spec file to build relative to `topDir`
-func Build(topDir, workerImg llb.State, specPath string, opts ...llb.ConstraintsOpt) llb.State {
+func Build(topDir, workerImg llb.State, specPath string, runOpts []llb.RunOption, opts ...llb.ConstraintsOpt) llb.State {
 	opts = append(opts, dalec.ProgressGroup("Build RPM"))
 	return workerImg.Run(
 		// some notes on these args:
@@ -35,6 +35,11 @@ func Build(topDir, workerImg llb.State, specPath string, opts ...llb.Constraints
 		llb.Dir("/build/top"),
 		llb.Network(llb.NetModeNone),
 		dalec.WithConstraints(opts...),
+		dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+			for _, opt := range runOpts {
+				opt.SetRunOption(ei)
+			}
+		}),
 	).
 		AddMount("/build/out", llb.Scratch())
 }

--- a/helpers.go
+++ b/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/identity"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var disableDiffMerge atomic.Bool
@@ -412,4 +413,13 @@ func (s *Spec) GetPackageDeps(target string) *PackageDependencies {
 		return deps.Dependencies
 	}
 	return s.Dependencies
+}
+
+// WithPlatform sets the platform in the constraints opts
+// This is similar to [llb.Platform] except this takes a pointer so you don't
+// need to worry about dereferencing a potentially nil pointer.
+func WithPlatform(p *ocispecs.Platform) llb.ConstraintsOpt {
+	return constraintsOptFunc(func(c *llb.Constraints) {
+		c.Platform = p
+	})
 }


### PR DESCRIPTION
Before this change, the mariner/azl targets were ignoring the client provided platform for the produced aritifacts.

With this change the platform is set on images so it will rely on binfmt_misc to execute those images correctly.
This also includes some optimizations:

1. If there is a build dependency on golang it will mount the native golang toolchain over the platform-specific one and adds the proper envs to produce the correct binaries for the target platform
2. go modules fetched with the generator will use the native go
3. The rpm build root is generated using the native platform since there is no platform specific code included there
4. Native dnf is used to install packages into the rootfs with the target arch (this required a change to dnf as tdnf appears to be bugged in this case).

This does *not* add support for cross compilation (run x86 code to generate, e.g., arm64 code) outside of the specific optimizations listed above.
