### PR TITLE
spec.image.postinstall.symlink: Add CreateDir option

### DIFF
--- a/frontend/windows/handle_container.go
+++ b/frontend/windows/handle_container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"runtime"
 
 	"github.com/Azure/dalec"
@@ -123,6 +124,7 @@ func copySymlinks(post *dalec.PostInstall) llb.StateOption {
 		for _, srcPath := range keys {
 			l := lm[srcPath]
 			dstPath := l.Path
+			s = s.File(llb.Mkdir(path.Dir(dstPath), 0755, llb.WithParents(true)))
 			s = s.File(llb.Copy(s, srcPath, dstPath))
 		}
 

--- a/helpers.go
+++ b/helpers.go
@@ -361,7 +361,7 @@ func InstallPostSymlinks(post *PostInstall, rootfsPath string) llb.RunOption {
 		buf.WriteString("set -ex\n")
 
 		for src, tgt := range post.Symlinks {
-			fmt.Fprintf(buf, "mkdir -p %q\n", filepath.Join(rootfsPath, path.Dir(tgt.Path)))
+			fmt.Fprintf(buf, "mkdir -p %q\n", filepath.Join(rootfsPath, filepath.Dir(tgt.Path)))
 			fmt.Fprintf(buf, "ln -s %q %q\n", src, filepath.Join(rootfsPath, tgt.Path))
 		}
 

--- a/helpers.go
+++ b/helpers.go
@@ -361,6 +361,7 @@ func InstallPostSymlinks(post *PostInstall, rootfsPath string) llb.RunOption {
 		buf.WriteString("set -ex\n")
 
 		for src, tgt := range post.Symlinks {
+			fmt.Fprintf(buf, "mkdir -p %q\n", filepath.Join(rootfsPath, path.Dir(tgt.Path)))
 			fmt.Fprintf(buf, "ln -s %q %q\n", src, filepath.Join(rootfsPath, tgt.Path))
 		}
 

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -316,6 +316,14 @@ index 0000000..5260cb1
 						Name: src2Patch3ContextName,
 					},
 				},
+				"src3": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/usr/bin/env bash\necho goodbye",
+							Permissions: 0o700,
+						},
+					},
+				},
 			},
 			Patches: map[string][]dalec.PatchSpec{
 				"src2": {
@@ -394,6 +402,7 @@ echo "$BAR" > bar.txt
 				Post: &dalec.PostInstall{
 					Symlinks: map[string]dalec.SymlinkTarget{
 						"/usr/bin/src1": {Path: "/src1"},
+						"/usr/bin/src3": {Path: "/non/existing/dir/src3"},
 					},
 				},
 			},
@@ -402,6 +411,7 @@ echo "$BAR" > bar.txt
 				Binaries: map[string]dalec.ArtifactConfig{
 					"src1":       {},
 					"src2/file2": {},
+					"src3":       {},
 					// These are files we created in the build step
 					// They aren't really binaries but we want to test that they are created and have the right content
 					"foo0.txt": {},
@@ -437,12 +447,14 @@ echo "$BAR" > bar.txt
 				{
 					Name: "Post-install symlinks should be created",
 					Files: map[string]dalec.FileCheckOutput{
-						"/src1": {},
+						"/src1":                  {},
+						"/non/existing/dir/src3": {},
 					},
 					Steps: []dalec.TestStep{
 						{Command: "/bin/bash -c 'test -L /src1'"},
 						{Command: "/bin/bash -c 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
 						{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+						{Command: "/non/existing/dir/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
 					},
 				},
 				{

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -198,6 +198,14 @@ index 0000000..5260cb1
 						},
 					},
 				},
+				"src3": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/usr/bin/env bash\necho goodbye",
+							Permissions: 0o700,
+						},
+					},
+				},
 			},
 			Patches: map[string][]dalec.PatchSpec{
 				"src2": {
@@ -244,6 +252,7 @@ echo "$BAR" > bar.txt
 				Post: &dalec.PostInstall{
 					Symlinks: map[string]dalec.SymlinkTarget{
 						"/Windows/System32/src1": {Path: "/src1"},
+						"/Windows/System32/src3": {Path: "/non/existing/dir/src3"},
 					},
 				},
 			},
@@ -252,6 +261,7 @@ echo "$BAR" > bar.txt
 				Binaries: map[string]dalec.ArtifactConfig{
 					"src1":       {},
 					"src2/file2": {},
+					"src3":       {},
 					// These are files we created in the build step
 					// They aren't really binaries but we want to test that they are created and have the right content
 					"foo0.txt": {},


### PR DESCRIPTION
**What this PR does / why we need it**:

Some images need binaries and files to be in some other places than traditional packages. To enable this the `Symlinks` field was introduced.
But if one wants to create a symlink in an non existing directory the creation fails.

This PR adds an option to create the underlying directory if it does not exist.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

**Special notes for your reviewer**:
1. ~~As far as I understood the Windows path does not need to be update because it creates the directories every time~~ Windows path doesn't create the dir, too
2. It can be argued that this shouldn't be an option and the directory creation should be done every time. This also aligns with 1.

cc @blanquicet 