### PR TITLE
deb: Disable dh_dwz which can cause issues for go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,22 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-        - "*.go"
-        - "**/*.go"
-        - Dockerfile
-        - docker-bake.hcl
-        - .github/workflows/ci.yml
-        - frontend/mariner2/Dockerfile
-        - "test/fixtures/*"
-        - go.mod
-        - go.sum
+    paths-ignore:
+      - 'website/**'
+      - 'docs/**'
+      - '*.md'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+
   push:
     branches:
       - main
-    paths:
-      - "*.go"
-      - "**/*.go"
-      - Dockerfile
-      - docker-bake.hcl
-      - .github/workflows/ci.yml
-      - frontend/mariner2/Dockerfile
-      - go.mod
-      - go.sum
+    paths-ignore:
+      - 'website/**'
+      - 'docs/**'
+      - '*.md'
+      - 'CODEOWNERS'
+      - 'LICENSE'
 
 permissions:
   contents: read

--- a/frontend/deb/templates/debian_rules.tmpl
+++ b/frontend/deb/templates/debian_rules.tmpl
@@ -26,6 +26,10 @@ fix_sources:
 override_dh_auto_configure: fix_sources
 	@# Stop debhelper from running auto configure, which should be part of the build steps
 
+# dh_dwz is problematic for (some) go builds and causes the build to error out.
+override_dh_dwz:
+	@# https://salsa.debian.org/go-team/packages/dh-golang/-/commit/831f3a9dccc14f63f21d3dfac0c0d0e0c25b4084
+
 {{ .OverridePerms }}
 
 {{ .OverrideSystemd }}


### PR DESCRIPTION
debbuild will automatically execute this `dh_dwz` target which, for some go builds, will error out like:

```
0.69 dwz: debian/msft-golang/usr/lib/msft-golang/bin/go: Found compressed .debug_abbrev section, not attempting dwz compression
40.69 dwz: debian/msft-golang/usr/lib/msft-golang/bin/gofmt: Found compressed .debug_abbrev section, not attempting dwz compression
40.69 dwz: Too few files for multifile optimization
```

This does what dh_golang does and overrides this so the target doesn't do anything.
We may want to make this opt-in in the future somehow (or scope it down to just go builds?).
Not really sure what a good approach will be here, but for now this is blocking being able to build certain packages.
