### PR TITLE
Add symlink and libs artifact types

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -31,7 +31,23 @@ type Artifacts struct {
 	// On linux this would typically be installed to /usr/lib/<package name>
 	Libs map[string]ArtifactConfig `yaml:"libs,omitempty" json:"libraries,omitempty"`
 
+	// Links is the list of symlinks to be installed with the package
+	// Links should only be used if the *package* should contain the link.
+	// For making a container compatible with another image, use [PostInstall] in
+	// the [ImageConfig].
+	Links []ArtifactSymlinkConfig `yaml:"links,omitempty" json:"links,omitempty"`
+
 	// TODO: other types of artifacts (libexec, etc)
+}
+
+type ArtifactSymlinkConfig struct {
+	// Source is the path that is being linked to
+	// Example:
+	//   If you want a symlink in /usr/bin/foo that is linking to /usr/bin/foo/foo
+	//   then the `Source` is `/usr/bin/foo/foo`
+	Source string `yaml:"source,omitempty" json:"source,omitempty"`
+	// Dest is the path where the symlink will be installed
+	Dest string `yaml:"dest,omitempty" json:"dest,omitempty"`
 }
 
 // CreateArtifactDirectories describes various directories that should be created on install.
@@ -114,6 +130,9 @@ func (a *Artifacts) IsEmpty() bool {
 		return false
 	}
 	if len(a.Libs) > 0 {
+		return false
+	}
+	if len(a.Links) > 0 {
 		return false
 	}
 	return true

--- a/artifacts.go
+++ b/artifacts.go
@@ -26,6 +26,11 @@ type Artifacts struct {
 	Licenses map[string]ArtifactConfig `yaml:"licenses,omitempty" json:"licenses,omitempty"`
 	// Systemd is the list of systemd units and dropin files for the package
 	Systemd *SystemdConfiguration `yaml:"systemd,omitempty" json:"systemd,omitempty"`
+
+	// Libs is the list of library files to be installed.
+	// On linux this would typically be installed to /usr/lib/<package name>
+	Libs map[string]ArtifactConfig `yaml:"libs,omitempty" json:"libraries,omitempty"`
+
 	// TODO: other types of artifacts (libexec, etc)
 }
 
@@ -106,6 +111,9 @@ func (a *Artifacts) IsEmpty() bool {
 		return false
 	}
 	if len(a.Licenses) > 0 {
+		return false
+	}
+	if len(a.Libs) > 0 {
 		return false
 	}
 	return true

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -53,6 +53,20 @@
 			"type": "object",
 			"description": "ArtifactDirConfig contains information about the directory to be created"
 		},
+		"ArtifactSymlinkConfig": {
+			"properties": {
+				"source": {
+					"type": "string",
+					"description": "Source is the path that is being linked to\nExample:\n  If you want a symlink in /usr/bin/foo that is linking to /usr/bin/foo/foo\n  then the `Source` is `/usr/bin/foo/foo`"
+				},
+				"dest": {
+					"type": "string",
+					"description": "Dest is the path where the symlink will be installed"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
 		"Artifacts": {
 			"properties": {
 				"binaries": {
@@ -111,6 +125,13 @@
 					},
 					"type": "object",
 					"description": "Libs is the list of library files to be installed.\nOn linux this would typically be installed to /usr/lib/\u003cpackage name\u003e"
+				},
+				"links": {
+					"items": {
+						"$ref": "#/$defs/ArtifactSymlinkConfig"
+					},
+					"type": "array",
+					"description": "Links is the list of symlinks to be installed with the package\nLinks should only be used if the *package* should contain the link.\nFor making a container compatible with another image, use [PostInstall] in\nthe [ImageConfig]."
 				}
 			},
 			"additionalProperties": false,

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -104,6 +104,13 @@
 				"systemd": {
 					"$ref": "#/$defs/SystemdConfiguration",
 					"description": "Systemd is the list of systemd units and dropin files for the package"
+				},
+				"libraries": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactConfig"
+					},
+					"type": "object",
+					"description": "Libs is the list of library files to be installed.\nOn linux this would typically be installed to /usr/lib/\u003cpackage name\u003e"
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/deb/debroot.go
+++ b/frontend/deb/debroot.go
@@ -143,6 +143,17 @@ func Debroot(sOpt dalec.SourceOpts, spec *dalec.Spec, worker, in llb.State, targ
 		states = append(states, pls...)
 	}
 
+	if len(spec.Artifacts.Links) > 0 {
+		buf := bytes.NewBuffer(nil)
+		for _, l := range spec.Artifacts.Links {
+			src := strings.TrimPrefix(l.Source, "/")
+			dst := strings.TrimPrefix(l.Dest, "/")
+			fmt.Fprintln(buf, src, dst)
+		}
+
+		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, spec.Name+".links"), 0o644, buf.Bytes()), opts...))
+	}
+
 	return dalec.MergeAtPath(in, states, "/"), nil
 }
 

--- a/frontend/deb/debroot.go
+++ b/frontend/deb/debroot.go
@@ -431,6 +431,16 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir string) []llb.
 		}
 	}
 
+	if len(spec.Artifacts.Libs) > 0 {
+		sorted := dalec.SortMapKeys(spec.Artifacts.Libs)
+		for _, key := range sorted {
+			cfg := spec.Artifacts.Libs[key]
+			resolved := cfg.ResolveName(key)
+
+			writeInstall(key, filepath.Join("/usr/lib", spec.Name, cfg.SubPath), resolved)
+		}
+	}
+
 	if installBuf.Len() > 0 {
 		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, spec.Name+".install"), 0o700, installBuf.Bytes())))
 	}

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -534,6 +534,13 @@ func (w *specWrapper) Install() fmt.Stringer {
 		copyArtifact(root, l, &cfg)
 	}
 
+	libs := dalec.SortMapKeys(w.Spec.Artifacts.Libs)
+	for _, l := range libs {
+		cfg := w.Spec.Artifacts.Libs[l]
+		root := filepath.Join(`%{buildroot}/%{_libdir}`, w.Name)
+		copyArtifact(root, l, &cfg)
+	}
+
 	b.WriteString("\n")
 	return b
 }
@@ -632,15 +639,14 @@ func (w *specWrapper) Files() fmt.Stringer {
 				fmt.Fprintln(b, file)
 			}
 		}
-
 	}
+
 	docKeys := dalec.SortMapKeys(w.Spec.Artifacts.Docs)
 	for _, d := range docKeys {
 		cfg := w.Spec.Artifacts.Docs[d]
 		path := filepath.Join(`%{_docdir}`, w.Name, cfg.SubPath, cfg.ResolveName(d))
 		fullDirective := strings.Join([]string{`%doc`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
-
 	}
 
 	licenseKeys := dalec.SortMapKeys(w.Spec.Artifacts.Licenses)
@@ -649,6 +655,13 @@ func (w *specWrapper) Files() fmt.Stringer {
 		path := filepath.Join(`%{_licensedir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
 		fullDirective := strings.Join([]string{`%license`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
+	}
+
+	libKeys := dalec.SortMapKeys(w.Spec.Artifacts.Libs)
+	for _, l := range libKeys {
+		cfg := w.Spec.Artifacts.Libs[l]
+		path := filepath.Join(`%{_libdir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
+		fmt.Fprintln(b, path)
 	}
 
 	b.WriteString("\n")

--- a/frontend/rpm/template.go
+++ b/frontend/rpm/template.go
@@ -541,6 +541,11 @@ func (w *specWrapper) Install() fmt.Stringer {
 		copyArtifact(root, l, &cfg)
 	}
 
+	for _, l := range w.Spec.Artifacts.Links {
+		fmt.Fprintln(b, "mkdir -p", filepath.Dir(filepath.Join("%{buildroot}", l.Dest)))
+		fmt.Fprintln(b, "ln -sf", l.Source, "%{buildroot}/"+l.Dest)
+	}
+
 	b.WriteString("\n")
 	return b
 }
@@ -662,6 +667,10 @@ func (w *specWrapper) Files() fmt.Stringer {
 		cfg := w.Spec.Artifacts.Libs[l]
 		path := filepath.Join(`%{_libdir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
 		fmt.Fprintln(b, path)
+	}
+
+	for _, l := range w.Spec.Artifacts.Links {
+		fmt.Fprintln(b, l.Dest)
 	}
 
 	b.WriteString("\n")

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.11.5 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -327,4 +328,18 @@ func readDefaultPlatform(ctx context.Context, t *testing.T, gwc gwclient.Client)
 	err := json.Unmarshal(dt, &p)
 	assert.NilError(t, err)
 	return p
+}
+
+func validatePathAndPermissions(ctx context.Context, ref gwclient.Reference, path string, expected os.FileMode) error {
+	stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: path})
+	if err != nil {
+		return err
+	}
+
+	got := os.FileMode(stat.Mode).Perm()
+
+	if expected != got {
+		return fmt.Errorf("expected permissions %v to equal expected %v", got, expected)
+	}
+	return nil
 }

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -1,0 +1,234 @@
+# Artifacts
+
+Artifacts are used to configure what actually gets installed with a package.
+Anything that needs to be installed needs an entry in the artifacts section.
+
+There are different types of artifacts which are installed to different locations
+on the target system.
+What location this is depends on the target OS/distro and the kind of artifact.
+
+
+## Artifact Configuration
+
+Most artifact types share a common data type so can be configured similarly.
+It is shown here as a reference which is linked to in the artifact descriptions
+where it is pertinent.
+
+Configuration options shared by most artifacts:
+
+- *subpath*(string): The provided path is joined to the typical install path,
+                     e.g. `/usr/bin/<subpath>`, where the artifact will be
+                     installed to.
+- *mode*(octal): file permissions to apply to the artifact.
+
+
+### Binaries
+
+Binaries are binary files that may be executed.
+On Linux these would typically get installed into `/usr/bin`.
+
+Binaries are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+Example:
+
+```yaml
+artifacts:
+  binaries:
+    src/my_bin:
+      subpath: ""
+      mode: 0o755
+```
+
+You may use a trailing wildcard to specify multiple binaries in a directory,
+though behavior may differ between different OS's/distros.
+
+### Manpages
+
+Manpages is short for manual pages.
+On Linux these are typically installed to `/usr/share/man`
+
+Manpages are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  managpes:
+    src/man/*:
+      subpath: ""
+      mode: 0o755
+```
+
+You may use a trailing wildcard to specify multiple binaries in a directory,
+though behavior may differ between different OS's/distros.
+
+### Data Dirs
+
+Data dirs are a list of read-only, architecture-independent data files.
+On Linux these typically get placed into `/usr/share`.
+
+Data dirs are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  data_dirs:
+    build_output/my_bin:
+      subpath: ""
+      mode: 0o755
+```
+
+### Directories
+
+Directories allows you to create new directories when installing the package.
+Two types of directory artifacts are supported:
+
+1. *config*: This is a directory where configuration files typically go, e.g. /etc/my_package2. *State*: This is directory for persistant state, typically in `/var/lib` on Linux.
+
+
+Unlike many other artifact types, this does not reference any file produced
+by build. Instead these are created as empty directories.
+
+Example:
+
+```yaml
+artifacts:
+  createDirectories:
+    state:
+      mystate:
+        mode: 0o755
+    config:
+      myconfig:
+        mode: 0o755
+```
+
+### Config Files
+
+Config files are, depending on the package manager, specially marked as configuration.
+Typically these go under `/etc` on Linux.
+
+Config files are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  configFiles:
+    src/my_config.json:
+      subpath: ""
+      mode: 0o755
+```
+
+### Docs
+
+Docs are general documentation, not manpages, for your package.
+On Linux these typically go under `/usr/share/doc/<package name>`
+
+Docs are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  docs:
+    src/doc/info.md:
+      subpath: ""
+      mode: 0o755
+```
+
+You may use a trailing wildcard to specify multiple binaries in a directory,
+though behavior may differ between different OS's/distros.
+
+### Licenses
+
+Licenses are license files to be installed with the package.
+
+Licenses are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  licenses:
+    src/LICENSE.md:
+      subpath: ""
+      mode: 0o755
+```
+
+### Systemd
+
+Systemd artifacts are used for installing systemd unit configurations.
+Two different types of systemd configurations are currently supported:
+
+1. Unit files - including services, sockets, mounts, or any other systemd unit type.
+2. Drop-ins - Adds customization to an existing systemd unit
+
+See the systemd documentation for more details on these types.
+
+Example:
+
+```yaml
+artifacts:
+  systemd:
+    units:
+      src/contrib/init/my_service.service:
+        enable: false
+        name: ""
+    dropins:
+      src/contrib/init/customize-a-thing.service:
+        enable: false
+        name: ""
+```
+
+### Libs
+
+Libs are library files to be included with your package.
+On Linux these typically go under `/usr/lib/<package>`.
+
+Libs are a mapping of file path to [artifact configuration](#artifact-configuration).
+The file path is the path to a file that must be available after the build
+section has finished. This path is relative to the working directory of the
+build phase *before* any directory changes are made.
+
+
+```yaml
+artifacts:
+  libs:
+    my_output_dir/lib.o:
+        subpath: ""
+        mode: 0o755
+```
+
+You may use a trailing wildcard to specify multiple binaries in a directory,
+though behavior may differ between different OS's/distros.
+
+### Links
+
+Links are a list of symlinks to be included with the package.
+Unlike most other artifact typtes, links do not reference any specific build
+artifact but rather a literal source-to-target mapping for the symlink.
+
+Example:
+
+This creates a symlink at /usr/bin/go pointing to /usr/lib/golang/go.
+
+```yaml
+artifacts:
+  links:
+    - source: /usr/lib/golang/go
+      dest: /usr/bin/go
+```

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -198,6 +198,8 @@ artifacts:
       subpath: man8
 ```
 
+For more information, please see [Artifacts](artifacts.md)
+
 ## Tests section
 
 Tests section is used to define the tests for the spec. These tests can be used to define the test cases, steps, or any other tests needed for the package.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
         'sources',
         'targets',
         'testing',
+        'artifacts',
       ],
     },
     {


### PR DESCRIPTION
Adds support for library files and package-level symlinks.
These are required for supporting packages such as golang.

Also adds more in-depth docs for artifacts.