### PR TITLE
Custom Repo Fixes

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -836,6 +836,10 @@
 				"digest": {
 					"type": "string",
 					"description": "Digest is the digest of the file to download.\nThis is used to verify the integrity of the file.\nForm: \u003calgorithm\u003e:\u003cdigest\u003e"
+				},
+				"permissions": {
+					"type": "integer",
+					"description": "Permissions is the octal file permissions to set on the file."
 				}
 			},
 			"additionalProperties": false,

--- a/frontend/azlinux/handle_container.go
+++ b/frontend/azlinux/handle_container.go
@@ -56,7 +56,7 @@ func specToContainerLLB(w worker, spec *dalec.Spec, targetKey string, rpmDir llb
 	}
 
 	installTimeRepos := spec.GetInstallRepos(targetKey)
-	importRepos, err := repoMountInstallOpts(w, builderImg, installTimeRepos, sOpt, opts...)
+	importRepos, err := repoMountInstallOpts(installTimeRepos, sOpt, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}

--- a/frontend/jammy/handle_container.go
+++ b/frontend/jammy/handle_container.go
@@ -90,7 +90,7 @@ func buildImageRootfs(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts,
 			AddMount(workPath, in)
 	}
 
-	customRepoOpts, err := customRepoMounts(worker, spec.GetInstallRepos(targetKey), sOpt, opts...)
+	customRepoOpts, err := customRepoMounts(spec.GetInstallRepos(targetKey), sOpt, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}
@@ -131,13 +131,13 @@ func buildImageRootfs(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts,
 		With(installSymlinks), nil
 }
 
-func installTestDeps(worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.StateOption, error) {
+func installTestDeps(spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.StateOption, error) {
 	deps := spec.GetTestDeps(targetKey)
 	if len(deps) == 0 {
 		return func(s llb.State) llb.State { return s }, nil
 	}
 
-	extraRepoOpts, err := customRepoMounts(worker, spec.GetTestRepos(targetKey), sOpt, opts...)
+	extraRepoOpts, err := customRepoMounts(spec.GetTestRepos(targetKey), sOpt, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/jammy/handle_deb.go
+++ b/frontend/jammy/handle_deb.go
@@ -120,14 +120,14 @@ func runTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOp
 	return ref, err
 }
 
-var RepoPlatform = dalec.RepoPlatformConfig{
+var jammyRepoPlatform = dalec.RepoPlatformConfig{
 	ConfigRoot: "/etc/apt/sources.list.d",
 	GPGKeyRoot: "/usr/share/keyrings",
 	ConfigExt:  ".list",
 }
 
 func customRepoMounts(repos []dalec.PackageRepositoryConfig, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.RunOption, error) {
-	withRepos, err := dalec.WithRepoConfigs(repos, &RepoPlatform, sOpt, opts...)
+	withRepos, err := dalec.WithRepoConfigs(repos, &jammyRepoPlatform, sOpt, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func customRepoMounts(repos []dalec.PackageRepositoryConfig, sOpt dalec.SourceOp
 		return nil, err
 	}
 
-	keyMounts, _, err := dalec.GetRepoKeys(repos, &RepoPlatform, sOpt, opts...)
+	keyMounts, _, err := dalec.GetRepoKeys(repos, &jammyRepoPlatform, sOpt, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,6 @@ apt autoclean -y
 
 dpkg -i --force-depends `+pkgPath+`
 
-ls -lrt /usr/share/keyrings
 apt update
 aptitude install -y -f -o "Aptitude::ProblemResolver::Hints::=reject `+pkgName+` :UNINST"
 `),

--- a/frontend/windows/handle_zip.go
+++ b/frontend/windows/handle_zip.go
@@ -117,7 +117,7 @@ func installBuildDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string)
 				return in, errors.Wrap(err, "error creating intermediate package for installing build dependencies")
 			}
 
-			customRepoOpts, err := customRepoMounts(in, spec.GetBuildRepos(targetKey), sOpt, opts...)
+			customRepoOpts, err := customRepoMounts(spec.GetBuildRepos(targetKey), sOpt, opts...)
 			if err != nil {
 				return in, err
 			}
@@ -315,13 +315,7 @@ var jammyRepoPlatformCfg = dalec.RepoPlatformConfig{
 	GPGKeyRoot: "/usr/share/keyrings",
 }
 
-func customRepoMounts(worker llb.State, repos []dalec.PackageRepositoryConfig, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.RunOption, error) {
-	worker = worker.Run(
-		dalec.ShArgs("apt update && apt install -y gnupg2"),
-		dalec.WithMountedAptCache(aptCachePrefix),
-		dalec.WithConstraints(opts...),
-	).Root() // make sure we have gpg installed
-
+func customRepoMounts(repos []dalec.PackageRepositoryConfig, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) (llb.RunOption, error) {
 	withRepos, err := dalec.WithRepoConfigs(repos, &jammyRepoPlatformCfg, sOpt, opts...)
 	if err != nil {
 		return nil, err
@@ -332,7 +326,7 @@ func customRepoMounts(worker llb.State, repos []dalec.PackageRepositoryConfig, s
 		return nil, err
 	}
 
-	keyMounts, _, err := dalec.GetRepoKeys(worker, repos, &jammyRepoPlatformCfg, sOpt, opts...)
+	keyMounts, _, err := dalec.GetRepoKeys(repos, &jammyRepoPlatformCfg, sOpt, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/load.go
+++ b/load.go
@@ -489,7 +489,6 @@ func fillExtraRepoDefaults(extraRepo *PackageRepositoryConfig) {
 	for _, mount := range extraRepo.Data {
 		fillDefaults(&mount.Spec)
 	}
-
 }
 
 func (s Spec) Validate() error {

--- a/load.go
+++ b/load.go
@@ -454,8 +454,10 @@ func (s *Spec) FillDefaults() {
 		}
 	}
 
-	for i := range len(s.Dependencies.ExtraRepos) {
-		fillExtraRepoDefaults(&s.Dependencies.ExtraRepos[i])
+	if s.Dependencies != nil {
+		for i := range len(s.Dependencies.ExtraRepos) {
+			fillExtraRepoDefaults(&s.Dependencies.ExtraRepos[i])
+		}
 	}
 }
 
@@ -474,6 +476,13 @@ func fillExtraRepoDefaults(extraRepo *PackageRepositoryConfig) {
 	for keyName := range extraRepo.Keys {
 		keySource := extraRepo.Keys[keyName]
 		fillDefaults(&keySource)
+
+		// Default to 0644 permissions for gpg keys. This is because apt will will only import
+		// keys with a particular permission set.
+		if keySource.HTTP != nil {
+			keySource.HTTP.Permissions = 0644
+		}
+
 		extraRepo.Keys[keyName] = keySource
 	}
 

--- a/load.go
+++ b/load.go
@@ -453,6 +453,34 @@ func (s *Spec) FillDefaults() {
 			s.Patches[k][i].Strip = &strip
 		}
 	}
+
+	for i := range len(s.Dependencies.ExtraRepos) {
+		fillExtraRepoDefaults(&s.Dependencies.ExtraRepos[i])
+	}
+}
+
+func fillExtraRepoDefaults(extraRepo *PackageRepositoryConfig) {
+	if len(extraRepo.Envs) == 0 {
+		// default to all stages for the extra repo if unspecified
+		extraRepo.Envs = []string{"build", "install", "test"}
+	}
+
+	for configName := range extraRepo.Config {
+		configSource := extraRepo.Config[configName]
+		fillDefaults(&configSource)
+		extraRepo.Config[configName] = configSource
+	}
+
+	for keyName := range extraRepo.Keys {
+		keySource := extraRepo.Keys[keyName]
+		fillDefaults(&keySource)
+		extraRepo.Keys[keyName] = keySource
+	}
+
+	for _, mount := range extraRepo.Data {
+		fillDefaults(&mount.Spec)
+	}
+
 }
 
 func (s Spec) Validate() error {

--- a/load_test.go
+++ b/load_test.go
@@ -629,6 +629,9 @@ dependencies:
 	}
 
 	err = spec.SubstituteArgs(map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	extraRepo := spec.Dependencies.ExtraRepos[0]
 	assert.Equal(t, extraRepo.Config["custom.repo"].Context.Name,

--- a/source.go
+++ b/source.go
@@ -164,6 +164,11 @@ func (src *SourceHTTP) AsState(name string, opts ...llb.ConstraintsOpt) (llb.Sta
 	if src.Digest != "" {
 		httpOpts = append(httpOpts, llb.Checksum(src.Digest))
 	}
+
+	if src.Permissions != 0 {
+		httpOpts = append(httpOpts, llb.Chmod(src.Permissions))
+	}
+
 	st := llb.HTTP(src.URL, httpOpts...)
 	return st, nil
 }

--- a/spec.go
+++ b/spec.go
@@ -197,6 +197,8 @@ type SourceHTTP struct {
 	// This is used to verify the integrity of the file.
 	// Form: <algorithm>:<digest>
 	Digest digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
+	// Permissions is the octal file permissions to set on the file.
+	Permissions fs.FileMode `yaml:"permissions,omitempty" json:"permissions,omitempty"`
 }
 
 // SourceContext is used to generate a source from a build context. The path to

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -28,21 +28,23 @@ var azlinuxConstraints = constraintsSymbols{
 	LessThanOrEqual:    "<=",
 }
 
-var azlinuxTestRepoConfig = map[string]dalec.Source{
-	"local.repo": {
-		Inline: &dalec.SourceInline{
-			File: &dalec.SourceInlineFile{
-				Contents: `[Local]
+var azlinuxTestRepoConfig = func(keyPath string) map[string]dalec.Source {
+	return map[string]dalec.Source{
+		"local.repo": {
+			Inline: &dalec.SourceInline{
+				File: &dalec.SourceInlineFile{
+					Contents: fmt.Sprintf(`[Local]
 name=Local Repository
 baseurl=file:///opt/repo
 repo_gpgcheck=1
 priority=0
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/public.key
-	`,
+gpgkey=file:///etc/pki/rpm-gpg/%s
+	`, keyPath),
+				},
 			},
 		},
-	},
+	}
 }
 
 func TestMariner2(t *testing.T) {
@@ -169,7 +171,7 @@ type workerConfig struct {
 	// ContextName is the name of the worker context that the build target will use
 	// to see if a custom worker is proivded in a context
 	ContextName    string
-	TestRepoConfig map[string]dalec.Source
+	TestRepoConfig func(string) map[string]dalec.Source
 	Constraints    constraintsSymbols
 	Platform       *ocispecs.Platform
 }

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -205,7 +205,6 @@ type testLinuxConfig struct {
 		Units   string
 		Targets string
 	}
-
 	Worker  workerConfig
 	Release OSRelease
 }

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -205,6 +205,7 @@ type testLinuxConfig struct {
 		Units   string
 		Targets string
 	}
+
 	Worker  workerConfig
 	Release OSRelease
 }

--- a/test/custom_repo_test.go
+++ b/test/custom_repo_test.go
@@ -165,13 +165,14 @@ func testCustomRepo(ctx context.Context, t *testing.T, workerCfg workerConfig, t
 			depSpec := getDepSpec("with-public-key")
 			repoState := getRepoState(ctx, t, gwc, w, gpgKey, depSpec)
 
+			keyName := "public.asc"
 			spec := getSpec(depSpec, map[string]dalec.Source{
 				// in the dalec spec, the public key will be passed in via build context
-				"public.key": {
+				keyName: {
 					Context: &dalec.SourceContext{
 						Name: "repo-public-key",
 					},
-					Path: "public.key",
+					Path: "public.asc",
 				},
 			})
 
@@ -211,7 +212,7 @@ Expire-Date: 0
 %commit
 EOF
 		`), pg).
-		Run(dalec.ShArgs("gpg --export --armor test@example.com > /tmp/gpg/public.key; gpg --export-secret-keys --armor test@example.com > /tmp/gpg/private.key"), pg).
+		Run(dalec.ShArgs("gpg --export --armor test@example.com > /tmp/gpg/public.asc; gpg --export-secret-keys --armor test@example.com > /tmp/gpg/private.key"), pg).
 		AddMount("/tmp/gpg", llb.Scratch())
 
 	return st

--- a/test/custom_repo_test.go
+++ b/test/custom_repo_test.go
@@ -123,7 +123,7 @@ func testCustomRepo(ctx context.Context, t *testing.T, workerCfg workerConfig, t
 
 	t.Run("no public key", func(t *testing.T) {
 		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
+		ctx := startTestSpan(ctx, t)
 
 		testNoPublicKey := func(ctx context.Context, gwc gwclient.Client) {
 			sr := newSolveRequest(withBuildTarget(targetCfg.Worker), withSpec(ctx, t, nil))
@@ -153,7 +153,7 @@ func testCustomRepo(ctx context.Context, t *testing.T, workerCfg workerConfig, t
 
 	t.Run("with public key", func(t *testing.T) {
 		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
+		ctx := startTestSpan(ctx, t)
 
 		testWithPublicKey := func(ctx context.Context, gwc gwclient.Client) {
 			sr := newSolveRequest(withBuildTarget(targetCfg.Worker), withSpec(ctx, t, nil))

--- a/test/jammy_test.go
+++ b/test/jammy_test.go
@@ -14,7 +14,6 @@ func signRepoJammy(gpgKey llb.State) llb.StateOption {
 		// assuming in is the state that has the repo files under / including
 		// Release file
 		return in.Run(
-			dalec.ShArgs("gpg --import < /tmp/gpg/public.key"),
 			dalec.ShArgs("gpg --import < /tmp/gpg/private.key"),
 			llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
 			dalec.ProgressGroup("Importing gpg key")).
@@ -33,7 +32,7 @@ var jammyTestRepoConfig = map[string]dalec.Source{
 	"local.list": {
 		Inline: &dalec.SourceInline{
 			File: &dalec.SourceInlineFile{
-				Contents: `deb [signed-by=/usr/share/keyrings/public.key] copy:/opt/repo/ /`,
+				Contents: `deb [signed-by=/usr/share/keyrings/public.asc] copy:/opt/repo/ /`,
 			},
 		},
 	},

--- a/test/jammy_test.go
+++ b/test/jammy_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Azure/dalec"
@@ -28,14 +29,16 @@ func signRepoJammy(gpgKey llb.State) llb.StateOption {
 	}
 }
 
-var jammyTestRepoConfig = map[string]dalec.Source{
-	"local.list": {
-		Inline: &dalec.SourceInline{
-			File: &dalec.SourceInlineFile{
-				Contents: `deb [signed-by=/usr/share/keyrings/public.asc] copy:/opt/repo/ /`,
+var jammyTestRepoConfig = func(name string) map[string]dalec.Source {
+	return map[string]dalec.Source{
+		"local.list": {
+			Inline: &dalec.SourceInline{
+				File: &dalec.SourceInlineFile{
+					Contents: fmt.Sprintf(`deb [signed-by=/usr/share/keyrings/%s] copy:/opt/repo/ /`, name),
+				},
 			},
 		},
-	},
+	}
 }
 
 func TestJammy(t *testing.T) {

--- a/website/docs/examples/repos/msft-ubuntu.yml.md
+++ b/website/docs/examples/repos/msft-ubuntu.yml.md
@@ -8,7 +8,9 @@ dependencies:
     msft-golang:
   extra_repos:
     - keys:
-        msft.gpg: # Note: This must currently use a `.gpg` suffix or apt will not be happy
+       # Note: The name for the key must use the proper `.gpg` (binary) or `.asc` (ascii)
+       # extension, or apt will not be able to import the key properly
+        msft.asc:          
           http:
             url: https://packages.microsoft.com/keys/microsoft.asc
             digest: sha256:2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa
@@ -16,8 +18,8 @@ dependencies:
         microsoft-prod.list:
           inline:
             file:
-              # Note the `signed-by` path is always going to be `/usr/share/keyrings/<source key name>` for Ubuntu, in this case our source key name is `msft.gpg`
-              contents: deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/msft.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
+              # Note the `signed-by` path is always going to be `/usr/share/keyrings/<source key name>` for Ubuntu, in this case our source key name is `msft.asc`
+              contents: deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/msft.asc] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
       envs:
         # The repository will only be available when installing build dependencies
         - build

--- a/website/docs/repositories.md
+++ b/website/docs/repositories.md
@@ -14,7 +14,7 @@ structure:
   A map of keys required to enable the configured repositories. Each key in
   this map is associated with a specific source and must be imported to allow
   the repositories to function as expected. The content of this is a
-  [source](sources.md) just like in the sources section.
+  [source](sources.md) just like in the sources section. 
 
 - **`config`**
   A collection of repository configurations to add to the environment. The
@@ -42,6 +42,11 @@ structure:
     container build target.
 
 These configurations are highly distribution specific.
+
+:::tip
+Be careful to name the key files properly depending on whether they are ascii armored (`*.asc`) or binary (`*.gpg`). 
+Some package managers such as `apt` do not handle keys properly if they are not named with the correct extension.
+:::
 
 ### Examples:
 

--- a/website/docs/sources.md
+++ b/website/docs/sources.md
@@ -97,18 +97,23 @@ by the client, not the actual secret values.
 
 ### HTTP
 
-HTTP sources fetch a file from an HTTP URL.
-HTTP content is not verified by digest today, but it is in the roadmap.
+HTTP sources fetch a file from an HTTP URL. The HTTP source type is considered to be a "file" source. 
+
+The fetched file can be verified against a digest
+if one is supplied. There is also a `permissions` field that can set the octal permissions
+of the fetched file.
 
 ```yaml
 sources:
   someSource1:
     http:
-      # No Digest verification
       url: https://example.com/someFile.txt
+      # optional digest field
+      digest: sha256:1234567890abcdef
+      # optional permissions field
+      permissions: 0644
 ```
 
-The HTTP source type is considered to be a "file" source.
 
 ### Build context
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a few fixes for the custom repos feature. 

1. Adds code to fill defaults in the extra_repos section of the spec.
3. Adds a `permissions` field to the http source. This allows us to fill in the permissions by default if they are on an http source that is nested under a key. It is important that fetched gpg keys have the proper permissions, otherwise apt cannot import them properly. Assuming that they do have proper permissions, apt can handle both `.asc` and `.gpg` keys just fine. This makes the explicit de-armor step unnecessary and means we no longer need gpg as a dependency in the jammy worker images.
4. Adds armored and de-armored key test variants to the custom repo tests to ensure everything is working properly. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #425

**Special notes for your reviewer**:
