### PR TITLE
jsonschema: ignore extension fields

### DIFF
--- a/cmd/gen-jsonschema/main.go
+++ b/cmd/gen-jsonschema/main.go
@@ -17,6 +17,10 @@ func main() {
 	}
 
 	schema := r.Reflect(&dalec.Spec{})
+	if schema.PatternProperties == nil {
+		schema.PatternProperties = make(map[string]*jsonschema.Schema)
+	}
+	schema.PatternProperties["^x-"] = &jsonschema.Schema{}
 
 	dt, err := json.MarshalIndent(schema, "", "\t")
 	if err != nil {

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -1250,5 +1250,8 @@
 			],
 			"description": "TestStep is a wrapper for [BuildStep] to include checks on stdio streams"
 		}
+	},
+	"patternProperties": {
+		"^x-": true
 	}
 }


### PR DESCRIPTION
`x-` fields are documented as fields we ignore, so make it so jsonschema validations ignore it as well.

example:

<img width="495" alt="image" src="https://github.com/user-attachments/assets/d20d93f5-5f9f-4911-9ba8-5762e40e8311">

