### PR TITLE
Force evaluation before test execution

### DIFF
--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -49,6 +49,10 @@ func handleRPM(w worker) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
+			if err := ref.Evaluate(ctx); err != nil {
+				return ref, nil, err
+			}
+
 			if imgRef, err := runTests(ctx, client, w, spec, sOpt, st, targetKey, pg); err != nil {
 				// return the container ref in case of error so it can be used to debug
 				// the installed package state.

--- a/frontend/jammy/handle_deb.go
+++ b/frontend/jammy/handle_deb.go
@@ -49,6 +49,10 @@ func handleDeb(ctx context.Context, client gwclient.Client) (*gwclient.Result, e
 			return nil, nil, err
 		}
 
+		if err := ref.Evaluate(ctx); err != nil {
+			return ref, nil, err
+		}
+
 		if ref, err := runTests(ctx, client, spec, sOpt, st, targetKey, opt); err != nil {
 			cfg, _ := buildImageConfig(ctx, client, spec, platform, targetKey)
 			return ref, cfg, err

--- a/frontend/test_runner.go
+++ b/frontend/test_runner.go
@@ -41,6 +41,14 @@ func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, ref
 		return nil
 	}
 
+	if err := ref.Evaluate(ctx); err != nil {
+		// Force evaluation here so that any errors for the build itself can surface
+		// more cleanly.
+		// Otherwise an error for something wrong in the build (e.g. a failed compilation)
+		// will look like an error in a test (or all tests).
+		return err
+	}
+
 	ctr, err := ref.ToState()
 	if err != nil {
 		return err


### PR DESCRIPTION
This makes it so error messages from the build are not wrapped in error messages for tests.

Before this change the build is performed lazily until the point when the tests try to interact with the rootfs under test making it appear like a build failure is a test error when in reality we didn't even get to the test.

Closes #400