### PR TITLE
Various improvements to testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,6 @@ jobs:
           go-version: '1.22'
           cache: false
 
-      - name: Expose GitHub tokens for caching
-        uses: crazy-max/ghaction-github-runtime@b3a9207c0e1ef41f4cf215303c976869d0c2c1c4 # v3.0.0
       - name: Setup jaeger
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,10 @@ jobs:
       - name: download deps
         run: go mod download
       - name: Run integration tests
-        run: go test -v -json ./test | go run ./cmd/test2json2gha
+        run: go test -v -json ./test | go run ./cmd/test2json2gha --slow 5s
       - name: dump logs
         if: failure()
         run: sudo journalctl -u docker
-
 
   unit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,29 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: '1.22'
           cache: false
 
+      - name: Configure dockerd
+        run: |
+          set -ex -o pipefail
+
+          docker ps -a
+          docker images
+
+          sudo mkdir -p /etc/docker
+          test ! -f /etc/docker/daemon.json && echo '{}' | sudo tee /etc/docker/daemon.json
+
+          tmp="$(mktemp)"
+          jq '.features["containerd-snapshotter"] = true' /etc/docker/daemon.json | tee "${tmp}"
+          sudo cp "${tmp}" /etc/docker/daemon.json
+          rm "${tmp}"
+
+          sudo systemctl restart docker
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup jaeger
         run: |
           set -e
@@ -104,7 +120,9 @@ jobs:
           echo "OTEL_SERVICE_NAME=dalec-integration-test" >> "${GITHUB_ENV}"
 
           tmp="$(mktemp)"
-          echo "Environment=\"OTEL_EXPORTER_OTLP_ENDPOINT=http://${docker0_ip}:4318\"" > "${tmp}"
+          echo "[Service]" > "${tmp}"
+          echo "Environment=\"OTEL_EXPORTER_OTLP_ENDPOINT=http://${docker0_ip}:4318\"" >> "${tmp}"
+
           sudo mkdir -p /etc/systemd/system/docker.service.d
           sudo mkdir -p /etc/systemd/system/containerd.service.d
           sudo cp "${tmp}" /etc/systemd/system/docker.service.d/otlp.conf
@@ -113,17 +131,6 @@ jobs:
           sudo systemctl daemon-reload
           sudo systemctl restart containerd
           sudo systemctl restart docker
-
-      # Tests currently require buildkit v0.12.0 or higher
-      # The version of buildkit builtin to moby currently (v24) is too old
-      # So we need to setup a custom builder.
-      - name: Set up builder
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.7.1
-        with:
-          driver-opts: |
-            network=host
-            env.OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
-            env.OTEL_SERVICE_NAME=buildkitd
 
       - name: download deps
         run: go mod download
@@ -150,7 +157,7 @@ jobs:
           mkdir -p /tmp/reports
           curl -sSLf localhost:16686/api/traces?service=${OTEL_SERVICE_NAME} > /tmp/reports/jaeger-tests.json
           curl -sSLf localhost:16686/api/traces?service=containerd > /tmp/reports/jaeger-containerd.json
-          curl -sSLf localhost:16686/api/traces?service=buildkitd > /tmp/reports/jaeger-buildkitd.json
+          curl -sSLf localhost:16686/api/traces?service=docker > /tmp/reports/jaeger-docker.json
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,26 @@ jobs:
             exit 1
           fi
 
-
   integration:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - Mariner2
+          - Azlinux3
+          - Bookworm
+          - Bullseye
+          - Bionic
+          - Focal
+          - Jammy
+          - Noble
+          - Windows
+          - other
+        include:
+          - suite: other
+            skip: Mariner2|Azlinux3|Bookworm|Bullseye|Bionic|Focal|Jammy|Noble|Windows
+
     # TODO: support diff/merge
     # Right now this is handled by the e2e suite, but we can migrate that here.
     steps:
@@ -105,13 +122,24 @@ jobs:
         with:
           driver-opts: |
             network=host
-            env.OTLP_EXPORTER_OPTELP_ENDPOINT=http://127.0.0.1:4318
+            env.OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
             env.OTEL_SERVICE_NAME=buildkitd
 
       - name: download deps
         run: go mod download
       - name: Run integration tests
-        run: go test -v -json ./test | go run ./cmd/test2json2gha --slow 5s
+        run: |
+          set -ex
+          if [ -n "${TEST_SUITE}" ] && [ ! "${TEST_SUITE}" = "other" ]; then
+            run="-run=${TEST_SUITE}"
+          fi
+          if [ -n "${TEST_SKIP}" ]; then
+            skip="-skip=${TEST_SKIP}"
+          fi
+          go test -timeout=30m -v -json ${run} ${skip} ./test | go run ./cmd/test2json2gha --slow 120s
+        env:
+          TEST_SUITE: ${{ matrix.suite }}
+          TEST_SKIP: ${{ matrix.skip }}
       - name: dump logs
         if: failure()
         run: sudo journalctl -u docker
@@ -127,7 +155,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-reports
+          name: integration-test-reports-${{matrix.suite}}
           path: /tmp/reports/*
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,36 @@ jobs:
 
       - name: Expose GitHub tokens for caching
         uses: crazy-max/ghaction-github-runtime@b3a9207c0e1ef41f4cf215303c976869d0c2c1c4 # v3.0.0
+      - name: Setup jaeger
+        run: |
+          set -e
+          docker run -d --net=host --restart=always --name jaeger -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:1.62.0
+          docker0_ip="$(ip -f inet addr show docker0 | grep -Po 'inet \K[\d.]+')"
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://${docker0_ip}:4318" >> "${GITHUB_ENV}"
+          echo "OTEL_SERVICE_NAME=dalec-integration-test" >> "${GITHUB_ENV}"
+
+          tmp="$(mktemp)"
+          echo "Environment=\"OTEL_EXPORTER_OTLP_ENDPOINT=http://${docker0_ip}:4318\"" > "${tmp}"
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          sudo mkdir -p /etc/systemd/system/containerd.service.d
+          sudo cp "${tmp}" /etc/systemd/system/docker.service.d/otlp.conf
+          sudo cp "${tmp}" /etc/systemd/system/containerd.service.d/otlp.conf
+
+          sudo systemctl daemon-reload
+          sudo systemctl restart containerd
+          sudo systemctl restart docker
+
       # Tests currently require buildkit v0.12.0 or higher
       # The version of buildkit builtin to moby currently (v24) is too old
       # So we need to setup a custom builder.
       - name: Set up builder
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.7.1
+        with:
+          driver-opts: |
+            network=host
+            env.OTLP_EXPORTER_OPTELP_ENDPOINT=http://127.0.0.1:4318
+            env.OTEL_SERVICE_NAME=buildkitd
+
       - name: download deps
         run: go mod download
       - name: Run integration tests
@@ -92,6 +117,22 @@ jobs:
       - name: dump logs
         if: failure()
         run: sudo journalctl -u docker
+      - name: Get traces
+        if: always()
+        run: |
+          set -ex
+          mkdir -p /tmp/reports
+          curl -sSLf localhost:16686/api/traces?service=${OTEL_SERVICE_NAME} > /tmp/reports/jaeger-tests.json
+          curl -sSLf localhost:16686/api/traces?service=containerd > /tmp/reports/jaeger-containerd.json
+          curl -sSLf localhost:16686/api/traces?service=buildkitd > /tmp/reports/jaeger-buildkitd.json
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: /tmp/reports/*
+          retention-days: 1
+
 
   unit:
     runs-on: ubuntu-22.04

--- a/cmd/test2json2gha/event.go
+++ b/cmd/test2json2gha/event.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// TestEvent is the go test2json event data structure we receive from `go test`
+// This is defined in https://pkg.go.dev/cmd/test2json#hdr-Output_Format
+type TestEvent struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+// TestResult is where we collect all the data about a test
+type TestResult struct {
+	output  *os.File
+	failed  bool
+	pkg     string
+	name    string
+	elapsed float64
+	skipped bool
+}
+
+func (r *TestResult) Close() {
+	r.output.Close()
+}
+
+func collectTestOutput(te *TestEvent, tr *TestResult) error {
+	if te.Output != "" {
+		_, err := tr.output.Write([]byte(te.Output))
+		if err != nil {
+			return errors.Wrap(err, "error collecting test event output")
+		}
+	}
+
+	tr.pkg = te.Package
+	tr.name = te.Test
+	if te.Elapsed > 0 {
+		tr.elapsed = te.Elapsed
+	}
+
+	if te.Action == "fail" {
+		tr.failed = true
+	}
+	if te.Action == "skip" {
+		tr.skipped = true
+	}
+	return nil
+}

--- a/cmd/test2json2gha/main.go
+++ b/cmd/test2json2gha/main.go
@@ -95,12 +95,6 @@ func do(in io.Reader, out io.Writer, modName string, slowThreshold time.Duration
 			return false, errors.WithStack(err)
 		}
 
-		if te.Test == "" {
-			// Don't bother processing events that aren't specifically for a test
-			// Go adds extra events in for package level info that we don't need.
-			continue
-		}
-
 		tr, err := getOutputStream()
 		if err != nil {
 			return false, err
@@ -139,6 +133,14 @@ func do(in io.Reader, out io.Writer, modName string, slowThreshold time.Duration
 
 		hist.Add(tr.elapsed)
 		elapsed += tr.elapsed
+
+		if tr.name == "" {
+			// Don't write generic package-level details unless its a failure
+			// since there is nothing interesting here.
+			if !tr.failed {
+				continue
+			}
+		}
 
 		if err := writeResult(tr, buf, failBuf, slowBuf, slow, modName); err != nil {
 			slog.Error("Error writing result", "error", err)

--- a/cmd/test2json2gha/markdown.go
+++ b/cmd/test2json2gha/markdown.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func mdBold(v string) string {
+	return "**" + v + "**"
+}
+
+func mdDetails(s string) string {
+	return fmt.Sprintf("\n<details>\n%s\n</details>\n", s)
+}
+
+func mdSummary(s string) string {
+	return "<summary>" + s + "</summary>\n"
+}
+
+func mdPreformat(s string) string {
+	return fmt.Sprintf("\n```\n%s\n```\n", s)
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func mdLog(head string, content fmt.Stringer) string {
+	sb := &strings.Builder{}
+	sb.WriteString(mdSummary(head))
+	sb.WriteString(mdPreformat(content.String()))
+	return mdDetails(sb.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/tonistiigi/fsutil v0.0.0-20241121093142-31cf1f437184
+	github.com/vearutop/dynhist-go v1.2.3
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/bool64/dev v0.2.28 h1:6ayDfrB/jnNr2iQAZHI+uT3Qi6rErSbJYQs1y8rSrwM=
+github.com/bool64/dev v0.2.28/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -175,6 +177,8 @@ github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Q
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
+github.com/vearutop/dynhist-go v1.2.3 h1:EIMWszSDm6b7zmqySgx8zW2qNctE3IXUJggGlDFwJBE=
+github.com/vearutop/dynhist-go v1.2.3/go.mod h1:liiiYiwAi8ixC3DbkxooEhASTF6ysJSXy+piCrBtxEg=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/load_test.go
+++ b/load_test.go
@@ -732,7 +732,7 @@ tests: &tests
         starts_with: ${SOME_ARG}
         ends_with: ${SOME_ARG}
     steps:
-      - command: ${SOME_ARG}
+      - command: hello
         stdout: *check-output
         stderr: *check-output
         stdin: ${SOME_ARG}
@@ -844,7 +844,6 @@ targets:
 		assert.Check(t, cmp.Equal(spec.Tests[0].Steps[0].Stderr.Contains[0], "test"))
 		assert.Check(t, cmp.Equal(spec.Tests[0].Steps[0].Stderr.StartsWith, "test"))
 		assert.Check(t, cmp.Equal(spec.Tests[0].Steps[0].Stderr.EndsWith, "test"))
-		assert.Check(t, cmp.Equal(spec.Tests[0].Steps[0].Command, "test"))
 
 		assert.Check(t, cmp.Equal(spec.PackageConfig.Signer.Args["FOO"], "test"))
 
@@ -873,7 +872,6 @@ targets:
 		assert.Check(t, cmp.Equal(target.Tests[0].Steps[0].Stderr.Contains[0], "test"))
 		assert.Check(t, cmp.Equal(target.Tests[0].Steps[0].Stderr.StartsWith, "test"))
 		assert.Check(t, cmp.Equal(target.Tests[0].Steps[0].Stderr.EndsWith, "test"))
-		assert.Check(t, cmp.Equal(target.Tests[0].Steps[0].Command, "test"))
 
 		assert.Check(t, cmp.Equal(target.Dependencies.ExtraRepos[0].Keys["img"].DockerImage.Cmd.Env["TEST"], "test"))
 		assert.Check(t, cmp.Equal(target.Dependencies.ExtraRepos[0].Keys["git"].Git.URL, "https://test"))

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -2136,7 +2136,7 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 							Command: "/bin/sh -c 'test -d /mount1'",
 						},
 						{
-							Command: `/bin/sh -c 'grep "some file" /mont1/some_file'`,
+							Command: `/bin/sh -c 'grep "some file" /mount1/some_file'`,
 						},
 						{
 							Command: "/bin/sh -c 'test -f /mount2'",

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -260,6 +260,8 @@ func (cfg *testLinuxConfig) GetPackage(name string) string {
 func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
 	t.Run("Fail when non-zero exit code during build", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
 		spec := dalec.Spec{
 			Name:        "test-build-commands-fail",
 			Version:     "0.0.1",
@@ -290,6 +292,9 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 	})
 
 	t.Run("container", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		const src2Patch3File = "patch3"
 		src2Patch3Content := []byte(`
 diff --git a/file3 b/file3
@@ -647,6 +652,8 @@ echo "$BAR" > bar.txt
 
 	t.Run("test systemd unit single", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-systemd-unit",
 			Description: "Test systemd unit",
@@ -770,6 +777,8 @@ WantedBy=multi-user.target
 
 	t.Run("test systemd unit multiple components", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-systemd-unit",
 			Description: "Test systemd unit",
@@ -884,6 +893,8 @@ Environment="FOO_ARGS=--some-foo-args"
 
 	t.Run("test systemd with only config dropin", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-systemd-unit",
 			Description: "Test systemd unit",
@@ -993,6 +1004,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 
 	t.Run("test directory creation", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-directory-creation",
 			Version:     "0.0.1",
@@ -1059,6 +1072,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 
 	t.Run("test data file installation", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-data-file-installation",
 			Version:     "0.0.1",
@@ -1151,6 +1166,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 
 	t.Run("test libexec file installation", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "libexec-test",
 			Version:     "0.0.1",
@@ -1255,6 +1272,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 
 	t.Run("test config files handled", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-config-files-work",
 			Version:     "0.0.1",
@@ -1314,6 +1333,8 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 
 	t.Run("docs and headers and licenses are handled correctly", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		spec := &dalec.Spec{
 			Name:        "test-docs-handled",
 			Version:     "0.0.1",
@@ -1486,9 +1507,7 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 	})
 
 	t.Run("custom repo", func(t *testing.T) {
-
 		t.Parallel()
-
 		ctx := startTestSpan(baseCtx, t)
 		testCustomRepo(ctx, t, testConfig.Worker, testConfig.Target)
 	})
@@ -1715,6 +1734,7 @@ func testPinnedBuildDeps(ctx context.Context, t *testing.T, cfg testLinuxConfig)
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := startTestSpan(baseCtx, t)
 
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				worker := getWorker(ctx, t, gwc)

--- a/test/fixtures/phony.go
+++ b/test/fixtures/phony.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	goModCache   = llb.AddMount("/go/pkg/mod", llb.Scratch(), llb.AsPersistentCacheDir("dalec-go-mod-cache", llb.CacheMountShared))
-	goBuildCache = llb.AddMount("/root/.cache/go-build", llb.Scratch(), llb.AsPersistentCacheDir("dalec-go-build-cache", llb.CacheMountShared))
+	goModCache   = llb.AddMount("/go/pkg/mod", llb.Scratch(), llb.AsPersistentCacheDir("/go/pkg/mod", llb.CacheMountShared))
+	goBuildCache = llb.AddMount("/root/.cache/go-build", llb.Scratch(), llb.AsPersistentCacheDir("/root/.cache/go-build", llb.CacheMountShared))
 )
 
 func PhonyFrontend(ctx context.Context, gwc gwclient.Client) (*gwclient.Result, error) {

--- a/test/fs_test.go
+++ b/test/fs_test.go
@@ -16,9 +16,12 @@ import (
 )
 
 func TestStateWrapper_ReadAt(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	st := llb.Scratch().File(llb.Mkfile("/foo", 0644, []byte("hello world")))
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -45,8 +48,11 @@ func TestStateWrapper_ReadAt(t *testing.T) {
 }
 
 func TestStateWrapper_OpenInvalidPath(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	st := llb.Scratch().File(llb.Mkfile("/bar", 0644, []byte("hello world")))
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -61,10 +67,13 @@ func TestStateWrapper_OpenInvalidPath(t *testing.T) {
 }
 
 func TestStateWrapper_Open(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	st := llb.Scratch().
 		File(llb.Mkfile("/foo", 0644, []byte("hello world")))
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		fs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -84,8 +93,11 @@ func TestStateWrapper_Open(t *testing.T) {
 }
 
 func TestStateWrapper_Stat(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	st := llb.Scratch().File(llb.Mkfile("/foo", 0755, []byte("contents")))
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -103,6 +115,9 @@ func TestStateWrapper_Stat(t *testing.T) {
 }
 
 func TestStateWrapper_ReadDir(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	st := llb.Scratch().File(llb.Mkdir("/bar", 0644)).
 		File(llb.Mkfile("/bar/foo", 0644, []byte("file contents"))).
 		File(llb.Mkdir("/bar/baz", 0644))
@@ -124,7 +139,7 @@ func TestStateWrapper_ReadDir(t *testing.T) {
 		},
 	}
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -148,6 +163,9 @@ func TestStateWrapper_ReadDir(t *testing.T) {
 }
 
 func TestStateWrapper_Walk(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	// create a simple test file structure like so:
 	/*
 		dir/
@@ -216,7 +234,7 @@ func TestStateWrapper_Walk(t *testing.T) {
 		},
 	}
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 		totalCalls := 0
@@ -259,6 +277,9 @@ func TestStateWrapper_Walk(t *testing.T) {
 }
 
 func TestStateWrapper_ReadPartial(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	contents := []byte(`
 		This is a
 		multiline
@@ -266,7 +287,7 @@ func TestStateWrapper_ReadPartial(t *testing.T) {
 	`)
 	st := llb.Scratch().File(llb.Mkfile("/foo", 0644, contents))
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 
@@ -308,6 +329,9 @@ func TestStateWrapper_ReadPartial(t *testing.T) {
 }
 
 func TestStateWrapper_ReadAll(t *testing.T) {
+	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
+
 	// purposefully exceed initial length of io.ReadAll buffer (512)
 	b := make([]byte, 520)
 	for i := 0; i < 520; i++ {
@@ -316,7 +340,7 @@ func TestStateWrapper_ReadAll(t *testing.T) {
 
 	st := llb.Scratch().File(llb.Mkfile("/file", 0644, b))
 
-	testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		rfs, err := bkfs.FromState(ctx, &st, gwc)
 		assert.Nil(t, err)
 

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -21,6 +21,8 @@ import (
 // TestHandlerTargetForwarding tests that targets are forwarded to the correct frontend.
 // We do this by registering a phony frontend and then forwarding a target to it and checking the outputs.
 func TestHandlerTargetForwarding(t *testing.T) {
+	t.Parallel()
+
 	runTest := func(t *testing.T, f testenv.TestFunc) {
 		t.Helper()
 		ctx := startTestSpan(baseCtx, t)
@@ -129,10 +131,12 @@ func TestHandlerTargetForwarding(t *testing.T) {
 
 func TestHandlerSubrequestResolve(t *testing.T) {
 	t.Parallel()
+	ctx := startTestSpan(baseCtx, t)
 
-	testPlatforms := func(t *testing.T, pls ...string) func(t *testing.T) {
+	testPlatforms := func(ctx context.Context, pls ...string) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
+			startTestSpan(ctx, t)
 
 			runTest(t, func(ctx context.Context, gwc gwclient.Client) {
 				spec := &dalec.Spec{
@@ -190,7 +194,7 @@ func TestHandlerSubrequestResolve(t *testing.T) {
 		}
 	}
 
-	t.Run("no platform", testPlatforms(t))
-	t.Run("single platform", testPlatforms(t, "linux/amd64"))
-	t.Run("multi-platform", testPlatforms(t, "linux/amd64", "linux/arm64"))
+	t.Run("no platform", testPlatforms(ctx))
+	t.Run("single platform", testPlatforms(ctx, "linux/amd64"))
+	t.Run("multi-platform", testPlatforms(ctx, "linux/amd64", "linux/arm64"))
 }

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -54,6 +54,9 @@ func newSimpleSpec() *dalec.Spec {
 
 func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
 		newSigningSpec := func() *dalec.Spec {
 			spec := newSimpleSpec()
 			spec.PackageConfig = &dalec.PackageConfig{
@@ -137,6 +140,8 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 		})
 
 		t.Run("with path build arg and build context", func(t *testing.T) {
+			t.Parallel()
+
 			spec := newSigningSpec()
 			spec.PackageConfig.Signer = nil
 
@@ -158,6 +163,8 @@ signer:
 		})
 
 		t.Run("path build arg takes precedence over spec config", func(t *testing.T) {
+			t.Parallel()
+
 			spec := newSigningSpec()
 			spec.PackageConfig.Signer.Frontend.Image = "notexist"
 
@@ -197,6 +204,8 @@ signer:
 		})
 
 		t.Run("with path build arg and build context", func(t *testing.T) {
+			t.Parallel()
+
 			spec := newSigningSpec()
 			spec.PackageConfig.Signer = nil
 
@@ -218,6 +227,8 @@ signer:
 		})
 
 		t.Run("with no build context and config path build arg", func(t *testing.T) {
+			t.Parallel()
+
 			spec := newSigningSpec()
 			spec.PackageConfig.Signer = nil
 
@@ -239,6 +250,8 @@ signer:
 		})
 
 		t.Run("local context with config path takes precedence over spec", func(t *testing.T) {
+			t.Parallel()
+
 			spec := newSigningSpec()
 			spec.PackageConfig.Signer.Frontend.Image = "notexist"
 
@@ -371,6 +384,7 @@ signer:
 }
 
 func windowsSigningTests(t *testing.T, tcfg targetConfig) {
+	t.Parallel()
 	runBuild := func(ctx context.Context, t *testing.T, gwc gwclient.Client, spec *dalec.Spec, srOpts ...srOpt) {
 		st := prepareWindowsSigningState(ctx, t, gwc, spec, srOpts...)
 
@@ -398,7 +412,6 @@ func windowsSigningTests(t *testing.T, tcfg targetConfig) {
 		slices.Sort(expectedFiles)
 		assert.Assert(t, cmp.DeepEqual(files, expectedFiles))
 	}
-
 	t.Run("target spec config", func(t *testing.T) {
 		t.Parallel()
 		runTest(t, func(ctx context.Context, gwc gwclient.Client) {

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -65,19 +65,26 @@ func TestSourceCmd(t *testing.T) {
 		}
 	}
 
-	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-		spec := testSpec()
-		req := newSolveRequest(withBuildTarget("debug/sources"), withSpec(ctx, t, spec))
-		res := solveT(ctx, t, gwc, req)
+	t.Run("base", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
 
-		checkFile(ctx, t, filepath.Join(sourceName, "foo"), res, []byte("foo bar\n"))
-		checkFile(ctx, t, filepath.Join(sourceName, "hello"), res, []byte("hello\n"))
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			spec := testSpec()
+			req := newSolveRequest(withBuildTarget("debug/sources"), withSpec(ctx, t, spec))
+			res := solveT(ctx, t, gwc, req)
+
+			checkFile(ctx, t, filepath.Join(sourceName, "foo"), res, []byte("foo bar\n"))
+			checkFile(ctx, t, filepath.Join(sourceName, "hello"), res, []byte("hello\n"))
+		})
 	})
 
 	t.Run("with mounted file", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(ctx, t)
 		t.Run("at root", func(t *testing.T) {
 			t.Parallel()
+			ctx := startTestSpan(ctx, t)
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				spec := testSpec()
 				spec.Sources[sourceName].DockerImage.Cmd.Steps = []*dalec.BuildStep{
@@ -109,6 +116,7 @@ func TestSourceCmd(t *testing.T) {
 		})
 		t.Run("nested", func(t *testing.T) {
 			t.Parallel()
+			ctx := startTestSpan(ctx, t)
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				spec := testSpec()
 				spec.Sources[sourceName].DockerImage.Cmd.Steps = []*dalec.BuildStep{
@@ -142,8 +150,10 @@ func TestSourceCmd(t *testing.T) {
 
 	t.Run("with mounted dir", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(ctx, t)
 		t.Run("at root", func(t *testing.T) {
 			t.Parallel()
+			ctx := startTestSpan(ctx, t)
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				spec := testSpec()
 				spec.Sources[sourceName].DockerImage.Cmd.Steps = []*dalec.BuildStep{
@@ -177,6 +187,7 @@ func TestSourceCmd(t *testing.T) {
 		})
 		t.Run("nested", func(t *testing.T) {
 			t.Parallel()
+			ctx := startTestSpan(ctx, t)
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				spec := testSpec()
 				spec.Sources[sourceName].DockerImage.Cmd.Steps = []*dalec.BuildStep{
@@ -245,6 +256,7 @@ func TestSourceBuild(t *testing.T) {
 	}
 
 	t.Run("inline", func(t *testing.T) {
+		t.Parallel()
 		fileSrc := func() dalec.Source {
 			return dalec.Source{
 				Inline: &dalec.SourceInline{
@@ -271,16 +283,19 @@ func TestSourceBuild(t *testing.T) {
 		}
 
 		t.Run("unspecified build file path", func(t *testing.T) {
+			t.Parallel()
 			doBuildTest(t, "file", newBuildSpec("", fileSrc))
 			doBuildTest(t, "dir", newBuildSpec("", dirSrc("Dockerfile")))
 		})
 
 		t.Run("Dockerfile as build file path", func(t *testing.T) {
+			t.Parallel()
 			doBuildTest(t, "file", newBuildSpec("Dockerfile", fileSrc))
 			doBuildTest(t, "dir", newBuildSpec("Dockerfile", dirSrc("Dockerfile")))
 		})
 
 		t.Run("non-standard build file path", func(t *testing.T) {
+			t.Parallel()
 			doBuildTest(t, "file", newBuildSpec("foo", fileSrc))
 			doBuildTest(t, "dir", newBuildSpec("foo", dirSrc("foo")))
 		})
@@ -477,6 +492,7 @@ index ea874f5..ba38f84 100644
 	})
 
 	t.Run("with patch", func(t *testing.T) {
+		t.Parallel()
 		t.Run("file", func(t *testing.T) {
 			t.Parallel()
 			testEnv.RunTest(baseCtx, t, func(ctx context.Context, gwc gwclient.Client) {

--- a/test/testenv/build.go
+++ b/test/testenv/build.go
@@ -1,6 +1,7 @@
 package testenv
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -154,33 +155,22 @@ func displaySolveStatus(ctx context.Context, t *testing.T) (chan *client.SolveSt
 		}
 		defer f.Close()
 
-		if !t.Failed() {
-			return
-		}
-
-		sz, _ := f.Seek(0, io.SeekEnd)
 		_, err = f.Seek(0, io.SeekStart)
 		if err != nil {
 			t.Log(err)
 			return
 		}
-		_, err = io.CopyN(&testWriter{t}, f, sz)
-		if err != nil {
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			t.Log(scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
 			t.Log(err)
-			return
 		}
 	}()
 
 	return ch, done
-}
-
-type testWriter struct {
-	t *testing.T
-}
-
-func (t *testWriter) Write(p []byte) (n int, err error) {
-	t.t.Log(string(p))
-	return len(p), nil
 }
 
 // withProjectRoot adds the current project root as the build context for the solve request.

--- a/test/testenv/buildkit.go
+++ b/test/testenv/buildkit.go
@@ -1,11 +1,8 @@
 package testenv
 
 import (
-	"fmt"
-	"os"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/moby/buildkit/client"
 )
@@ -63,52 +60,4 @@ func supportsFrontendAsInput(info *client.Info) bool {
 	}
 
 	return minor >= minVersion.Minor
-}
-
-// withGHCache adds the necessary cache export and import options to the solve request in order to use the GitHub Actions cache.
-// It uses the test name as a scope for the cache. Each test will have its own scope.
-// This means that caches are not shared between tests, but it also means that tests won't overwrite each other's cache.
-//
-// Github Actions sets some specific environment variables that we'll look for to even determine if we should configure the cache or not.
-//
-// This is effectively what `docker build --cache-from=gha,scope=foo --cache-to=gha,mode=max,scope=foo` would do.
-func withGHCache(t *testing.T, so *client.SolveOpt) {
-	if os.Getenv("GITHUB_ACTIONS") != "true" {
-		// This is not running in GitHub Actions, so we don't need to configure the cache.
-		return
-	}
-
-	// token and url are required for the cache to work.
-	// These need to be exposed as environment variables in the GitHub Actions workflow.
-	// See the crazy-max/ghaction-github-runtime@v3 action.
-	token := os.Getenv("ACTIONS_RUNTIME_TOKEN")
-	if token == "" {
-		fmt.Fprintln(os.Stderr, "::warning::GITHUB_ACTIONS_RUNTIME_TOKEN is not set, skipping cache export")
-		return
-	}
-
-	url := os.Getenv("ACTIONS_CACHE_URL")
-	if url == "" {
-		fmt.Fprintln(os.Stderr, "::warning::ACTIONS_CACHE_URL is not set, skipping cache export")
-		return
-	}
-
-	scope := "test-integration-" + t.Name()
-	so.CacheExports = append(so.CacheExports, client.CacheOptionsEntry{
-		Type: "gha",
-		Attrs: map[string]string{
-			"scope": scope,
-			"mode":  "max",
-			"token": token,
-			"url":   url,
-		},
-	})
-	so.CacheImports = append(so.CacheImports, client.CacheOptionsEntry{
-		Type: "gha",
-		Attrs: map[string]string{
-			"scope": scope,
-			"token": token,
-			"url":   url,
-		},
-	})
 }

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -290,7 +290,6 @@ func (b *BuildxEnv) RunTest(ctx context.Context, t *testing.T, f TestFunc, opts 
 
 	var so client.SolveOpt
 	withProjectRoot(t, &so)
-	withGHCache(t, &so)
 	withResolveLocal(&so)
 
 	_, err = c.Build(ctx, so, "", func(ctx context.Context, gwc gwclient.Client) (*gwclient.Result, error) {

--- a/test/var_passthrough_test.go
+++ b/test/var_passthrough_test.go
@@ -38,6 +38,8 @@ func getBuildPlatform(ctx context.Context, t *testing.T) *ocispecs.Platform {
 }
 
 func TestPassthroughVars(t *testing.T) {
+	t.Parallel()
+
 	runTest := func(t *testing.T, f testenv.TestFunc) {
 		t.Helper()
 		ctx := startTestSpan(baseCtx, t)

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -184,6 +184,8 @@ func testWindows(ctx context.Context, t *testing.T, tcfg targetConfig) {
 		})
 	})
 	t.Run("container", func(t *testing.T) {
+		t.Parallel()
+
 		spec := dalec.Spec{
 			Name:        "test-container-build",
 			Version:     "0.0.1",

--- a/tests.go
+++ b/tests.go
@@ -187,14 +187,6 @@ func (s *TestStep) processBuildArgs(lex *shell.Lex, args map[string]string, allo
 	}
 	s.Stderr = stderr
 
-	updated, err = expandArgs(lex, s.Command, args, allowArg)
-	if err != nil {
-		appendErr(errors.Wrap(err, "command"))
-	}
-	if updated != s.Command {
-		s.Command = updated
-	}
-
 	return goerrors.Join(errs...)
 }
 


### PR DESCRIPTION
- Add some missing `t.Parallal()` and `startTestSpan` calls
- Fix test log output to print line by line instead of per read
- Use the same cache keys for the main Dockerfile and the test fixtures
- Add test stats to GHA summary
- Get tracing reports from integration tests
- Remove GH cache since this wasn't really giving us anything, and maybe was even slowing things down
- ci: Fix issue reporting failures from test panic
- ci: Split integration tests per distro into separate jobs

Supersedes #482 
Fixes #476 