### PR TITLE
fix: source: cmd: Persist rootfs state across steps

### DIFF
--- a/source.go
+++ b/source.go
@@ -312,6 +312,10 @@ func generateSourceFromImage(st llb.State, cmd *Command, sOpts SourceOpts, subPa
 		} else {
 			out = cmdSt.AddMount(subPath, out)
 		}
+
+		// Update the base state so that changes to the rootfs propagate between
+		// steps.
+		st = cmdSt.Root()
 	}
 
 	return out, nil

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -44,6 +44,15 @@ func TestSourceCmd(t *testing.T) {
 								{
 									Command: `cat /output/foo | grep "foo bar"`,
 								},
+
+								// Make sure changes to the rootfs (as opposed to the output dir)
+								// persist across steps.
+								{
+									Command: `echo "hello world" > /tmp/hello`,
+								},
+								{
+									Command: `grep "hello world" /tmp/hello`,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Before this, given an image source with multiple steps

```yaml
path: /bar
image:
  ref: foobar
  steps:
    - command: echo foo > /foo
    - command: [ -f /foo ]
```

The 2nd step would fail because the rootfs state was not being persisted between steps, only the changes to the path that is output for the source.