### PR TITLE
apt: fix potential issue from prior build errors in cache

### DIFF
--- a/frontend/deb/distro/install.go
+++ b/frontend/deb/distro/install.go
@@ -26,6 +26,9 @@ set -ex
 rm -f /var/lib/apt/lists/_*
 apt autoclean -y
 
+# Remove any previously failed attempts to get repo data
+rm -rf /var/lib/apt/lists/partial/*
+
 apt update
 apt install -y "$@"
 `
@@ -73,6 +76,8 @@ set -ex
 rm -f /var/lib/apt/lists/_*
 apt autoclean -y
 
+# Remove any previously failed attempts to get repo data
+rm -rf /var/lib/apt/lists/partial/*
 apt update
 
 if ! command -v aptitude > /dev/null; then

--- a/helpers.go
+++ b/helpers.go
@@ -507,7 +507,7 @@ func repoConfigAsMount(config PackageRepositoryConfig, platformCfg *RepoPlatform
 
 	for name, repoConfig := range config.Config {
 		// each of these sources represent a repo config file
-		repoConfigSt, err := repoConfig.AsState(name, sOpt, append(opts, ProgressGroup("Importing repo config: "+name))...)
+		repoConfigSt, err := repoConfig.AsMount(name, sOpt, append(opts, ProgressGroup("Importing repo config: "+name))...)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func GetRepoKeys(configs []PackageRepositoryConfig, cfg *RepoPlatformConfig, sOp
 	names := []string{}
 	for _, config := range configs {
 		for name, repoKey := range config.Keys {
-			gpgKey, err := repoKey.AsState(name, sOpt, append(opts, ProgressGroup("Fetching repo key: "+name))...)
+			gpgKey, err := repoKey.AsMount(name, sOpt, append(opts, ProgressGroup("Fetching repo key: "+name))...)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
In some cases, if `apt update` had an error, the content `apt update`
was trying to fetch will be stored in `/var/lib/apt/lists/partial`.
In Dalec, `/var/lib/apt/lists` is a persistent cache.
As a note: `apt update` does not exit non-zero here, but `apt install`
might... depending on if the package is already in the local package
cache, which can make finding this issue pretty difficult.

For certain errors this can make builds unrecoverable since there's no
real way to clean up this cache outside of blowing away the entire build
cache.

This change just clears out anything in `/var/lib/apt/lists/partial`
before calling `apt update` since it should not be needed anyway and is
potentially problematic to have.

---

The issue here is sometimes a user can provide bad input (like gpg keys with the wrong permissions) and the user cannot recover from this on their own even if they fix the perms.