### PR TITLE
Make keepGitDir optional

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -750,8 +750,7 @@
 			"type": "object",
 			"required": [
 				"url",
-				"commit",
-				"keepGitDir"
+				"commit"
 			]
 		},
 		"SourceHTTP": {

--- a/spec.go
+++ b/spec.go
@@ -144,7 +144,7 @@ type SourceDockerImage struct {
 type SourceGit struct {
 	URL        string  `yaml:"url" json:"url"`
 	Commit     string  `yaml:"commit" json:"commit"`
-	KeepGitDir bool    `yaml:"keepGitDir" json:"keepGitDir"`
+	KeepGitDir bool    `yaml:"keepGitDir,omitempty" json:"keepGitDir,omitempty"`
 	Auth       GitAuth `yaml:"auth,omitempty" json:"auth,omitempty"`
 }
 


### PR DESCRIPTION
This was never meant to be a required field, so mark it as omitempty so that the jsonschema validation in editors don't complain about it being missing.
