### PR TITLE
Add support for allowing network access during build

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -18,6 +18,14 @@
 					},
 					"type": "object",
 					"description": "Env is the list of environment variables to set for all commands in this step group."
+				},
+				"network_mode": {
+					"type": "string",
+					"enum": [
+						"none",
+						"sandbox"
+					],
+					"description": "NetworkMode sets the network mode to use during the build phase.\nAccepted values: none, sandbox\nDefault: none"
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/azlinux/handle_rpm.go
+++ b/frontend/azlinux/handle_rpm.go
@@ -240,8 +240,11 @@ func specToRpmLLB(ctx context.Context, w worker, client gwclient.Client, spec *d
 	if err != nil {
 		return llb.Scratch(), err
 	}
+
 	specPath := filepath.Join("SPECS", spec.Name, spec.Name+".spec")
-	st := rpm.Build(br, base, specPath, opts...)
+
+	builder := base.With(dalec.SetBuildNetworkMode(spec))
+	st := rpm.Build(br, builder, specPath, opts...)
 
 	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt)
 }

--- a/frontend/rpm/rpmbuild.go
+++ b/frontend/rpm/rpmbuild.go
@@ -33,7 +33,6 @@ func Build(topDir, workerImg llb.State, specPath string, opts ...llb.Constraints
 		llb.AddMount("/build/top", topDir),
 		llb.AddMount("/build/tmp", llb.Scratch(), llb.Tmpfs()),
 		llb.Dir("/build/top"),
-		llb.Network(llb.NetModeNone),
 		dalec.WithConstraints(opts...),
 	).
 		AddMount("/build/out", llb.Scratch())

--- a/frontend/windows/handle_zip.go
+++ b/frontend/windows/handle_zip.go
@@ -143,12 +143,12 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 	binaries := maps.Keys(spec.Artifacts.Binaries)
 	script := generateInvocationScript(binaries)
 
-	st := worker.Run(
+	builder := worker.With(dalec.SetBuildNetworkMode(spec))
+	st := builder.Run(
 		dalec.ShArgs(script.String()),
 		llb.Dir("/build"),
 		withSourcesMounted("/build", patched, spec.Sources),
 		llb.AddMount("/tmp/scripts", buildScript),
-		llb.Network(llb.NetModeNone),
 	).AddMount(outputDir, llb.Scratch())
 
 	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt)

--- a/spec.go
+++ b/spec.go
@@ -401,6 +401,11 @@ type ArtifactBuild struct {
 	Steps []BuildStep `yaml:"steps" json:"steps" jsonschema:"required"`
 	// Env is the list of environment variables to set for all commands in this step group.
 	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+
+	// NetworkMode sets the network mode to use during the build phase.
+	// Accepted values: none, sandbox
+	// Default: none
+	NetworkMode string `yaml:"network_mode,omitempty" json:"network_mode,omitempty" jsonschema:"enum=none,enum=sandbox"`
 }
 
 // BuildStep is used to execute a command to build the artifact(s).

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/dalec"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
+	"gotest.tools/v3/assert"
+)
+
+func testBuildNetworkMode(ctx context.Context, t *testing.T, cfg targetConfig) {
+	type testCase struct {
+		mode            string
+		canHazInternetz bool // :)
+	}
+
+	cases := []testCase{
+		{mode: "", canHazInternetz: false},
+		{mode: "none", canHazInternetz: false},
+		{mode: "sandbox", canHazInternetz: true},
+	}
+
+	for _, tc := range cases {
+		name := "mode=" + tc.mode
+		if tc.mode == "" {
+			name += "<unset>"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := startTestSpan(ctx, t)
+
+			spec := dalec.Spec{
+				Name:        "test-build-network-mode",
+				Version:     "0.0.1",
+				Revision:    "1",
+				License:     "MIT",
+				Website:     "https://github.com/azure/dalec",
+				Vendor:      "Dalec",
+				Packager:    "Dalec",
+				Description: "Should not have internet access during build",
+				Dependencies: &dalec.PackageDependencies{
+					Build: map[string]dalec.PackageConstraints{"curl": {}},
+				},
+				Build: dalec.ArtifactBuild{
+					NetworkMode: tc.mode,
+					Steps: []dalec.BuildStep{
+						{
+							Command: fmt.Sprintf("curl --head -ksSf %s > /dev/null", externalTestHost),
+						},
+						{
+							Command: "touch foo",
+						},
+					},
+				},
+				Artifacts: dalec.Artifacts{
+					// This is here so the windows can use this test
+					// Windows needs to have a non-empty output to suceeed.
+					Binaries: map[string]dalec.ArtifactConfig{"foo": {}},
+				},
+			}
+
+			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+				sr := newSolveRequest(withSpec(ctx, t, &spec), withBuildTarget(cfg.Package))
+
+				_, err := gwc.Solve(ctx, sr)
+				if tc.canHazInternetz {
+					assert.NilError(t, err)
+					return
+				}
+
+				var xErr *moby_buildkit_v1_frontend.ExitError
+				if !errors.As(err, &xErr) {
+					t.Fatalf("expected exit error, got %T: %v", errors.Unwrap(err), err)
+				}
+			})
+		})
+	}
+}

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -180,9 +180,14 @@ build:
 
 - `env`: The environment variables for the build.
 - `steps`: The build steps for the package.
+- `network_mode`: Set the network mode to use for build steps (accepts: empty, `none`, `sandbox`)
 
 :::tip
 TARGETOS is a built-in argument that Dalec will substitute with the target OS value. For more information, please see [Args section](#args-section).
+:::
+
+:::tip
+Set `network_mode` to `sandbox` to allow internet access during build
 :::
 
 ## Artifacts section


### PR DESCRIPTION
Adds a field `network_mode`. The value of this field can be any of:

- Unset
- "none" - Disable networking (default)
- "sandbox" - Networking enabled with its own network namespace

Buildkit supports `host` mode as well, but I have opted to not support that here for now.