### PR TITLE
Fix custom repo test

### DIFF
--- a/frontend/jammy/handle_container.go
+++ b/frontend/jammy/handle_container.go
@@ -104,24 +104,8 @@ func buildImageRootfs(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts,
 	debug := llb.Scratch().File(llb.Mkfile("debug", 0o644, []byte(`debug=2`)), opts...)
 	opts = append(opts, dalec.ProgressGroup("Install spec package"))
 
-	script := llb.Scratch().File(
-		llb.Mkfile("install.sh", 0o755, []byte(`#!/usr/bin/env sh
-set -ex
-
-rm -f /var/lib/apt/lists/_*
-apt autoclean -y
-
-apt update
-apt install -y /tmp/pkg/*.deb
-		`)),
-		opts...,
-	)
-
-	p := "/tmp/dalec/internal/install/container.sh"
-
 	return baseImg.Run(
-		dalec.ShArgs(p),
-		llb.AddMount(p, script, llb.SourcePath("install.sh")),
+		installPackages([]string{"/tmp/pkg/*.deb"}, opts...),
 		customRepoOpts,
 		llb.AddEnv("DEBIAN_FRONTEND", "noninteractive"),
 		llb.AddMount("/tmp/pkg", deb, llb.Readonly),

--- a/frontend/jammy/handle_deb.go
+++ b/frontend/jammy/handle_deb.go
@@ -170,6 +170,11 @@ apt install -y `+strings.Join(ls, " ")+`
 
 func installWithConstraints(pkgPath string, pkgName string, opts ...llb.ConstraintsOpt) llb.RunOption {
 	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+		// The apt solver always tries to select the latest package version even when constraints specify that an older version should be installed and that older version is available in a repo.
+		// This leads the solver to simply refuse to install our target package if the latest version of ANY dependency package is incompatible with the constraints.
+		// To work around this we first install the .deb for the package with dpkg, specifically ignoring any dependencies so that we can avoid the constraints issue.
+		// We then use aptitude to fix the (possibly broken) install of the package, and we pass the aptitude solver a hint to REJECT any solution that involves uninstalling the package.
+		// This forces aptitude to find a solution that will respect the constraints even if the solution involves pinning dependency packages to older versions.
 		script := llb.Scratch().File(
 			llb.Mkfile("install.sh", 0o755, []byte(`#!/usr/bin/env sh
 set -ex
@@ -186,11 +191,6 @@ aptitude install -y -f -o "Aptitude::ProblemResolver::Hints::=reject `+pkgName+`
 `),
 			), opts...)
 
-		// The apt solver always tries to select the latest package version even when constraints specify that an older version should be installed and that older version is available in a repo.
-		// This leads the solver to simply refuse to install our target package if the latest version of ANY dependency package is incompatible with the constraints.
-		// To work around this we first install the .deb for the package with dpkg, specifically ignoring any dependencies so that we can avoid the constraints issue.
-		// We then use aptitude to fix the (possibly broken) install of the package, and we pass the aptitude solver a hint to REJECT any solution that involves uninstalling the package.
-		// This forces aptitude to find a solution that will respect the constraints even if the solution involves pinning dependency packages to older versions.
 		dalec.WithMountedAptCache(AptCachePrefix).SetRunOption(ei)
 
 		p := "/tmp/dalec/internal/deb/install-with-constraints.sh"

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -448,7 +448,7 @@ func testCustomWindowscrossWorker(ctx context.Context, t *testing.T, targetCfg t
 	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		// base package that will be used as a build dependency of the main package.
 		depSpec := &dalec.Spec{
-			Name:        "dalec-test-package",
+			Name:        "dalec-test-package-windows-worker-dep",
 			Version:     "0.0.1",
 			Revision:    "1",
 			Description: "A basic package for various testing uses",


### PR DESCRIPTION
A few fixes here:

1. Minor refactor on custom repo tests so that the proper `*testing.T` is being used. This fixes a problem with the test build not producing any logs making it hard to figure out what the error is.
2. Namespace dep package names per test so that we don't have 2 parallel tests using the same package name, potentially creating a race where the package is cached and re-used in the other test.
3. Remove cached repo data for local repos (e.g., ones created in /top/repo) to fix the case where a repo can appear to become unsigned causing apt to error out.