### PR TITLE
deb: Use custom install script instead of dh-exec

### DIFF
--- a/frontend/deb/templates/debian_install_header.sh
+++ b/frontend/deb/templates/debian_install_header.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux
+
+do_install() {
+	local parent="${1}"
+	shift
+
+	local dest="${1}"
+	shift
+
+	mkdir -p "${parent}"
+
+	local files=($@)
+
+	# When the number of files passed in is more than 1, then dest *must* refer
+	# to a directory
+	if test ${#files[@]} -gt 1; then
+		mkdir -p "${dest}"
+	fi
+
+	for src in ${files[@]}; do
+		cp --reflink=auto -a "${src}" "${dest}"
+	done
+}


### PR DESCRIPTION
dh-exec has some limitations that we can't really get around. The immediate need is it can't copy a directory to a new name in the target location.
As such we need more flexibility in how we set things up, so this switches to bash so we can have the power that we need.

Should resolve the issue with CI in #385 
