### PR TITLE
feat: Add debugging setup for vscode

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,37 @@
+FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.22@sha256:9e5243001d0f43d6e1c556a0ce8eedc1bc80eb37b5210036b289d2c601bc08b6 AS go
+FROM scratch AS dlv-ctx
+
+FROM go  AS frontend-build
+ARG HOSTDIR
+WORKDIR ${HOSTDIR}
+COPY . .
+ENV CGO_ENABLED=0
+ARG TARGETARCH TARGETOS GOFLAGS=-trimpath
+ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=${GOFLAGS}
+RUN \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags=debug -gcflags="all=-N -l" -o /frontend ./cmd/frontend && \
+    go build -o /dalec-redirectio ./cmd/dalec-redirectio
+
+FROM go AS dlv-build
+ARG HOSTDIR
+WORKDIR /dlv
+ADD https://github.com/go-delve/delve.git#v1.23.1 .
+ENV CGO_ENABLED=0
+ARG TARGETARCH TARGETOS GOFLAGS=-trimpath
+ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=${GOFLAGS}
+RUN \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make build
+
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS frontend
+ARG HOSTDIR
+COPY . ${HOSTDIR}
+COPY --from=frontend-build /frontend /frontend
+COPY --from=frontend-build /dalec-redirectio /dalec-redirectio
+COPY --from=dlv-build /dlv/dlv /usr/local/bin/dlv
+LABEL moby.buildkit.frontend.network.none="true"
+LABEL moby.buildkit.frontend.caps="moby.buildkit.frontend.inputs,moby.buildkit.frontend.subrequests,moby.buildkit.frontend.contexts"
+ENTRYPOINT ["/frontend"]

--- a/cmd/frontend/debug.go
+++ b/cmd/frontend/debug.go
@@ -1,0 +1,43 @@
+//go:build debug
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func waitForDebug(ctx context.Context) error {
+	pid := fmt.Sprintf("%d", syscall.Getpid())
+	cmd := exec.Command(
+		"dlv",
+		"attach",
+		"--api-version=2",
+		"--headless",
+		"--listen=unix:/dlv.sock",
+		"--allow-non-terminal-interactive",
+		pid,
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			panic(err)
+		}
+	}()
+
+	s, cancel := signal.NotifyContext(ctx, syscall.SIGCONT)
+	defer cancel()
+	<-s.Done()
+
+	return nil
+}

--- a/cmd/frontend/no_debug.go
+++ b/cmd/frontend/no_debug.go
@@ -1,0 +1,9 @@
+//go:build !debug
+
+package main
+
+import "context"
+
+func waitForDebug(ctx context.Context) error {
+	return nil
+}

--- a/debug/debug.sh
+++ b/debug/debug.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [ -z "$(command -v socat)" ]; then
+    echo you must have "'socat'" installed
+    exit 1
+fi
+
+if [ -z "$(command -v pgrep)" ]; then
+    echo you must have "'pgrep'" installed
+    exit 1
+fi
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${PROJECT_DIR}"
+
+# Build frontend with debugging setup Note the host path for the dalec source
+# and the in-container build path must be the same
+REF="local/dalec/frontend:tmp"
+docker build \
+    -f Dockerfile.debug \
+    -t "${REF}" \
+    --build-arg=HOSTDIR="${PROJECT_DIR}" \
+    .
+
+# Wait for frontend process to start, and forward the socket connection when the process has started
+(
+    pid=""
+    while [ -z "$pid" ]; do
+        sleep 0.5
+        pid="$(pgrep frontend)"
+    done
+
+    socat_logfile="$(mktemp)"
+    socat -v UNIX:"/proc/${pid}/root/dlv.sock" TCP-LISTEN:30157,reuseaddr,fork 2>"$socat_logfile" &
+    scatpid="$!"
+    trap "kill -9 ${scatpid}" EXIT
+
+    # Detect when vs code has connected, then send the CONT signal to the frontend
+    txt=""
+    while [ -z "$txt" ]; do
+        sleep 0.5
+        if ! [ -f "$socat_logfile" ]; then
+            continue
+        fi
+        txt="$(head -n1 "$socat_logfile")"
+    done
+
+    kill -s CONT "$pid"
+    wait "$scatpid"
+) &
+
+# Run the build
+exec docker build --build-arg=BUILDKIT_SYNTAX="${REF}" "$@"


### PR DESCRIPTION
In order to use the debugger, you should Run any build as usual, but use substitute `debug/debug.sh` for `docker` in a docker invocation. The script uses `pgrep` and `socat`, as such they are required to run the script. Example:

```
./debug/debug.sh -f /tmp/moby-runc.yml --target=azlinux3/container --output=type=docker,name=hello:world .
```

Then, connect to the debugging setup using this `launch.json` config in vscode. You need the go plugin installed:

```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Connect to server",
            "type": "go",
            "request": "attach",
            "mode": "remote",
            "port": 30157,
            "host": "127.0.0.1",
            "apiVersion": 2
        }
    ]
}
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
