### PR TITLE
azlinux: include prebuilt-ca-certificates in image

### DIFF
--- a/frontend/azlinux/azlinux3.go
+++ b/frontend/azlinux/azlinux3.go
@@ -61,7 +61,7 @@ func (w azlinux3) Install(pkgs []string, opts ...installOpt) llb.RunOption {
 }
 
 func (w azlinux3) BasePackages() []string {
-	return []string{"distroless-packages-minimal"}
+	return []string{"distroless-packages-minimal", "prebuilt-ca-certificates"}
 }
 
 func (azlinux3) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {

--- a/frontend/azlinux/mariner2.go
+++ b/frontend/azlinux/mariner2.go
@@ -58,7 +58,7 @@ func (w mariner2) Install(pkgs []string, opts ...installOpt) llb.RunOption {
 }
 
 func (w mariner2) BasePackages() []string {
-	return []string{"distroless-packages-minimal"}
+	return []string{"distroless-packages-minimal", "prebuilt-ca-certificates"}
 }
 
 func (mariner2) DefaultImageConfig(ctx context.Context, resolver llb.ImageMetaResolver, platform *ocispecs.Platform) (*dalec.DockerImageSpec, error) {


### PR DESCRIPTION
Mistakenly thought this was part of the distroless minimal package but its not.

