### PR TITLE
Support customizing git auth

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -393,6 +393,24 @@
 			"type": "object",
 			"description": "GeneratorGomod is used to generate a go module cache from go module sources"
 		},
+		"GitAuth": {
+			"properties": {
+				"header": {
+					"type": "string",
+					"description": "Header is the name of the secret which contains the git auth header.\nwhen using git auth header based authentication.\nNote: This should not have the *actual* secret value, just the name of\nthe secret which was specified as a build secret."
+				},
+				"token": {
+					"type": "string",
+					"description": "Token is the name of the secret which contains a git auth token when using\ntoken based authentication.\nNote: This should not have the *actual* secret value, just the name of\nthe secret which was specified as a build secret."
+				},
+				"ssh": {
+					"type": "string",
+					"description": "SSH is the name of the secret which contains the ssh auth into when using\nssh based auth.\nNote: This should not have the *actual* secret value, just the name of\nthe secret which was specified as a build secret."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
 		"ImageConfig": {
 			"properties": {
 				"entrypoint": {
@@ -716,6 +734,9 @@
 				},
 				"keepGitDir": {
 					"type": "boolean"
+				},
+				"auth": {
+					"$ref": "#/$defs/GitAuth"
 				}
 			},
 			"additionalProperties": false,

--- a/helpers.go
+++ b/helpers.go
@@ -413,3 +413,9 @@ func (s *Spec) GetPackageDeps(target string) *PackageDependencies {
 	}
 	return s.Dependencies
 }
+
+type gitOptionFunc func(*llb.GitInfo)
+
+func (f gitOptionFunc) SetGitOption(gi *llb.GitInfo) {
+	f(gi)
+}

--- a/source.go
+++ b/source.go
@@ -137,6 +137,7 @@ func (src *SourceGit) AsState(opts ...llb.ConstraintsOpt) (llb.State, error) {
 		gOpts = append(gOpts, llb.KeepGitDir())
 	}
 	gOpts = append(gOpts, withConstraints(opts))
+	gOpts = append(gOpts, src.Auth.LLBOpt())
 
 	st := llb.Git(ref.Remote, src.Commit, gOpts...)
 	return st, nil

--- a/website/docs/sources.md
+++ b/website/docs/sources.md
@@ -70,11 +70,30 @@ You can override this behavior by setting `keepGitDir: true` in the git configur
 
 Git repositories are considered to be "directory" sources.
 
-Authentication will be handled using some defaults:
+Authentication will be handled using some default secret names which are fetched
+from the client:
 
-1. Local SSH agent
+1. Default SSH agent
 2. Providing a build secret called `GIT_AUTH_HEADER` for header based auth
 3. Providing a build secret called `GIT_AUTH_TOKEN` for token based auth
+
+You can customize each of these by setting the appropriate field in the
+git auth section (shown below with default values):
+
+```yaml
+  someSource1:
+    git:
+      # This uses an SSH style git URL.
+      url: git@github.com:myOrg/myRepo.git
+      commit: 1234567890abcdef
+      auth:
+        header: GIT_AUTH_HEADER # Default header secret used
+        token: GIT_AUTH_TOKEN # Default token secret used
+        ssh: default # Default SSH secret used
+```
+
+Note: These are secret names which are used to reference the secrets provided
+by the client, not the actual secret values.
 
 ### HTTP
 

--- a/website/docs/sources.md
+++ b/website/docs/sources.md
@@ -70,6 +70,11 @@ You can override this behavior by setting `keepGitDir: true` in the git configur
 
 Git repositories are considered to be "directory" sources.
 
+Authentication will be handled using some defaults:
+
+1. Local SSH agent
+2. Providing a build secret called `GIT_AUTH_HEADER` for header based auth
+3. Providing a build secret called `GIT_AUTH_TOKEN` for token based auth
 
 ### HTTP
 


### PR DESCRIPTION
Allows the client to pass in custom git auth secrets.
Also documents the existing defaults that are used.