### PR TITLE
azlinux: Make sure we install /etc/os-release

### DIFF
--- a/frontend/azlinux/azlinux3.go
+++ b/frontend/azlinux/azlinux3.go
@@ -60,6 +60,10 @@ func (w azlinux3) Install(pkgs []string, opts ...installOpt) llb.RunOption {
 	return dalec.WithRunOptions(tdnfInstall(&cfg, "3.0", pkgs), w.tdnfCacheMount(cfg.root))
 }
 
+func (w azlinux3) BasePackages() []string {
+	return []string{"azurelinux-release"}
+}
+
 func (azlinux3) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {
 	_, _, dt, err := resolver.ResolveImageConfig(ctx, azlinux3DistrolessRef, sourceresolver.Opt{Platform: platform})
 	if err != nil {

--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -151,7 +151,7 @@ func specToContainerLLB(w worker, spec *dalec.Spec, targetKey string, rpmDir llb
 
 	if len(files) > 0 {
 		rpmMountDir := "/tmp/rpms"
-		updated := make([]string, 0, len(files))
+		updated := w.BasePackages()
 		for _, f := range files {
 			updated = append(updated, filepath.Join(rpmMountDir, f))
 		}

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -23,6 +23,7 @@ type worker interface {
 	Install(pkgs []string, opts ...installOpt) llb.RunOption
 	DefaultImageConfig(context.Context, llb.ImageMetaResolver, *ocispecs.Platform) (*dalec.DockerImageSpec, error)
 	WorkerImageConfig(context.Context, llb.ImageMetaResolver, *ocispecs.Platform) (*dalec.DockerImageSpec, error)
+	BasePackages() []string
 }
 
 func newHandler(w worker) gwclient.BuildFunc {

--- a/frontend/azlinux/mariner2.go
+++ b/frontend/azlinux/mariner2.go
@@ -57,6 +57,10 @@ func (w mariner2) Install(pkgs []string, opts ...installOpt) llb.RunOption {
 	return dalec.WithRunOptions(tdnfInstall(&cfg, "2.0", pkgs), w.tdnfCacheMount(cfg.root))
 }
 
+func (w mariner2) BasePackages() []string {
+	return []string{"mariner-release"}
+}
+
 func (mariner2) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {
 	_, _, dt, err := resolver.ResolveImageConfig(ctx, mariner2DistrolessRef, sourceresolver.Opt{
 		Platform: platform,

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -37,6 +37,10 @@ func TestMariner2(t *testing.T) {
 			ContextName: azlinux.Mariner2WorkerContextName,
 			CreateRepo:  azlinuxWithRepo,
 		},
+		Release: OSRelease{
+			ID:        "mariner",
+			VersionID: "2.0",
+		},
 	})
 }
 
@@ -61,6 +65,10 @@ func TestAzlinux3(t *testing.T) {
 		Worker: workerConfig{
 			ContextName: azlinux.Azlinux3WorkerContextName,
 			CreateRepo:  azlinuxWithRepo,
+		},
+		Release: OSRelease{
+			ID:        "azurelinux",
+			VersionID: "3.0",
 		},
 	})
 }
@@ -116,7 +124,13 @@ type testLinuxConfig struct {
 		Units   string
 		Targets string
 	}
-	Worker workerConfig
+	Worker  workerConfig
+	Release OSRelease
+}
+
+type OSRelease struct {
+	ID        string
+	VersionID string
 }
 
 func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
@@ -399,6 +413,21 @@ echo "$BAR" > bar.txt
 						{Command: "/bin/bash -c 'test -L /src1'"},
 						{Command: "/bin/bash -c 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
 						{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+					},
+				},
+				{
+					Name: "Check /etc/os-release",
+					Files: map[string]dalec.FileCheckOutput{
+						"/etc/os-release": {
+							CheckOutput: dalec.CheckOutput{
+								Contains: []string{
+									fmt.Sprintf("ID=%s\n", testConfig.Release.ID),
+									// Note: the value of `VERSION_ID` needs to be quoted!
+									// TODO: Something is stripping the quotes here...
+									// fmt.Sprintf("VERSION_ID=%q\n", testConfig.Release.VersionID),
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This is needed for scanners and other things and is just generally good to have in the image.

Before, scanning the output of the `runc-azlinux3-container` target yields the following: (note that it can't detect the OS)

<details>

```
 DOCKER_HOST=unix:///Users/cpuguy83/.docker/run/docker.sock trivy image runc:azlinux3
2024-08-01T15:59:08-07:00	INFO	[vuln] Vulnerability scanning is enabled
2024-08-01T15:59:08-07:00	INFO	[secret] Secret scanning is enabled
2024-08-01T15:59:08-07:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-08-01T15:59:08-07:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-08-01T15:59:08-07:00	INFO	Detected OS	family="none" version=""
2024-08-01T15:59:08-07:00	WARN	Unsupported os	family="none"
2024-08-01T15:59:08-07:00	INFO	Number of language-specific files	num=1
2024-08-01T15:59:08-07:00	INFO	[gobinary] Detecting vulnerabilities...
2024-08-01T15:59:08-07:00	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.54/docs/scanner/vulnerability#severity-selection for details.

usr/bin/runc (gobinary)

Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 1, CRITICAL: 0)

┌───────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│                Library                │    Vulnerability    │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├───────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/cyphar/filepath-securejoin │ GHSA-6xv5-86q9-7xr8 │ MEDIUM   │ fixed  │ v0.2.3            │ 0.2.4           │ SecureJoin: on windows, paths outside of the rootfs could be │
│                                       │                     │          │        │                   │                 │ inadvertently produced...                                    │
│                                       │                     │          │        │                   │                 │ https://github.com/advisories/GHSA-6xv5-86q9-7xr8            │
├───────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                      │ CVE-2023-39325      │ HIGH     │        │ v0.8.0            │ 0.17.0          │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                                       │                     │          │        │                   │                 │ excessive work (CVE-2023-44487)                              │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│                                       ├─────────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-3978       │ MEDIUM   │        │                   │ 0.13.0          │ golang.org/x/net/html: Cross site scripting                  │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-3978                    │
│                                       ├─────────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-44487      │          │        │                   │ 0.17.0          │ HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable   │
│                                       │                     │          │        │                   │                 │ to a DDoS attack...                                          │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-44487                   │
│                                       ├─────────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-45288      │          │        │                   │ 0.23.0          │ golang: net/http, x/net/http2: unlimited number of           │
│                                       │                     │          │        │                   │                 │ CONTINUATION frames causes DoS                               │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
├───────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/protobuf            │ CVE-2024-24786      │          │        │ v1.27.1           │ 1.33.0          │ golang-protobuf: encoding/protojson, internal/encoding/json: │
│                                       │                     │          │        │                   │                 │ infinite loop in protojson.Unmarshal when unmarshaling       │
│                                       │                     │          │        │                   │                 │ certain forms of...                                          │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24786                   │
├───────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib                                │ CVE-2024-24791      │          │        │ 1.22.4            │ 1.21.12, 1.22.5 │ net/http: Denial of service due to improper 100-continue     │
│                                       │                     │          │        │                   │                 │ handling in net/http                                         │
│                                       │                     │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24791                   │
└───────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```
</details>

With this change:

<details>

```
❯ DOCKER_HOST=unix:///Users/cpuguy83/.docker/run/docker.sock trivy image runc:azlinux3
2024-08-01T16:01:04-07:00	INFO	[vuln] Vulnerability scanning is enabled
2024-08-01T16:01:04-07:00	INFO	[secret] Secret scanning is enabled
2024-08-01T16:01:04-07:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-08-01T16:01:04-07:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-08-01T16:01:04-07:00	INFO	Detected OS	family="azurelinux" version="3.0"
2024-08-01T16:01:04-07:00	INFO	[azurelinux] Detecting vulnerabilities...	os_version="3.0" pkg_num=5
2024-08-01T16:01:04-07:00	INFO	Number of language-specific files	num=1
2024-08-01T16:01:04-07:00	INFO	[gobinary] Detecting vulnerabilities...

runc:azlinux3 (azurelinux 3.0)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/bin/runc (gobinary)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 1, CRITICAL: 0)

┌───────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│                Library                │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├───────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/cyphar/filepath-securejoin │ GHSA-6xv5-86q9-7xr8 │ MEDIUM   │ fixed  │ v0.2.3            │ 0.2.4         │ SecureJoin: on windows, paths outside of the rootfs could be │
│                                       │                     │          │        │                   │               │ inadvertently produced...                                    │
│                                       │                     │          │        │                   │               │ https://github.com/advisories/GHSA-6xv5-86q9-7xr8            │
├───────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                      │ CVE-2023-39325      │ HIGH     │        │ v0.8.0            │ 0.17.0        │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                                       │                     │          │        │                   │               │ excessive work (CVE-2023-44487)                              │
│                                       │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│                                       ├─────────────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-3978       │ MEDIUM   │        │                   │ 0.13.0        │ golang.org/x/net/html: Cross site scripting                  │
│                                       │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3978                    │
│                                       ├─────────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-44487      │          │        │                   │ 0.17.0        │ HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable   │
│                                       │                     │          │        │                   │               │ to a DDoS attack...                                          │
│                                       │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-44487                   │
│                                       ├─────────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-45288      │          │        │                   │ 0.23.0        │ golang: net/http, x/net/http2: unlimited number of           │
│                                       │                     │          │        │                   │               │ CONTINUATION frames causes DoS                               │
│                                       │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
├───────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/protobuf            │ CVE-2024-24786      │          │        │ v1.27.1           │ 1.33.0        │ golang-protobuf: encoding/protojson, internal/encoding/json: │
│                                       │                     │          │        │                   │               │ infinite loop in protojson.Unmarshal when unmarshaling       │
│                                       │                     │          │        │                   │               │ certain forms of...                                          │
│                                       │                     │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-24786                   │
└───────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```
</details>