### PR TITLE
Remove warning message about skipping build targets

### DIFF
--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -620,7 +620,6 @@ func shouldLoadTarget(ctx context.Context, client gwclient.Client, mux *BuildMux
 	t, ok := spec.Targets[targetKey]
 	if !ok {
 		bklog.G(ctx).WithField("spec targets", maps.Keys(spec.Targets)).WithField("targetKey", targetKey).Info("Target not in the spec, skipping")
-		Warnf(ctx, client, llb.Scratch(), "Skipping loading of built-in target %q since it is not in the list of targets in the spec", targetKey)
 		return false
 	}
 


### PR DESCRIPTION
This warning was added in 9a2b35e1b14d6b7984925d0d33233226645dd82e to try and help reduce confusion if the spec contains targets and therefore we skip loading other targets.

As it turns out, its a bit overzealous if you specfy anything in the `targets` section:

    8 warnings found (use docker --debug to expand):
     - Skipping loading of built-in target "bullseye" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "mariner2" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "azlinux3" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "windowscross" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "bionic" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "focal" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "noble" since it is not in the list of targets in the spec
     - Skipping loading of built-in target "bookworm" since it is not in the list of targets in the spec

This is probably more confusing and will just git bigger as we add support for more things.
