### PR TITLE
Set image create

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,9 +100,9 @@ target "runc-jammy" {
     }
     target = tgt == "container" ? "jammy/testing/${tgt}" : "jammy/${tgt}"
     // only tag the container target
-    tags = tgt == "testing/container" ? ["runc:jammy"] : []
+    tags = tgt == "container" ? ["runc:jammy"] : []
     // only output non-container targets to the fs
-    output = tgt != "testing/container" ? ["_output"] : []
+    output = tgt != "container" ? ["_output"] : []
 
     cache-from = ["type=gha,scope=dalec/runc/jammy/${tgt}"]
     cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/runc/jammy/${tgt},mode=max"] : []

--- a/frontend/build.go
+++ b/frontend/build.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/dalec"
 	"github.com/containerd/platforms"
@@ -88,6 +89,10 @@ func BuildWithPlatform(ctx context.Context, client gwclient.Client, f PlatformBu
 		targetKey := GetTargetKey(dc)
 
 		ref, cfg, err := f(ctx, client, platform, spec, targetKey)
+		if cfg != nil {
+			now := time.Now()
+			cfg.Created = &now
+		}
 		return ref, cfg, nil, err
 	})
 	if err != nil {


### PR DESCRIPTION
Set image config created time

Before this was just using whatever created time was set on the base
image config which was incorrect.

Example using the `docker buildx bake runc-jammy-container` command:

Before:

	docker image ls | grep runc
	runc                                          jammy             8d1d42e074f3   25 minutes ago   228MB

After:

	docker image ls | grep runc
	runc                                          jammy             03c24620c8fa   5 seconds ago    228MB


**Note**: how the created time before was 25mins ago (b/c apparently the base
jammy image was recently updated, I've seen this be 2 weeks) compared to
after its 5 seconds ago.
