### PR TITLE
Fix: testrunner: Explicitly check permissions

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -621,8 +621,9 @@ func (c FileCheckOutput) Check(dt string, mode fs.FileMode, isDir bool, p string
 		return &CheckOutputError{Kind: "mode", Expected: "ModeFile", Actual: "ModeDir", Path: p}
 	}
 
-	if c.Permissions != 0 && c.Permissions != mode {
-		return &CheckOutputError{Kind: "permissions", Expected: c.Permissions.String(), Actual: mode.String(), Path: p}
+	perm := mode.Perm()
+	if c.Permissions != 0 && c.Permissions != perm {
+		return &CheckOutputError{Kind: "permissions", Expected: c.Permissions.String(), Actual: perm.String(), Path: p}
 	}
 
 	return c.CheckOutput.Check(dt, p)


### PR DESCRIPTION
The file checker takes an `os.FileMode` which contains things other than just permissions.
Make the checker explictly call `mode.Perm()` to ensure it has *just* the permissions bits when checking.

This fixes an issue when checking permission on a directory.
