### PR TITLE
Allow custom worker images

### DIFF
--- a/frontend/azlinux/azlinux3.go
+++ b/frontend/azlinux/azlinux3.go
@@ -16,8 +16,11 @@ const (
 	AzLinux3TargetKey     = "azlinux3"
 	tdnfCacheNameAzlinux3 = "azlinux3-tdnf-cache"
 
-	azlinux3Ref           = "azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0"
-	azlinux3DistrolessRef = "azurelinuxpreview.azurecr.io/public/azurelinux/distroless/base:3.0"
+	// Azlinux3Ref is the image ref used for the base worker image
+	Azlinux3Ref = "azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0"
+	// Azlinux3WorkerContextName is the build context name that can be used to lookup
+	Azlinux3WorkerContextName = "dalec-azlinux3-worker"
+	azlinux3DistrolessRef     = "azurelinuxpreview.azurecr.io/public/azurelinux/distroless/base:3.0"
 )
 
 func NewAzlinux3Handler() gwclient.BuildFunc {
@@ -26,11 +29,29 @@ func NewAzlinux3Handler() gwclient.BuildFunc {
 
 type azlinux3 struct{}
 
-func (w azlinux3) Base(resolver llb.ImageMetaResolver, opts ...llb.ConstraintsOpt) llb.State {
-	return llb.Image(azlinux3Ref, llb.WithMetaResolver(resolver), dalec.WithConstraints(opts...)).Run(
+func (w azlinux3) Base(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	base, err := sOpt.GetContext(Azlinux3Ref, dalec.WithConstraints(opts...))
+	if err != nil {
+		return llb.Scratch(), err
+	}
+
+	if base != nil {
+		return *base, nil
+	}
+
+	base, err = sOpt.GetContext(Azlinux3WorkerContextName, dalec.WithConstraints(opts...))
+	if err != nil {
+		return llb.Scratch(), nil
+	}
+	if base != nil {
+		return *base, nil
+	}
+
+	img := llb.Image(Azlinux3Ref, llb.WithMetaResolver(sOpt.Resolver), dalec.WithConstraints(opts...))
+	return img.Run(
 		w.Install([]string{"rpm-build", "mariner-rpm-macros", "build-essential", "ca-certificates"}, installWithConstraints(opts)),
 		dalec.WithConstraints(opts...),
-	).Root()
+	).Root(), nil
 }
 
 func (w azlinux3) Install(pkgs []string, opts ...installOpt) llb.RunOption {
@@ -41,6 +62,20 @@ func (w azlinux3) Install(pkgs []string, opts ...installOpt) llb.RunOption {
 
 func (azlinux3) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {
 	_, _, dt, err := resolver.ResolveImageConfig(ctx, azlinux3DistrolessRef, sourceresolver.Opt{Platform: platform})
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg dalec.DockerImageSpec
+	if err := json.Unmarshal(dt, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func (azlinux3) WorkerImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {
+	_, _, dt, err := resolver.ResolveImageConfig(ctx, Azlinux3Ref, sourceresolver.Opt{Platform: platform})
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/azlinux/handle_depsonly.go
+++ b/frontend/azlinux/handle_depsonly.go
@@ -15,7 +15,16 @@ func handleDepsOnly(w worker) gwclient.BuildFunc {
 	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 		return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
 			pg := dalec.ProgressGroup("Build mariner2 deps-only container: " + spec.Name)
-			baseImg := w.Base(client, pg)
+
+			sOpt, err := frontend.SourceOptFromClient(ctx, client)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			baseImg, err := w.Base(sOpt, pg)
+			if err != nil {
+				return nil, nil, err
+			}
 			rpmDir := baseImg.Run(
 				dalec.ShArgs(`set -ex; dir="/tmp/rpms/RPMS/$(uname -m)"; mkdir -p "${dir}"; tdnf install -y --releasever=2.0 --downloadonly --alldeps --downloaddir "${dir}" `+strings.Join(spec.GetRuntimeDeps(targetKey), " ")),
 				pg,
@@ -27,11 +36,7 @@ func handleDepsOnly(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			sOpt, err := frontend.SourceOptFromClient(ctx, client)
-			if err != nil {
-				return nil, nil, err
-			}
-			st, err := specToContainerLLB(w, client, spec, targetKey, rpmDir, files, sOpt, pg)
+			st, err := specToContainerLLB(w, spec, targetKey, rpmDir, files, sOpt, pg)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -65,7 +65,12 @@ func installBuildDeps(w worker, spec *dalec.Spec, targetKey string, opts ...llb.
 }
 
 func specToRpmLLB(ctx context.Context, w worker, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
-	base := w.Base(client, opts...).With(installBuildDeps(w, spec, targetKey, opts...))
+	base, err := w.Base(sOpt, opts...)
+	base = base.With(installBuildDeps(w, spec, targetKey, opts...))
+	if err != nil {
+		return llb.Scratch(), err
+	}
+
 	br, err := rpm.SpecToBuildrootLLB(base, spec, sOpt, targetKey, opts...)
 	if err != nil {
 		return llb.Scratch(), err

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -19,9 +19,10 @@ const (
 )
 
 type worker interface {
-	Base(resolver llb.ImageMetaResolver, opts ...llb.ConstraintsOpt) llb.State
+	Base(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error)
 	Install(pkgs []string, opts ...installOpt) llb.RunOption
 	DefaultImageConfig(context.Context, llb.ImageMetaResolver, *ocispecs.Platform) (*dalec.DockerImageSpec, error)
+	WorkerImageConfig(context.Context, llb.ImageMetaResolver, *ocispecs.Platform) (*dalec.DockerImageSpec, error)
 }
 
 func newHandler(w worker) gwclient.BuildFunc {
@@ -44,18 +45,30 @@ func newHandler(w worker) gwclient.BuildFunc {
 		Description: "Builds a container image with only the runtime dependencies installed.",
 	})
 
+	mux.Add("worker", handleBaseImg(w), &targets.Target{
+		Name:        "worker",
+		Description: "Builds the base worker image responsible for building the rpm",
+	})
+
 	return mux.Handle
 }
 
 func handleDebug(w worker) gwclient.BuildFunc {
 	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
-		return rpm.HandleDebug(getSpecWorker(w))(ctx, client)
+		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+		return rpm.HandleDebug(getSpecWorker(w, sOpt))(ctx, client)
 	}
 }
 
-func getSpecWorker(w worker) rpm.WorkerFunc {
+func getSpecWorker(w worker, sOpt dalec.SourceOpts) rpm.WorkerFunc {
 	return func(resolver llb.ImageMetaResolver, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
-		st := w.Base(resolver, opts...)
+		st, err := w.Base(sOpt, opts...)
+		if err != nil {
+			return llb.Scratch(), err
+		}
 		if spec.HasGomods() {
 			deps := spec.GetBuildDeps(targetKey)
 			hasGolang := func(s string) bool {
@@ -68,5 +81,48 @@ func getSpecWorker(w worker) rpm.WorkerFunc {
 			st = st.With(installBuildDeps(w, spec, targetKey, opts...))
 		}
 		return st, nil
+	}
+}
+
+func handleBaseImg(w worker) gwclient.BuildFunc {
+	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
+		return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
+
+			sOpt, err := frontend.SourceOptFromClient(ctx, client)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			st, err := w.Base(sOpt)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			def, err := st.Marshal(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			req := gwclient.SolveRequest{
+				Definition: def.ToPB(),
+			}
+
+			res, err := client.Solve(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				return nil, nil, err
+			}
+
+			cfg, err := w.DefaultImageConfig(ctx, client, platform)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			return ref, cfg, nil
+		})
 	}
 }

--- a/frontend/azlinux/mariner2.go
+++ b/frontend/azlinux/mariner2.go
@@ -16,8 +16,9 @@ const (
 	Mariner2TargetKey     = "mariner2"
 	tdnfCacheNameMariner2 = "mariner2-tdnf-cache"
 
-	mariner2Ref           = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
-	mariner2DistrolessRef = "mcr.microsoft.com/cbl-mariner/distroless/base:2.0"
+	Mariner2Ref               = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
+	Mariner2WorkerContextName = "dalec-mariner2-worker"
+	mariner2DistrolessRef     = "mcr.microsoft.com/cbl-mariner/distroless/base:2.0"
 )
 
 func NewMariner2Handler() gwclient.BuildFunc {
@@ -26,11 +27,28 @@ func NewMariner2Handler() gwclient.BuildFunc {
 
 type mariner2 struct{}
 
-func (w mariner2) Base(resolver llb.ImageMetaResolver, opts ...llb.ConstraintsOpt) llb.State {
-	return llb.Image(mariner2Ref, llb.WithMetaResolver(resolver), dalec.WithConstraints(opts...)).Run(
-		w.Install([]string{"rpm-build", "mariner-rpm-macros", "systemd-rpm-macros", "build-essential", "ca-certificates"}, installWithConstraints(opts)),
+func (w mariner2) Base(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	base, err := sOpt.GetContext(Mariner2Ref, dalec.WithConstraints(opts...))
+	if err != nil {
+		return llb.Scratch(), err
+	}
+
+	if base == nil {
+		base, err = sOpt.GetContext(Mariner2WorkerContextName, dalec.WithConstraints(opts...))
+		if err != nil {
+			return llb.Scratch(), nil
+		}
+	}
+
+	if base == nil {
+		st := llb.Image(Mariner2Ref, llb.WithMetaResolver(sOpt.Resolver), dalec.WithConstraints(opts...))
+		base = &st
+	}
+
+	return base.Run(
+		w.Install([]string{"rpm-build", "mariner-rpm-macros", "build-essential", "ca-certificates"}, installWithConstraints(opts)),
 		dalec.WithConstraints(opts...),
-	).Root()
+	).Root(), nil
 }
 
 func (w mariner2) Install(pkgs []string, opts ...installOpt) llb.RunOption {
@@ -43,6 +61,20 @@ func (mariner2) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaRe
 	_, _, dt, err := resolver.ResolveImageConfig(ctx, mariner2DistrolessRef, sourceresolver.Opt{
 		Platform: platform,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg dalec.DockerImageSpec
+	if err := json.Unmarshal(dt, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func (mariner2) WorkerImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {
+	_, _, dt, err := resolver.ResolveImageConfig(ctx, Mariner2Ref, sourceresolver.Opt{Platform: platform})
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/windows/handle_container.go
+++ b/frontend/windows/handle_container.go
@@ -54,7 +54,10 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 		}
 
 		pg := dalec.ProgressGroup("Build windows container: " + spec.Name)
-		worker := workerImg(sOpt, pg)
+		worker, err := workerImg(sOpt, pg)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		bin, err := buildBinaries(ctx, spec, worker, client, sOpt, targetKey)
 		if err != nil {

--- a/frontend/windows/handler.go
+++ b/frontend/windows/handler.go
@@ -2,10 +2,15 @@ package windows
 
 import (
 	"context"
+	"encoding/json"
 
+	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/frontend"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	bktargets "github.com/moby/buildkit/frontend/subrequests/targets"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -26,5 +31,62 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 		Description: "Builds binaries and installs them into a Windows base image",
 		Default:     true,
 	})
+
+	mux.Add("worker", handleWorker, &bktargets.Target{
+		Name:        "worker",
+		Description: "Builds the base worker image responsible for building the package",
+	})
+
 	return mux.Handle(ctx, client)
+}
+
+func handleWorker(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
+	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
+		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var opts []llb.ConstraintsOpt
+		if platform != nil {
+			opts = append(opts, llb.Platform(*platform))
+		}
+
+		st, err := workerImg(sOpt, opts...)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		res, err := client.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		_, _, dt, err := client.ResolveImageConfig(ctx, workerImgRef, sourceresolver.Opt{
+			Platform: platform,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var img dalec.DockerImageSpec
+		if err := json.Unmarshal(dt, &img); err != nil {
+			return nil, nil, err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return ref, &img, nil
+	})
 }

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -66,13 +66,13 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 		t.Run("root config", func(t *testing.T) {
 			t.Parallel()
 			spec := newSigningSpec()
-			runTest(t, distroSigningTest(t, spec, testConfig.SignTarget))
+			runTest(t, distroSigningTest(t, spec, testConfig.Target.Package))
 		})
 
 		t.Run("with target config", func(t *testing.T) {
 			t.Parallel()
 			spec := newSigningSpec()
-			first, _, _ := strings.Cut(testConfig.SignTarget, "/")
+			first, _, _ := strings.Cut(testConfig.Target.Package, "/")
 			spec.Targets = map[string]dalec.Target{
 				first: {
 					PackageConfig: &dalec.PackageConfig{
@@ -82,7 +82,7 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 			}
 			spec.PackageConfig.Signer = nil
 
-			runTest(t, distroSigningTest(t, spec, testConfig.SignTarget))
+			runTest(t, distroSigningTest(t, spec, testConfig.Target.Package))
 		})
 
 		t.Run("target config takes precedence when root config is there", func(t *testing.T) {
@@ -102,7 +102,7 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 				}
 			}
 
-			first, _, _ := strings.Cut(testConfig.SignTarget, "/")
+			first, _, _ := strings.Cut(testConfig.Target.Package, "/")
 			spec.Targets = map[string]dalec.Target{
 				first: {
 					PackageConfig: &dalec.PackageConfig{
@@ -116,7 +116,7 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 			}
 
 			spec.PackageConfig.Signer.Image = "notexist"
-			runTest(t, distroSigningTest(t, spec, testConfig.SignTarget), testenv.WithSolveStatusFn(handleStatus))
+			runTest(t, distroSigningTest(t, spec, testConfig.Target.Package), testenv.WithSolveStatusFn(handleStatus))
 
 			assert.Assert(t, found, "Spec signing override warning message not emitted")
 		})
@@ -129,7 +129,7 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 				"HELLO": "world",
 				"FOO":   "bar",
 			}
-			runTest(t, distroSigningTest(t, spec, testConfig.SignTarget))
+			runTest(t, distroSigningTest(t, spec, testConfig.Target.Package))
 		})
 
 		t.Run("with path build arg and build context", func(t *testing.T) {
@@ -145,7 +145,7 @@ signer:
 			runTest(t, distroSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withBuildContext(ctx, t, "dalec_signing_config", signConfig),
 				withBuildArg("DALEC_SIGNING_CONFIG_CONTEXT_NAME", "dalec_signing_config"),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/unusual_place.yml"),
@@ -179,7 +179,7 @@ signer:
 				distroSigningTest(
 					t,
 					spec,
-					testConfig.SignTarget,
+					testConfig.Target.Package,
 					withBuildContext(ctx, t, "dalec_signing_config", signConfig),
 					withBuildArg("DALEC_SIGNING_CONFIG_CONTEXT_NAME", "dalec_signing_config"),
 					withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/unusual_place.yml"),
@@ -203,7 +203,7 @@ signer:
 			runTest(t, distroSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withBuildContext(ctx, t, "dalec_signing_config", signConfig),
 				withBuildArg("DALEC_SIGNING_CONFIG_CONTEXT_NAME", "dalec_signing_config"),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/unusual_place.yml"),
@@ -224,7 +224,7 @@ signer:
 			runTest(t, distroSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withMainContext(ctx, t, signConfig),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/sign_config.yml"),
 			))
@@ -256,7 +256,7 @@ signer:
 			runTest(t, distroSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withMainContext(ctx, t, signConfig),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/sign_config.yml"),
 			), testenv.WithSolveStatusFn(handleStatus))
@@ -280,7 +280,7 @@ signer:
 					}
 				}
 			}
-			runTest(t, distroSkipSigningTest(t, spec, testConfig.SignTarget), testenv.WithSolveStatusFn(handleStatus))
+			runTest(t, distroSkipSigningTest(t, spec, testConfig.Target.Package), testenv.WithSolveStatusFn(handleStatus))
 			assert.Assert(t, found, "Signing disabled warning message not emitted")
 		})
 
@@ -313,7 +313,7 @@ signer:
 			runTest(t, distroSkipSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withBuildArg("DALEC_SIGNING_CONFIG_CONTEXT_NAME", "dalec_signing_config"),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/sign_config.yml"),
 				withBuildContext(ctx, t, "dalec_signing_config", signConfig),
@@ -351,7 +351,7 @@ signer:
 			runTest(t, distroSkipSigningTest(
 				t,
 				spec,
-				testConfig.SignTarget,
+				testConfig.Target.Package,
 				withMainContext(ctx, t, signConfig),
 				withBuildArg("DALEC_SIGNING_CONFIG_PATH", "/sign_config.yml"),
 			), testenv.WithSolveStatusFn(handleStatus))

--- a/test/testenv/builld.go
+++ b/test/testenv/builld.go
@@ -52,6 +52,7 @@ func buildBaseFrontend(ctx context.Context, c gwclient.Client) (*gwclient.Result
 			dockerui.DefaultLocalNameContext:    defPB,
 			dockerui.DefaultLocalNameDockerfile: dockerfileDef.ToPB(),
 		},
+		Evaluate: true,
 	})
 }
 

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -11,14 +11,14 @@ Many components, such as package dependencies and base images, are specific to a
 To print a list of available build targets:
 
 ```shell
-docker build --print=targets -f test/fixtures/moby-runc.yml .
-TARGET                           DESCRIPTION
+GET                           DESCRIPTION
 azlinux3/container (default)     Builds a container image for
 azlinux3/container/depsonly      Builds a container image with only the runtime dependencies installed.
 azlinux3/rpm                     Builds an rpm and src.rpm.
 azlinux3/rpm/debug/buildroot     Outputs an rpm buildroot suitable for passing to rpmbuild.
 azlinux3/rpm/debug/sources       Outputs all the sources specified in the spec file in the format given to rpmbuild.
 azlinux3/rpm/debug/spec          Outputs the generated RPM spec file
+azlinux3/worker                  Builds the base worker image responsible for building the rpm
 debug/gomods                     Outputs all the gomodule dependencies for the spec
 debug/resolve                    Outputs the resolved dalec spec file with build args applied.
 debug/sources                    Outputs all sources from a dalec spec file.
@@ -28,7 +28,9 @@ mariner2/rpm                     Builds an rpm and src.rpm.
 mariner2/rpm/debug/buildroot     Outputs an rpm buildroot suitable for passing to rpmbuild.
 mariner2/rpm/debug/sources       Outputs all the sources specified in the spec file in the format given to rpmbuild.
 mariner2/rpm/debug/spec          Outputs the generated RPM spec file
+mariner2/worker                  Builds the base worker image responsible for building the rpm
 windowscross/container (default) Builds binaries and installs them into a Windows base image
+windowscross/worker              Builds the base worker image responsible for building the rpm
 windowscross/zip                 Builds binaries combined into a zip file
 ```
 
@@ -62,3 +64,50 @@ targets:
     frontend:
       image: docker.io/my/custom:mariner2
 ```
+
+## Advanced Customization
+
+### Worker images
+
+In some cases you may need to have additional things installed in the worker
+image that are not typically available in the base image. As an example, a
+package dependency may not be available in the default package repositories.
+
+You can have Dalec output an image with the target's worker image with
+`<target>/worker>` build target, e.g. `--target=mariner2/worker`. You can then
+add any customizations and feed that back in via [source polices](#source-policies)
+or [named build contexts](#named-build-contexts).
+
+
+#### Source Policies
+
+`docker buildx build` has experimental support for providing a
+[source policy](https://docs.docker.com/build/building/variables/#experimental_buildkit_source_policy)
+which updates the base image ref used to create the worker image. This method
+will update any and all references to the matched image used for any part of
+the build. It also requires knowing the image(s) that are used ahead of time and
+creating the right set of match rules and potentially having to update this in
+the future if the worker image refs in Dalec change.
+
+A finer grained approach is to use [named build contexts](#named-build-contexts).
+
+#### Named Build Contexts
+
+`docker buildx build` has a flag called `--build-context`
+([doc](https://docs.docker.com/reference/cli/docker/buildx/build/#build-context))
+which allows you to provide additional build contexts apart from the main build
+context in the form of `<name>=<ref>`. See the prior linked documentation for
+what can go into `<ref>`.
+
+In the `mariner2` target, Dalec looks for a named context called either
+
+1. The actual base image used internally for mariner2
+  i. `--build-context mcr.microsoft.com/cbl-mariner/base/core:2.0=<new ref>`
+2. A build context named `dalec-mariner2-worker`
+  i. `--build-context dalec-mariner2-worker=<new ref>`
+
+If 1 is provided, then 2 is ignored.
+
+This works the same way in the `azlinux3` target but with the `azlinux3` base image
+(not currently displayed here since it is still preview, this will be updated
+once azlinux3 is GA) OR a build context named `dalec-azlinux3-worker`.


### PR DESCRIPTION
 Allow custom worker images
    
This allows builders to provide their own worker image via build context.
This enables builders to install their own repos, as an example, or use pre-built workers.
    
Adds `azlinux3/worker`, `mariner2/worker`, and `windowscross/worker/` build targets which outputs each worker image respectively.
You can take the output of these, inject whatever is needed, and feed that as an input into another build.

Note: By using the image ref as a build-context name, this brings dalec more inline with how Dockerfile works as well.
