### PR TITLE
Use async states

### DIFF
--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -79,7 +79,7 @@ func handleContainer(w worker) gwclient.BuildFunc {
 				).AddMount("/tmp/rootfs", in)
 			}
 
-			if err := frontend.RunTests(ctx, client, spec, ref, withTestDeps, targetKey); err != nil {
+			if err := frontend.RunTests(ctx, client, spec, ref, withTestDeps, targetKey, pg); err != nil {
 				return nil, nil, err
 			}
 

--- a/frontend/deb/debroot.go
+++ b/frontend/deb/debroot.go
@@ -154,7 +154,7 @@ func Debroot(sOpt dalec.SourceOpts, spec *dalec.Spec, worker, in llb.State, targ
 		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, spec.Name+".links"), 0o644, buf.Bytes()), opts...))
 	}
 
-	return dalec.MergeAtPath(in, states, "/"), nil
+	return dalec.MergeAtPath(in, states, "/", opts...), nil
 }
 
 func fixupArtifactPerms(spec *dalec.Spec) []byte {

--- a/frontend/jammy/handle_container.go
+++ b/frontend/jammy/handle_container.go
@@ -84,7 +84,7 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 			return nil, nil, err
 		}
 
-		if err := frontend.RunTests(ctx, client, spec, ref, installTestDeps(spec, targetKey, opt), targetKey); err != nil {
+		if err := frontend.RunTests(ctx, client, spec, ref, installTestDeps(spec, targetKey, opt), targetKey, opt); err != nil {
 			return nil, nil, err
 		}
 

--- a/frontend/rpm/handle_buildroot.go
+++ b/frontend/rpm/handle_buildroot.go
@@ -65,5 +65,5 @@ func SpecToBuildrootLLB(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpt
 		return llb.Scratch(), err
 	}
 
-	return Dalec2SpecLLB(spec, dalec.MergeAtPath(llb.Scratch(), sources, "SOURCES"), targetKey, "", opts...)
+	return Dalec2SpecLLB(spec, dalec.MergeAtPath(llb.Scratch(), sources, "SOURCES", opts...), targetKey, "", opts...)
 }

--- a/frontend/test_runner.go
+++ b/frontend/test_runner.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"sync"
 
 	"github.com/Azure/dalec"
 	"github.com/google/shlex"
@@ -19,7 +18,7 @@ import (
 )
 
 // Run tests runs the tests defined in the spec against the given target container.
-func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, ref gwclient.Reference, withTestDeps llb.StateOption, target string) error {
+func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, ref gwclient.Reference, withTestDeps llb.StateOption, target string, opts ...llb.ConstraintsOpt) error {
 	if skipVar := client.BuildOpts().Opts["build-arg:"+"DALEC_SKIP_TESTS"]; skipVar != "" {
 		skip, err := strconv.ParseBool(skipVar)
 		if err != nil {
@@ -52,127 +51,125 @@ func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, ref
 		return err
 	}
 
-	type testPair struct {
-		st     llb.State
-		t      *dalec.TestSpec
-		stdios map[int]llb.State
-	}
-
 	ctrWithDeps := ctr.With(withTestDeps)
+	states := make([]llb.State, 0, len(tests))
 
-	runs := make([]testPair, 0, len(tests))
 	for _, test := range tests {
 		base := ctr
 		for k, v := range test.Env {
 			base = base.AddEnv(k, v)
 		}
 
-		var opts []llb.RunOption
-		opts = append(opts, dalec.CacheDirsToRunOpt(test.CacheDirs, "", ""))
+		pg := dalec.ProgressGroup("Test: " + path.Join(target, test.Name))
+		opts := append(opts, pg)
 
-		pg := llb.ProgressGroup(identity.NewID(), "Test: "+path.Join(target, test.Name), false)
+		execOpts := []llb.RunOption{dalec.WithConstraints(opts...)}
+		execOpts = append(execOpts, dalec.CacheDirsToRunOpt(test.CacheDirs, "", ""))
 
 		for _, sm := range test.Mounts {
-			st, err := sm.Spec.AsMount(sm.Dest, sOpt, pg)
+			st, err := sm.Spec.AsMount(sm.Dest, sOpt, opts...)
 			if err != nil {
 				return err
 			}
-			opts = append(opts, llb.AddMount(sm.Dest, st, llb.SourcePath(sm.Dest)))
+			execOpts = append(execOpts, llb.AddMount(sm.Dest, st, llb.SourcePath(sm.Dest)))
 		}
 
 		opts = append(opts, pg)
-		if len(test.Steps) > 0 {
-			exec := ctrWithDeps
-			var worker llb.State
-			var needsStdioMount bool
-			ios := map[int]llb.State{}
-			for i, step := range test.Steps {
-				var stepOpts []llb.RunOption
-				id := identity.NewID()
-				ioSt := llb.Scratch()
-				if step.Stdin != "" {
-					needsStdioMount = true
-					stepOpts = append(stepOpts, llb.AddEnv("STDIN_FILE", filepath.Join("/tmp", id, "stdin")))
-					ioSt = ioSt.File(llb.Mkfile("stdin", 0444, []byte(step.Stdin)))
-				}
-				if !step.Stdout.IsEmpty() {
-					needsStdioMount = true
-					stepOpts = append(stepOpts, llb.AddEnv("STDOUT_FILE", path.Join("/tmp", id, "stdout")))
-					ioSt = ioSt.File(llb.Mkfile("stdout", 0664, nil))
-				}
+		if len(test.Steps) == 0 {
+			st := base.Async(runTest(test, nil, client, opts...))
+			states = append(states, st)
+			continue
+		}
 
-				if !step.Stderr.IsEmpty() {
-					needsStdioMount = true
-					stepOpts = append(stepOpts, llb.AddEnv("STDERR_FILE", path.Join("/tmp", id, "stderr")))
-					ioSt = ioSt.File(llb.Mkfile("stderr", 0664, nil))
-				}
+		worker := ctrWithDeps
 
-				cmd, err := shlex.Split(step.Command)
+		var needsStdioMount bool
+		ios := map[int]llb.State{}
+		for i, step := range test.Steps {
+			var stepOpts []llb.RunOption
+			id := identity.NewID()
+			ioSt := llb.Scratch()
+			if step.Stdin != "" {
+				needsStdioMount = true
+				stepOpts = append(stepOpts, llb.AddEnv("STDIN_FILE", filepath.Join("/tmp", id, "stdin")))
+				ioSt = ioSt.File(llb.Mkfile("stdin", 0444, []byte(step.Stdin)), opts...)
+			}
+			if !step.Stdout.IsEmpty() {
+				needsStdioMount = true
+				stepOpts = append(stepOpts, llb.AddEnv("STDOUT_FILE", path.Join("/tmp", id, "stdout")))
+				ioSt = ioSt.File(llb.Mkfile("stdout", 0664, nil), opts...)
+			}
+
+			if !step.Stderr.IsEmpty() {
+				needsStdioMount = true
+				stepOpts = append(stepOpts, llb.AddEnv("STDERR_FILE", path.Join("/tmp", id, "stderr")))
+				ioSt = ioSt.File(llb.Mkfile("stderr", 0664, nil), opts...)
+			}
+
+			cmd, err := shlex.Split(step.Command)
+			if err != nil {
+				return err
+			}
+			if needsStdioMount {
+				fSt, err := client.(frontendClient).CurrentFrontend()
 				if err != nil {
 					return err
 				}
-				if needsStdioMount {
-					fSt, err := client.(frontendClient).CurrentFrontend()
-					if err != nil {
-						return err
-					}
-					p := filepath.Join("/tmp", id+"-2", "dalec-redirectio")
-					stepOpts = append(stepOpts, llb.AddMount(p, *fSt, llb.SourcePath("/dalec-redirectio")))
-					cmd = append([]string{p}, cmd...)
-				}
-
-				stepOpts = append(stepOpts, llb.Args(cmd))
-				stepOpts = append(stepOpts, llb.With(func(s llb.State) llb.State {
-					for k, v := range step.Env {
-						s = s.AddEnv(k, v)
-					}
-
-					return s
-				}))
-				stepOpts = append(opts, stepOpts...)
-
-				var est llb.ExecState
-				if i == 0 {
-					est = exec.Run(stepOpts...)
-				} else {
-					est = exec.Run(stepOpts...)
-				}
-				if needsStdioMount {
-					ioSt = est.AddMount(filepath.Join("/tmp", id), ioSt)
-					ios[i] = ioSt
-				}
-				worker = est.Root()
+				p := filepath.Join("/tmp", id+"-2", "dalec-redirectio")
+				stepOpts = append(stepOpts, llb.AddMount(p, *fSt, llb.SourcePath("/dalec-redirectio")))
+				cmd = append([]string{p}, cmd...)
 			}
 
-			runs = append(runs, testPair{st: worker, t: test, stdios: ios})
-		} else {
-			runs = append(runs, testPair{st: base, t: test})
+			stepOpts = append(stepOpts, llb.Args(cmd))
+			stepOpts = append(stepOpts, llb.With(func(s llb.State) llb.State {
+				for k, v := range step.Env {
+					s = s.AddEnv(k, v)
+				}
+
+				return s
+			}))
+
+			est := worker.Run(stepOpts...)
+			if needsStdioMount {
+				ioSt = est.AddMount(filepath.Join("/tmp", id), ioSt)
+				ios[i] = ioSt
+			}
+			worker = est.Root()
 		}
+
+		st := worker.Async(runTest(test, ios, client, opts...))
+		states = append(states, st)
 	}
 
-	var errs errorList
-	var wg sync.WaitGroup
-	for _, pair := range runs {
-		pair := pair
-		wg.Add(1)
-		go func() {
-			if err := runTest(ctx, pair.t, pair.st, pair.stdios, client); err != nil {
-				errs.Append(errors.Wrap(err, "FAILED: "+path.Join(target, pair.t.Name)))
-			}
-			wg.Done()
-		}()
+	refs := make([]gwclient.Reference, 0, len(states))
+	for _, st := range states {
+		def, err := st.Marshal(ctx, opts...)
+		if err != nil {
+			return err
+		}
+
+		res, err := client.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return err
+		}
+		refs = append(refs, ref)
 	}
 
-	wg.Wait()
-
-	return errs.Join()
+	return evalRefs(ctx, refs)
 }
 
 type frontendClient interface {
 	CurrentFrontend() (*llb.State, error)
 }
 
-func checkFile(ctx context.Context, client gwclient.Client, ref gwclient.Reference, p string, check dalec.FileCheckOutput) error {
+func checkFile(ctx context.Context, ref gwclient.Reference, p string, check dalec.FileCheckOutput) error {
 	stat, err := ref.StatFile(ctx, gwclient.StatRequest{
 		Path: p,
 	})
@@ -206,51 +203,28 @@ func checkFile(ctx context.Context, client gwclient.Client, ref gwclient.Referen
 	return nil
 }
 
-func runTest(ctx context.Context, t *dalec.TestSpec, st llb.State, ios map[int]llb.State, client gwclient.Client) error {
-	def, err := st.Marshal(ctx)
-	if err != nil {
-		return err
-	}
-
-	res, err := client.Solve(ctx, gwclient.SolveRequest{
-		Definition: def.ToPB(),
-		Evaluate:   true,
-	})
-	if err != nil {
-		return err
-	}
-
-	ref, err := res.SingleRef()
-	if err != nil {
-		return err
-	}
-
-	var outErr error
-	for p, check := range t.Files {
-		if err := checkFile(ctx, client, ref, p, check); err != nil {
-			outErr = stderrors.Join(outErr, fmt.Errorf("%s: %w", p, err))
+func checkStdio(client gwclient.Client, ionum int, t *dalec.TestSpec, opts ...llb.ConstraintsOpt) asyncStateFunc {
+	return func(ctx context.Context, st llb.State, constraints *llb.Constraints) (llb.State, error) {
+		for _, o := range opts {
+			o.SetConstraintsOption(constraints)
 		}
-	}
 
-	for i, st := range ios {
-		def, err := st.Marshal(ctx)
+		def, err := st.Marshal(ctx, withConstraints(constraints))
 		if err != nil {
-			outErr = stderrors.Join(errors.Wrap(err, "failed to marshal stdio state"))
-			continue
+			return st, errors.Wrap(err, "failed to marshal stdio state")
 		}
+
 		res, err := client.Solve(ctx, gwclient.SolveRequest{
 			Definition: def.ToPB(),
 			Evaluate:   true,
 		})
 		if err != nil {
-			outErr = stderrors.Join(errors.Wrap(err, "failed to solve stdio state"))
-			continue
+			return st, errors.Wrap(err, "failed to solve stdio state")
 		}
 
 		ref, err := res.SingleRef()
 		if err != nil {
-			outErr = stderrors.Join(errors.Wrap(err, "failed to get stdio ref for %d"))
-			continue
+			return st, errors.Wrapf(err, "failed to get stdio ref for %d", ionum)
 		}
 
 		checkFile := func(c dalec.CheckOutput, name string) error {
@@ -269,39 +243,94 @@ func runTest(ctx context.Context, t *dalec.TestSpec, st llb.State, ios map[int]l
 			return nil
 		}
 
-		step := t.Steps[i]
+		var outErr error
+		step := t.Steps[ionum]
 		if err := checkFile(step.Stdout, "stdout"); err != nil {
-			outErr = stderrors.Join(err)
+			outErr = stderrors.Join(outErr, err)
 		}
 		if err := checkFile(step.Stderr, "stderr"); err != nil {
 			outErr = stderrors.Join(err)
 		}
+		return st, outErr
+	}
+}
+
+func evalRefs(ctx context.Context, refs []gwclient.Reference) error {
+	ch := make(chan error, len(refs))
+	var outErr error
+
+	for _, ref := range refs {
+		go func() {
+			ch <- ref.Evaluate(ctx)
+		}()
 	}
 
+	for i := 0; i < len(refs); i++ {
+		select {
+		case <-ctx.Done():
+		case err := <-ch:
+			if err != nil {
+				outErr = stderrors.Join(outErr, err)
+			}
+		}
+	}
 	return outErr
 }
 
-type errorList struct {
-	mu sync.Mutex
-	ls []error
-}
+func runTest(t *dalec.TestSpec, ios map[int]llb.State, client gwclient.Client, opts ...llb.ConstraintsOpt) asyncStateFunc {
+	return func(ctx context.Context, st llb.State, constraints *llb.Constraints) (llb.State, error) {
+		for _, o := range opts {
+			o.SetConstraintsOption(constraints)
+		}
 
-func (e *errorList) Append(err error) {
-	if err == nil {
-		return
+		def, err := st.Marshal(ctx, withConstraints(constraints))
+		if err != nil {
+			return st, err
+		}
+
+		res, err := client.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+			Evaluate:   true,
+		})
+		if err != nil {
+			return st, err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return st, err
+		}
+
+		var outErr error
+		for p, check := range t.Files {
+			if err := checkFile(ctx, ref, p, check); err != nil {
+				outErr = stderrors.Join(outErr, fmt.Errorf("%s: %w", p, err))
+			}
+		}
+
+		refs := make([]gwclient.Reference, 0, len(ios))
+
+		for i, st := range ios {
+			st := st.Async(checkStdio(client, i, t, opts...))
+			def, err := st.Marshal(ctx, opts...)
+			if err != nil {
+				return st, err
+			}
+
+			res, err := client.Solve(ctx, gwclient.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return st, err
+			}
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				return st, err
+			}
+			refs = append(refs, ref)
+		}
+
+		return st, stderrors.Join(outErr, evalRefs(ctx, refs))
 	}
-	e.mu.Lock()
-	e.ls = append(e.ls, err)
-	e.mu.Unlock()
-}
-
-func (e *errorList) Join() error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if len(e.ls) == 0 {
-		return nil
-	}
-
-	return stderrors.Join(e.ls...)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -157,7 +157,7 @@ func DuplicateMap[K comparable, V any](m map[K]V) map[K]V {
 }
 
 // MergeAtPath merges the given states into the given destination path in the given input state.
-func MergeAtPath(input llb.State, states []llb.State, dest string) llb.State {
+func MergeAtPath(input llb.State, states []llb.State, dest string, opts ...llb.ConstraintsOpt) llb.State {
 	if disableDiffMerge.Load() {
 		output := input
 		for _, st := range states {
@@ -174,11 +174,11 @@ func MergeAtPath(input llb.State, states []llb.State, dest string) llb.State {
 		st := src
 		if dest != "" && dest != "/" {
 			st = llb.Scratch().
-				File(llb.Copy(src, "/", dest, WithCreateDestPath()))
+				File(llb.Copy(src, "/", dest, WithCreateDestPath()), opts...)
 		}
-		diffs = append(diffs, llb.Diff(input, st))
+		diffs = append(diffs, llb.Diff(input, st, opts...))
 	}
-	return llb.Merge(diffs)
+	return llb.Merge(diffs, opts...)
 }
 
 type localOptionFunc func(*llb.LocalInfo)

--- a/helpers.go
+++ b/helpers.go
@@ -68,7 +68,7 @@ func WithMountedAptCache(namePrefix string) llb.RunOption {
 		// To resolve that we delete the file.
 		ei.State = ei.State.File(
 			llb.Rm("/etc/apt/apt.conf.d/docker-clean", llb.WithAllowNotFound(true)),
-			constraintsOptFunc(func(c *llb.Constraints) {
+			ConstraintsOptFunc(func(c *llb.Constraints) {
 				*c = ei.Constraints
 			}),
 		)
@@ -95,38 +95,38 @@ func WithRunOptions(opts ...llb.RunOption) llb.RunOption {
 	})
 }
 
-type constraintsOptFunc func(*llb.Constraints)
+type ConstraintsOptFunc func(*llb.Constraints)
 
-func (f constraintsOptFunc) SetConstraintsOption(c *llb.Constraints) {
+func (f ConstraintsOptFunc) SetConstraintsOption(c *llb.Constraints) {
 	f(c)
 }
 
-func (f constraintsOptFunc) SetRunOption(ei *llb.ExecInfo) {
+func (f ConstraintsOptFunc) SetRunOption(ei *llb.ExecInfo) {
 	f(&ei.Constraints)
 }
 
-func (f constraintsOptFunc) SetLocalOption(li *llb.LocalInfo) {
+func (f ConstraintsOptFunc) SetLocalOption(li *llb.LocalInfo) {
 	f(&li.Constraints)
 }
 
-func (f constraintsOptFunc) SetOCILayoutOption(oi *llb.OCILayoutInfo) {
+func (f ConstraintsOptFunc) SetOCILayoutOption(oi *llb.OCILayoutInfo) {
 	f(&oi.Constraints)
 }
 
-func (f constraintsOptFunc) SetHTTPOption(hi *llb.HTTPInfo) {
+func (f ConstraintsOptFunc) SetHTTPOption(hi *llb.HTTPInfo) {
 	f(&hi.Constraints)
 }
 
-func (f constraintsOptFunc) SetImageOption(ii *llb.ImageInfo) {
+func (f ConstraintsOptFunc) SetImageOption(ii *llb.ImageInfo) {
 	f(&ii.Constraints)
 }
 
-func (f constraintsOptFunc) SetGitOption(gi *llb.GitInfo) {
+func (f ConstraintsOptFunc) SetGitOption(gi *llb.GitInfo) {
 	f(&gi.Constraints)
 }
 
 func WithConstraints(ls ...llb.ConstraintsOpt) llb.ConstraintsOpt {
-	return constraintsOptFunc(func(c *llb.Constraints) {
+	return ConstraintsOptFunc(func(c *llb.Constraints) {
 		for _, opt := range ls {
 			opt.SetConstraintsOption(c)
 		}
@@ -251,7 +251,7 @@ func (f RunOptFunc) SetRunOption(ei *llb.ExecInfo) {
 // If a progress group is already set in the constraints the id is reused.
 // If no progress group is set a new id is generated.
 func ProgressGroup(name string) llb.ConstraintsOpt {
-	return constraintsOptFunc(func(c *llb.Constraints) {
+	return ConstraintsOptFunc(func(c *llb.Constraints) {
 		if c.Metadata.ProgressGroup != nil {
 			id := c.Metadata.ProgressGroup.Id
 			llb.ProgressGroup(id, name, false).SetConstraintsOption(c)


### PR DESCRIPTION
Make use of async states to help prevent unlazying builds until we are ready to solve things.
See individual commits for more details.