### PR TITLE
docs: Fix edit URL

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -39,7 +39,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/Azure/dalec/blob/main/website/docs/',
+            'https://github.com/Azure/dalec/blob/main/website/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
There is an extra /docs/ causing a 404 when clicking on the "Edit this page" button, for instance the button on https://azure.github.io/dalec/build-source points to https://github.com/Azure/dalec/blob/main/website/docs/docs/build-source.md, but the correct one is https://github.com/Azure/dalec/blob/main/website/docs/build-source.md

