### PR TITLE
Switch usage of containerd platforms package

### DIFF
--- a/frontend/build.go
+++ b/frontend/build.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/dalec"
-	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"

--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/dalec"
-	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/platforms"
 	"github.com/goccy/go-yaml"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerui"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/containerd/containerd v1.7.18
 	github.com/containerd/platforms v0.2.1
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-cmp v0.6.0
@@ -29,7 +28,6 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.11.5 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
@@ -37,6 +35,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/console v1.0.4 // indirect
+	github.com/containerd/containerd v1.7.18 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goccy/go-yaml"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -163,7 +164,7 @@ func TestHandlerSubrequestResolve(t *testing.T) {
 				err = yaml.Unmarshal(dt, &ls)
 				assert.NilError(t, err)
 
-				var checkPlatforms []platforms.Platform
+				var checkPlatforms []ocispecs.Platform
 
 				for _, p := range pls {
 					platform, err := platforms.Parse(p)

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/frontend"
-	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/platforms"
 	"github.com/goccy/go-yaml"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -20,6 +20,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/tonistiigi/fsutil/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -195,7 +196,7 @@ func newSolveRequest(opts ...srOpt) gwclient.SolveRequest {
 	return *cfg.req
 }
 
-func withPlatform(platform platforms.Platform) srOpt {
+func withPlatform(platform ocispecs.Platform) srOpt {
 	return func(cfg *newSolveRequestConfig) {
 		cfg.req.FrontendOpt["platform"] = platforms.Format(platform)
 	}
@@ -317,12 +318,12 @@ func reqToState(ctx context.Context, gwc gwclient.Client, sr gwclient.SolveReque
 	return st
 }
 
-func readDefaultPlatform(ctx context.Context, t *testing.T, gwc gwclient.Client) platforms.Platform {
+func readDefaultPlatform(ctx context.Context, t *testing.T, gwc gwclient.Client) ocispecs.Platform {
 	req := newSolveRequest(withSubrequest(frontend.KeyDefaultPlatform), withSpec(ctx, t, nil))
 	res := solveT(ctx, t, gwc, req)
 
 	dt := res.Metadata["result.json"]
-	var p platforms.Platform
+	var p ocispecs.Platform
 
 	err := json.Unmarshal(dt, &p)
 	assert.NilError(t, err)

--- a/test/var_passthrough_test.go
+++ b/test/var_passthrough_test.go
@@ -6,15 +6,16 @@ import (
 
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/test/testenv"
-	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/platforms"
 	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func getBuildPlatform(ctx context.Context, t *testing.T) *platforms.Platform {
-	buildPlatform := make(chan *platforms.Platform, 1)
+func getBuildPlatform(ctx context.Context, t *testing.T) *ocispecs.Platform {
+	buildPlatform := make(chan *ocispecs.Platform, 1)
 	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		defer close(buildPlatform)
 		dc, err := dockerui.NewClient(gwc)
@@ -49,8 +50,8 @@ func TestPassthroughVars(t *testing.T) {
 	tests := []struct {
 		name               string
 		needsBuildPlatform bool
-		targetPlatform     platforms.Platform
-		buildPlatform      *platforms.Platform
+		targetPlatform     ocispecs.Platform
+		buildPlatform      *ocispecs.Platform
 		optInArgs          map[string]string
 		env                map[string]string
 		wantEnv            map[string]string


### PR DESCRIPTION
The platforms package was moved to a separate repo and the old ones are now marked as deprecated.
This is causing updates to the containerd module to trigger linting errors.
