### PR TITLE
Add Custom Repo Support For Jammy

### DIFF
--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -56,7 +56,7 @@ func specToContainerLLB(w worker, spec *dalec.Spec, targetKey string, rpmDir llb
 	}
 
 	installTimeRepos := spec.GetInstallRepos(targetKey)
-	importRepos, err := repoMountInstallOpts(installTimeRepos, sOpt, opts...)
+	importRepos, err := repoMountInstallOpts(builderImg, installTimeRepos, sOpt, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -189,7 +189,7 @@ func installBuildDepsPackage(target string, packageName string, w worker, deps m
 	}
 }
 
-func installBuildDeps(ctx context.Context, w worker, sOpt dalec.SourceOpts, client gwclient.Client, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.StateOption, error) {
+func installBuildDeps(ctx context.Context, w worker, client gwclient.Client, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.StateOption, error) {
 	deps := spec.GetBuildDeps(targetKey)
 	if len(deps) == 0 {
 		return func(in llb.State) llb.State { return in }, nil
@@ -230,7 +230,7 @@ func specToRpmLLB(ctx context.Context, w worker, client gwclient.Client, spec *d
 		return llb.Scratch(), err
 	}
 
-	installOpt, err := installBuildDeps(ctx, w, sOpt, client, spec, targetKey, opts...)
+	installOpt, err := installBuildDeps(ctx, w, client, spec, targetKey, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -83,7 +83,7 @@ func getSpecWorker(ctx context.Context, w worker, client gwclient.Client, sOpt d
 				return llb.Scratch(), errors.New("spec contains go modules but does not have golang in build deps")
 			}
 
-			installOpt, err := installBuildDeps(ctx, w, sOpt, client, spec, targetKey, opts...)
+			installOpt, err := installBuildDeps(ctx, w, client, spec, targetKey, opts...)
 			if err != nil {
 				return llb.Scratch(), err
 			}

--- a/frontend/azlinux/handler.go
+++ b/frontend/azlinux/handler.go
@@ -83,7 +83,7 @@ func getSpecWorker(ctx context.Context, w worker, client gwclient.Client, sOpt d
 				return llb.Scratch(), errors.New("spec contains go modules but does not have golang in build deps")
 			}
 
-			installOpt, err := installBuildDeps(ctx, w, client, spec, targetKey, opts...)
+			installOpt, err := installBuildDeps(ctx, w, sOpt, client, spec, targetKey, opts...)
 			if err != nil {
 				return llb.Scratch(), err
 			}

--- a/helpers.go
+++ b/helpers.go
@@ -537,10 +537,9 @@ func GetRepoKeys(worker llb.State, configs []PackageRepositoryConfig, cfg *RepoP
 			mountPath := filepath.Join(cfg.GPGKeyRoot, name)
 
 			opt := runOptionFunc(func(ei *llb.ExecInfo) {
-				keySt := gpgKey
 				inPath := filepath.Join("/tmp/in", name)
 				outPath := filepath.Join("/tmp/out", name)
-				keySt = worker.Run(
+				keySt := worker.Run(
 					// dearmor key if necessary
 					ShArgs(fmt.Sprintf("cat '%s' | gpg --dearmor --output '%s'", inPath, outPath)),
 					llb.AddMount(inPath, gpgKey, llb.SourcePath(name))).

--- a/helpers.go
+++ b/helpers.go
@@ -523,7 +523,7 @@ func WithRepoConfigs(repos []PackageRepositoryConfig, cfg *RepoPlatformConfig, s
 	return WithRunOptions(configStates...), nil
 }
 
-func GetRepoKeys(configs []PackageRepositoryConfig, cfg *RepoPlatformConfig, sOpt SourceOpts, opts ...llb.ConstraintsOpt) (llb.RunOption, []string, error) {
+func GetRepoKeys(worker llb.State, configs []PackageRepositoryConfig, cfg *RepoPlatformConfig, sOpt SourceOpts, opts ...llb.ConstraintsOpt) (llb.RunOption, []string, error) {
 	keys := []llb.RunOption{}
 	names := []string{}
 	for _, config := range configs {
@@ -534,8 +534,22 @@ func GetRepoKeys(configs []PackageRepositoryConfig, cfg *RepoPlatformConfig, sOp
 				return nil, nil, err
 			}
 
-			keys = append(keys,
-				llb.AddMount(filepath.Join(cfg.GPGKeyRoot, name), gpgKey, llb.SourcePath(name)))
+			mountPath := filepath.Join(cfg.GPGKeyRoot, name)
+
+			opt := runOptionFunc(func(ei *llb.ExecInfo) {
+				keySt := gpgKey
+				inPath := filepath.Join("/tmp/in", name)
+				outPath := filepath.Join("/tmp/out", name)
+				keySt = worker.Run(
+					// dearmor key if necessary
+					ShArgs(fmt.Sprintf("cat '%s' | gpg --dearmor --output '%s'", inPath, outPath)),
+					llb.AddMount(inPath, gpgKey, llb.SourcePath(name))).
+					AddMount("/tmp/out/", llb.Scratch())
+
+				llb.AddMount(mountPath, keySt, llb.SourcePath(name)).SetRunOption(ei)
+			})
+
+			keys = append(keys, opt)
 			names = append(names, name)
 		}
 	}

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -27,6 +27,23 @@ var azlinuxConstraints = constraintsSymbols{
 	LessThanOrEqual:    "<=",
 }
 
+var azlinuxTestRepoConfig = map[string]dalec.Source{
+	"local.repo": {
+		Inline: &dalec.SourceInline{
+			File: &dalec.SourceInlineFile{
+				Contents: `[Local]
+name=Local Repository
+baseurl=file:///opt/repo
+repo_gpgcheck=1
+priority=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/public.key
+	`,
+			},
+		},
+	},
+}
+
 func TestMariner2(t *testing.T) {
 	t.Parallel()
 
@@ -49,9 +66,11 @@ func TestMariner2(t *testing.T) {
 			Targets: "/etc/systemd/system",
 		},
 		Worker: workerConfig{
-			ContextName: azlinux.Mariner2WorkerContextName,
-			CreateRepo:  azlinuxWithRepo,
-			Constraints: azlinuxConstraints,
+			ContextName:    azlinux.Mariner2WorkerContextName,
+			CreateRepo:     azlinuxWithRepo,
+			SignRepo:       signRepoAzLinux,
+			TestRepoConfig: azlinuxTestRepoConfig,
+			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "mariner",
@@ -79,9 +98,11 @@ func TestAzlinux3(t *testing.T) {
 			Targets: "/etc/systemd/system",
 		},
 		Worker: workerConfig{
-			ContextName: azlinux.Azlinux3WorkerContextName,
-			CreateRepo:  azlinuxWithRepo,
-			Constraints: azlinuxConstraints,
+			ContextName:    azlinux.Azlinux3WorkerContextName,
+			CreateRepo:     azlinuxWithRepo,
+			SignRepo:       signRepoAzLinux,
+			TestRepoConfig: azlinuxTestRepoConfig,
+			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "azurelinux",
@@ -127,11 +148,12 @@ type workerConfig struct {
 	// as well as optional state options for additional configuration.
 	// the output [llb.StateOption] should install the repo into the worker image.
 	CreateRepo func(llb.State, ...llb.StateOption) llb.StateOption
+	SignRepo   func(llb.State) llb.StateOption
 	// ContextName is the name of the worker context that the build target will use
 	// to see if a custom worker is proivded in a context
-	ContextName string
-
-	Constraints constraintsSymbols
+	ContextName    string
+	TestRepoConfig map[string]dalec.Source
+	Constraints    constraintsSymbols
 }
 
 type constraintsSymbols struct {
@@ -1255,9 +1277,6 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 	})
 
 	t.Run("custom repo", func(t *testing.T) {
-		if strings.HasPrefix(testConfig.Target.Package, "jammy") {
-			t.Skip("skipping custom repo test for jammy")
-		}
 
 		t.Parallel()
 
@@ -1379,7 +1398,7 @@ func testCustomLinuxWorker(ctx context.Context, t *testing.T, targetCfg targetCo
 	})
 }
 
-func signRepo(gpgKey llb.State) llb.StateOption {
+func signRepoAzLinux(gpgKey llb.State) llb.StateOption {
 	// key should be a state that has a public key under /public.key
 	return func(in llb.State) llb.State {
 		return in.Run(
@@ -1413,7 +1432,7 @@ Expire-Date: 0
 %commit
 EOF
 		`), pg).
-		Run(dalec.ShArgs("gpg --export --armor test@example.com > /tmp/gpg/PUBLIC-RPM-GPG-KEY; gpg --export-secret-keys --armor test@example.com > /tmp/gpg/private.key"), pg).
+		Run(dalec.ShArgs("gpg --export --armor test@example.com > /tmp/gpg/public.key; gpg --export-secret-keys --armor test@example.com > /tmp/gpg/private.key"), pg).
 		AddMount("/tmp/gpg", llb.Scratch())
 
 	return st
@@ -1466,22 +1485,7 @@ func testCustomRepo(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
 
 				ExtraRepos: []dalec.PackageRepositoryConfig{
 					{
-						Config: map[string]dalec.Source{
-							"local.repo": {
-								Inline: &dalec.SourceInline{
-									File: &dalec.SourceInlineFile{
-										Contents: `[Local]
-name=Local Repository
-baseurl=file:///opt/repo
-repo_gpgcheck=1
-priority=0
-enabled=1
-gpgkey=file:///etc/pki/rpm/PUBLIC-RPM-GPG-KEY
-	`,
-									},
-								},
-							},
-						},
+						Config: cfg.Worker.TestRepoConfig,
 						Data: []dalec.SourceMount{
 							{
 								Dest: "/opt/repo",
@@ -1526,7 +1530,7 @@ gpgkey=file:///etc/pki/rpm/PUBLIC-RPM-GPG-KEY
 		pkg := reqToState(ctx, client, sr, t)
 
 		// create a repo using our existing worker
-		workerWithRepo := w.With(cfg.Worker.CreateRepo(pkg, signRepo(key)))
+		workerWithRepo := w.With(cfg.Worker.CreateRepo(pkg, cfg.Worker.SignRepo(key)))
 
 		// copy out just the contents of the repo
 		return llb.Scratch().File(llb.Copy(workerWithRepo, "/opt/repo", "/", &llb.CopyInfo{CopyDirContentsOnly: true}))
@@ -1556,17 +1560,17 @@ gpgkey=file:///etc/pki/rpm/PUBLIC-RPM-GPG-KEY
 		w := reqToState(ctx, gwc, sr, t)
 
 		// generate a gpg key to sign the repo
-		// under /PUBLIC-RPM-GPG-KEY
+		// under /public.key
 		gpgKey := generateGPGKey(w)
 		repoState := getRepoState(ctx, gwc, w, gpgKey)
 
 		spec := getSpec(map[string]dalec.Source{
 			// in the dalec spec, the public key will be passed in via build context
-			"PUBLIC-RPM-GPG-KEY": {
+			"public.key": {
 				Context: &dalec.SourceContext{
 					Name: "repo-public-key",
 				},
-				Path: "PUBLIC-RPM-GPG-KEY",
+				Path: "public.key",
 			},
 		})
 

--- a/test/jammy_test.go
+++ b/test/jammy_test.go
@@ -8,6 +8,37 @@ import (
 	"github.com/moby/buildkit/client/llb"
 )
 
+func signRepoJammy(gpgKey llb.State) llb.StateOption {
+	// key should be a state that has a public key under /public.key
+	return func(in llb.State) llb.State {
+		// assuming in is the state that has the repo files under / including
+		// Release file
+		return in.Run(
+			dalec.ShArgs("gpg --import < /tmp/gpg/public.key"),
+			dalec.ShArgs("gpg --import < /tmp/gpg/private.key"),
+			llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
+			dalec.ProgressGroup("Importing gpg key")).
+			Run(
+				dalec.ShArgs(`ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2) && \
+					gpg --list-keys --keyid-format LONG && \
+					gpg --default-key $ID -abs -o /opt/repo/Release.gpg /opt/repo/Release && \
+					gpg --default-key "$ID" --clearsign -o /opt/repo/InRelease /opt/repo/Release`),
+				llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
+				dalec.ProgressGroup("signing repo"),
+			).Root()
+	}
+}
+
+var jammyTestRepoConfig = map[string]dalec.Source{
+	"local.list": {
+		Inline: &dalec.SourceInline{
+			File: &dalec.SourceInlineFile{
+				Contents: `deb [signed-by=/usr/share/keyrings/public.key] copy:/opt/repo/ /`,
+			},
+		},
+	},
+}
+
 func TestJammy(t *testing.T) {
 	t.Parallel()
 
@@ -31,35 +62,35 @@ func TestJammy(t *testing.T) {
 		},
 		Worker: workerConfig{
 			ContextName: jammy.JammyWorkerContextName,
+			// /pkg1.deb ...
 			CreateRepo: func(pkg llb.State, opts ...llb.StateOption) llb.StateOption {
 				repoFile := []byte(`
-deb [trusted=yes] copy:/opt/testrepo/ /
+deb [trusted=yes] copy:/opt/repo/ /
 `)
 				return func(in llb.State) llb.State {
-					repo := in.Run(
-						dalec.ShArgs("apt-get update && apt-get install -y apt-utils"),
+					withRepo := in.Run(
+						dalec.ShArgs("apt-get update && apt-get install -y apt-utils gnupg"),
 						dalec.WithMountedAptCache(jammy.AptCachePrefix),
-					).
+					).File(llb.Copy(pkg, "/", "/opt/repo")).
 						Run(
 							llb.Dir("/opt/repo"),
-							dalec.ShArgs("apt-ftparchive packages . | gzip -1 > Packages.gz"),
+							dalec.ShArgs("apt-ftparchive packages . > Packages"),
 						).
-						AddMount("/opt/repo", pkg)
+						Run(
+							llb.Dir("/opt/repo"),
+							dalec.ShArgs("apt-ftparchive release . > Release"),
+						).Root()
 
-					return in.
-						File(llb.Copy(repo, "/", "/opt/testrepo")).
-						File(llb.Mkfile("/etc/apt/sources.list.d/test-dalec-local-repo.list", 0o644, repoFile)).
-						// This file prevents installation of things like docs in ubuntu
-						// containers We don't want to exclude this because tests want to
-						// check things for docs in the build container. But we also don't
-						// want to remove this completely from the base worker image in the
-						// frontend because we usually don't want such things in the build
-						// environment. This is only needed because certain tests (which
-						// are using this customized builder image) are checking for files
-						// that are being excluded by this config file.
-						File(llb.Rm("/etc/dpkg/dpkg.cfg.d/excludes", llb.WithAllowNotFound(true)))
+					for _, opt := range opts {
+						withRepo = opt(withRepo)
+					}
+
+					return withRepo.
+						File(llb.Mkfile("/etc/apt/sources.list.d/test-dalec-local-repo.list", 0o644, repoFile))
 				}
 			},
+			SignRepo:       signRepoJammy,
+			TestRepoConfig: jammyTestRepoConfig,
 			Constraints: constraintsSymbols{
 				Equal:              "=",
 				GreaterThan:        ">>",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow up PR to #366. With this PR Dalec now accepts specifying dependencies from outside package repos on Jammy targets.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #211 

**Special notes for your reviewer**:
