### PR TITLE
Adamperlin/azlinux use separate build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _output
 .vscode
+.vim-lsp-settings


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a step towards ensuring that fields from the Dalec spec are properly sanitized and cannot interfere with the generated RPM spec (see #330). Instead of writing the build steps into the generated RPM spec directly (which would allow a user to place RPM macros/directives in their build steps, changing the behavior of the generated RPM spec) we now write the build steps to a separate shell script, much as we do for windows and (soon to exist) jammy targets. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
