### PR TITLE
Add docs on built-in TARGET* build args

### DIFF
--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -33,6 +33,22 @@ args:
   REVISION: 1
 ```
 
+There are a few built-in arguments which, if present, Dalec will substitute values for. They are listed as examples in the following block:
+
+```yaml
+args:
+  TARGETOS:
+  TARGETARCH:
+  TARGETPLATFORM:
+  TARGETVARIANT:
+```
+
+For example, upon invoking `docker build` with `--platform=linux/amd64`, we would have `TARGETOS=linux`, `TARGETARCH=amd64`, `TARGETPLATFORM=linux/amd64`.
+
+:::note
+No default value should be included for these build args. These args are opt-in. If you haven't listed them in the args section as shown above, Dalec will **not** substitute values for them.
+:::
+
 ## Metadata section
 
 Metadata section is used to define the metadata of the spec. This metadata includes the name, packager, vendor, license, website, and description of the spec.
@@ -156,6 +172,7 @@ build:
     TAG: v${VERSION}
     GOPROXY: direct
     CGO_ENABLED: "0"
+    GOOS: ${TARGETOS}
   steps:
     - command: |
         go build -ldflags "-s -w -X github.com/foo/bar/version.Version=${TAG}" -o /out/my-binary ./cmd/my-binary
@@ -163,6 +180,10 @@ build:
 
 - `env`: The environment variables for the build.
 - `steps`: The build steps for the package.
+
+:::tip
+TARGETOS is a built-in argument that Dalec will substitute with the target OS value. For more information, please see [Args section](#args-section).
+:::
 
 ## Artifacts section
 

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -43,7 +43,7 @@ args:
   TARGETVARIANT:
 ```
 
-For example, upon invoking `docker build` with `--platform=linux/amd64`, we would have `TARGETOS=linux`, `TARGETARCH=amd64`, `TARGETPLATFORM=linux/amd64`.
+These arguments are set based on the default docker platform for the machine, *unless* the platform is overriden explicitly in the docker build with `--platform`. For example, upon invoking `docker build` on a Linux amd64 machine, we would have `TARGETOS=linux`, `TARGETARCH=amd64`, `TARGETPLATFORM=linux/amd64`.
 
 :::note
 No default value should be included for these build args. These args are opt-in. If you haven't listed them in the args section as shown above, Dalec will **not** substitute values for them.


### PR DESCRIPTION
**What this PR does / why we need it**:

We haven't yet documented how to opt-in to TARGET{OS, ARCH, VARIANT, PLATFORM} args in Dalec. This PR adds those docs.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #97 

**Special notes for your reviewer**:
