### PR TITLE
Fix issue mounting files

### DIFF
--- a/source.go
+++ b/source.go
@@ -307,7 +307,7 @@ func generateSourceFromImage(st llb.State, cmd *Command, sOpts SourceOpts, subPa
 			return llb.Scratch(), err
 		}
 
-		srcSt, err := src.Spec.AsMount(src.Dest, sOpts, opts...)
+		srcSt, err := src.Spec.AsMount(internalMountSourceName, sOpts, opts...)
 		if err != nil {
 			return llb.Scratch(), err
 		}
@@ -322,7 +322,7 @@ func generateSourceFromImage(st llb.State, cmd *Command, sOpts SourceOpts, subPa
 		}
 
 		if !SourceIsDir(src.Spec) {
-			mountOpt = append(mountOpt, llb.SourcePath(src.Dest))
+			mountOpt = append(mountOpt, llb.SourcePath(internalMountSourceName))
 		}
 		baseRunOpts = append(baseRunOpts, llb.AddMount(src.Dest, srcSt, mountOpt...))
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -324,7 +324,7 @@ func TestSourceDockerImage(t *testing.T) {
 			src.DockerImage = &img
 
 			ops := getSourceOp(ctx, t, src)
-			fileMountCheck := []expectMount{{dest: "/filedest", selector: "/filedest", typ: pb.MountType_BIND}}
+			fileMountCheck := []expectMount{{dest: "/filedest", selector: internalMountSourceName, typ: pb.MountType_BIND}}
 			checkCmd(t, ops[2:], &src, [][]expectMount{noMountCheck, fileMountCheck})
 		})
 
@@ -985,6 +985,7 @@ func mountMatches(gotMount *pb.Mount, wantMount expectMount) bool {
 }
 
 func checkContainsMount(t *testing.T, mounts []*pb.Mount, expect expectMount) {
+	t.Helper()
 	for _, mnt := range mounts {
 		if mountMatches(mnt, expect) {
 			return

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -481,6 +481,77 @@ echo "$BAR" > bar.txt
 
 			Tests: []*dalec.TestSpec{
 				{
+					Name: "Verify source mounts work",
+					Mounts: []dalec.SourceMount{
+						{
+							Dest: "/foo",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: "hello world",
+									},
+								},
+							},
+						},
+						{
+							Dest: "/nested/foo",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: "hello world nested",
+									},
+								},
+							},
+						},
+						{
+							Dest: "/dir",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									Dir: &dalec.SourceInlineDir{
+										Files: map[string]*dalec.SourceInlineFile{
+											"foo": {Contents: "hello from dir"},
+										},
+									},
+								},
+							},
+						},
+						{
+							Dest: "/nested/dir",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									Dir: &dalec.SourceInlineDir{
+										Files: map[string]*dalec.SourceInlineFile{
+											"foo": {Contents: "hello from nested dir"},
+										},
+									},
+								},
+							},
+						},
+					},
+					Steps: []dalec.TestStep{
+						{
+							Command: "/bin/sh -c 'cat /foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello world"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /nested/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello world nested"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /dir/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello from dir"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /nested/dir/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello from nested dir"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+					},
+				},
+				{
 					Name: "Check that the binary artifacts execute and provide the expected output",
 					Steps: []dalec.TestStep{
 						{


### PR DESCRIPTION
Mounts were using the destination path as the source name when generating a source, this made it so mounts would only work correctly if mounted at the root of the filesystem since source names generally should not have path separators.

Fixes #459 