### PR TITLE
Add support for outputing multiple windows images from one build

### DIFF
--- a/frontend/gateway.go
+++ b/frontend/gateway.go
@@ -101,12 +101,7 @@ func GetBuildArg(client gwclient.Client, k string) (string, bool) {
 	return "", false
 }
 
-func SourceOptFromClient(ctx context.Context, c gwclient.Client) (dalec.SourceOpts, error) {
-	dc, err := dockerui.NewClient(c)
-	if err != nil {
-		return dalec.SourceOpts{}, err
-	}
-
+func SourceOptFromUIClient(ctx context.Context, c gwclient.Client, dc *dockerui.Client) dalec.SourceOpts {
 	return dalec.SourceOpts{
 		Resolver: c,
 		Forward:  ForwarderFromClient(ctx, c),
@@ -125,7 +120,15 @@ func SourceOptFromClient(ctx context.Context, c gwclient.Client) (dalec.SourceOp
 			}
 			return st, nil
 		},
-	}, nil
+	}
+}
+
+func SourceOptFromClient(ctx context.Context, c gwclient.Client) (dalec.SourceOpts, error) {
+	dc, err := dockerui.NewClient(c)
+	if err != nil {
+		return dalec.SourceOpts{}, err
+	}
+	return SourceOptFromUIClient(ctx, c, dc), nil
 }
 
 var (

--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -204,7 +204,14 @@ func (m *BuildMux) loadSpec(ctx context.Context, client gwclient.Client) (*dalec
 	}
 
 	// Note: this is not suitable for passing to builds since it does not have platform information
-	spec, err := LoadSpec(ctx, dc, nil)
+	spec, err := LoadSpec(ctx, dc, nil, func(cfg *LoadConfig) {
+		cfg.SubstituteOpts = append(cfg.SubstituteOpts, func(cfg *dalec.SubstituteConfig) {
+			// Allow any args here since we aren't trying to validate the spec at this point.
+			cfg.AllowArg = func(string) bool {
+				return true
+			}
+		})
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/windows/dockerui.go
+++ b/frontend/windows/dockerui.go
@@ -1,0 +1,123 @@
+package windows
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/platforms"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/frontend/dockerui"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// This is a copy of dockerui.Client.Build
+// It has one modification: Instead of `platforms.Format` it uses `platforms.FormatAll`
+// The value returned from this function is used as a map key to store build
+// result references.
+// When `platforms.Format` is used, the `OSVersion` field is not taken into account
+// which means we end up overwriting map keys when there are multiple windows
+// platform images being output but with different OSVerions.
+// platforms.FormatAll takes OSVersion into account.
+func dcBuild(ctx context.Context, bc *dockerui.Client, fn dockerui.BuildFunc) (*resultBuilder, error) {
+	res := gwclient.NewResult()
+
+	targets := make([]*ocispecs.Platform, 0, len(bc.TargetPlatforms))
+	for _, p := range bc.TargetPlatforms {
+		p := p
+		targets = append(targets, &p)
+	}
+	if len(targets) == 0 {
+		targets = append(targets, nil)
+	}
+	expPlatforms := &exptypes.Platforms{
+		Platforms: make([]exptypes.Platform, len(targets)),
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for i, tp := range targets {
+		i, tp := i, tp
+		eg.Go(func() error {
+			ref, img, baseImg, err := fn(ctx, tp, i)
+			if err != nil {
+				return err
+			}
+
+			config, err := json.Marshal(img)
+			if err != nil {
+				return errors.Wrapf(err, "failed to marshal image config")
+			}
+
+			var baseConfig []byte
+			if baseImg != nil {
+				baseConfig, err = json.Marshal(baseImg)
+				if err != nil {
+					return errors.Wrapf(err, "failed to marshal source image config")
+				}
+			}
+
+			p := platforms.DefaultSpec()
+			if tp != nil {
+				p = *tp
+			}
+
+			// in certain conditions we allow input platform to be extended from base image
+			if p.OS == "windows" && img.OS == p.OS {
+				if p.OSVersion == "" && img.OSVersion != "" {
+					p.OSVersion = img.OSVersion
+				}
+				if p.OSFeatures == nil && len(img.OSFeatures) > 0 {
+					p.OSFeatures = append([]string{}, img.OSFeatures...)
+				}
+			}
+
+			p = platforms.Normalize(p)
+			k := platforms.FormatAll(p)
+
+			if bc.MultiPlatformRequested {
+				res.AddRef(k, ref)
+				res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k), config)
+				if len(baseConfig) > 0 {
+					res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageBaseConfigKey, k), baseConfig)
+				}
+			} else {
+				res.SetRef(ref)
+				res.AddMeta(exptypes.ExporterImageConfigKey, config)
+				if len(baseConfig) > 0 {
+					res.AddMeta(exptypes.ExporterImageBaseConfigKey, baseConfig)
+				}
+			}
+			expPlatforms.Platforms[i] = exptypes.Platform{
+				ID:       k,
+				Platform: p,
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return &resultBuilder{
+		Result:       res,
+		expPlatforms: expPlatforms,
+	}, nil
+}
+
+type resultBuilder struct {
+	*gwclient.Result
+	expPlatforms *exptypes.Platforms
+}
+
+func (rb *resultBuilder) Finalize() (*gwclient.Result, error) {
+	dt, err := json.Marshal(rb.expPlatforms)
+	if err != nil {
+		return nil, err
+	}
+	rb.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+	return rb.Result, nil
+}

--- a/frontend/windows/handle_container.go
+++ b/frontend/windows/handle_container.go
@@ -6,19 +6,26 @@ import (
 	"fmt"
 	"path"
 	"runtime"
+	"sync"
 
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/frontend"
+	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
 	defaultBaseImage = "mcr.microsoft.com/windows/nanoserver:1809"
 	windowsSystemDir = "/Windows/System32/"
+
+	argBasesPathKey    = "DALEC_WINDOWSCROSS_BASES_PATH"
+	argBasesContextKey = "DALEC_WINDOWSCROSS_BASES_CONTEXT"
 )
 
 var (
@@ -32,35 +39,201 @@ var (
 	}
 )
 
+// ImageBases is the structure used by clients that want to specify multiple
+// base images for the container build target via the `DALEC_WINDOWSCROSS_BASES_PATH`
+// and `DALEC_WINDOWSCROSS_BASES_CONTEXT` build-args.
+type ImageBases struct {
+	Refs []string `json:"refs,omitempty" yaml:"refs,omitempty"`
+}
+
+func (ib *ImageBases) getRefs() []string {
+	if ib == nil {
+		return nil
+	}
+	return ib.Refs
+}
+
+func (ib *ImageBases) len() int {
+	if ib == nil {
+		return 0
+	}
+	return len(ib.Refs)
+}
+
+func getImageBases(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts) (*ImageBases, error) {
+
+	bOpts := client.BuildOpts().Opts
+	p := bOpts["build-arg:"+argBasesPathKey]
+	if p == "" {
+		return nil, nil
+	}
+
+	src := dalec.Source{
+		Context: &dalec.SourceContext{Name: "context"},
+		Path:    p,
+	}
+
+	if name := bOpts["build-arg:"+argBasesContextKey]; name != "" {
+		src.Context.Name = name
+	}
+
+	pg := dalec.ProgressGroup("Determine base images")
+	st, err := src.AsMount("src", sOpt, pg)
+	if err != nil {
+		return nil, err
+	}
+
+	def, err := st.Marshal(ctx, pg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshalling state to solve for \"%s=%s\" and \"%s=%s\"", argBasesPathKey, p, argBasesContextKey, src.Context.Name)
+	}
+
+	res, err := client.Solve(ctx, gwclient.SolveRequest{Definition: def.ToPB()})
+	if err != nil {
+		return nil, errors.Wrapf(err, "solving state for \"%s=%s\" and \"%s=%s\"", argBasesPathKey, p, argBasesContextKey, src.Context.Name)
+	}
+
+	ref, err := res.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	dt, err := ref.ReadFile(ctx, gwclient.ReadRequest{Filename: p})
+	if err != nil {
+		return nil, err
+	}
+
+	var bases ImageBases
+
+	if err := json.Unmarshal(dt, &bases); err != nil {
+		return nil, err
+	}
+	return &bases, nil
+}
+
 func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
-	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
-		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+	dc, err := dockerui.NewClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(dc.TargetPlatforms) > 1 {
+		return nil, fmt.Errorf("multi-platform output is not supported")
+	}
+
+	sOpt := frontend.SourceOptFromUIClient(ctx, client, dc)
+
+	bases, err := getImageBases(ctx, client, sOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := bases.getRefs()
+	if len(refs) == 0 {
+		refs = append(refs, defaultBaseImage)
+	}
+
+	eg, grpCtx := errgroup.WithContext(ctx)
+	cfgs := make([][]byte, len(refs))
+	targets := make([]ocispecs.Platform, len(cfgs))
+
+	basePlatform := defaultPlatform
+	if len(dc.TargetPlatforms) > 0 {
+		basePlatform = dc.TargetPlatforms[0]
+	}
+
+	for idx, ref := range refs {
+		idx := idx
+		ref := ref
+		eg.Go(func() error {
+			_, _, dt, err := client.ResolveImageConfig(grpCtx, ref, sourceresolver.Opt{
+				Platform: &basePlatform,
+				ImageOpt: &sourceresolver.ResolveImageOpt{
+					ResolveMode: dc.ImageResolveMode.String(),
+				},
+			})
+
+			if err != nil {
+				return err
+			}
+
+			var cfg dalec.DockerImageSpec
+			if err := json.Unmarshal(dt, &cfg); err != nil {
+				return errors.Wrapf(err, "image config for %s", ref)
+			}
+
+			cfgs[idx] = dt
+			targets[idx] = cfg.Platform
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	for _, p := range targets {
+		s := platforms.FormatAll(p)
+		if _, ok := seen[s]; ok {
+			return nil, fmt.Errorf("mutiple base images provided with the same platform value")
+		}
+		seen[s] = struct{}{}
+	}
+
+	dc.TargetPlatforms = targets
+	if len(targets) > 1 {
+		dc.MultiPlatformRequested = true
+	}
+	targetKey := frontend.GetTargetKey(client)
+
+	warnBaseOverride := sync.OnceFunc(func() {
+		frontend.Warn(ctx, client, llb.Scratch(), "Base image defined in spec overwritten by base images context")
+	})
+
+	getBaseRef := func(idx int, spec *dalec.Spec) string {
+		baseRef := refs[idx]
+
+		updated := dalec.GetBaseOutputImage(spec, targetKey)
+		if updated == "" {
+			return baseRef
+		}
+
+		if bases.len() == 0 {
+			return updated
+		}
+
+		warnBaseOverride()
+		return baseRef
+	}
+
+	rb, err := dcBuild(ctx, dc, func(ctx context.Context, platform *ocispecs.Platform, idx int) (ref gwclient.Reference, retCfg, retBaseCfg *dalec.DockerImageSpec, retErr error) {
+		spec, err := frontend.LoadSpec(ctx, dc, platform, frontend.WithAllowArgs(
+			argBasesPathKey,
+			argBasesContextKey,
+		))
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		if err := validateRuntimeDeps(spec, targetKey); err != nil {
-			return nil, nil, fmt.Errorf("error validating windows spec: %w", err)
+			return nil, nil, nil, fmt.Errorf("error validating windows spec: %w", err)
 		}
 
 		pg := dalec.ProgressGroup("Build windows container: " + spec.Name)
 		worker, err := distroConfig.Worker(sOpt, pg)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		bin, err := buildBinaries(ctx, spec, worker, client, sOpt, targetKey)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to build binary %w", err)
+			return nil, nil, nil, fmt.Errorf("unable to build binary %w", err)
 		}
 
-		baseImgName := getBaseOutputImage(spec, targetKey, defaultBaseImage)
-
-		if platform == nil {
-			platform = &defaultPlatform
-		}
-
-		baseImage := llb.Image(baseImgName, llb.Platform(*platform))
+		baseRef := getBaseRef(idx, spec)
+		baseImage := llb.Image(baseRef, llb.Platform(*platform))
 
 		out := baseImage.
 			File(llb.Copy(bin, "/", windowsSystemDir)).
@@ -68,40 +241,39 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 
 		def, err := out.Marshal(ctx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		res, err := client.Solve(ctx, gwclient.SolveRequest{
 			Definition: def.ToPB(),
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
-		imgRef := dalec.GetBaseOutputImage(spec, targetKey)
-		if imgRef == "" {
-			imgRef = defaultBaseImage
+		var baseCfg dalec.DockerImageSpec
+		if err := json.Unmarshal(cfgs[idx], &baseCfg); err != nil {
+			return nil, nil, nil, errors.Wrap(err, "error unmarshalling base image config")
 		}
 
-		_, _, dt, err := client.ResolveImageConfig(ctx, imgRef, sourceresolver.Opt{
-			Platform: platform,
-		})
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "could not resolve base image config")
-		}
-
+		// Get a copy of the cfg so we can modify it
 		var img dalec.DockerImageSpec
-		if err := json.Unmarshal(dt, &img); err != nil {
-			return nil, nil, errors.Wrap(err, "error unmarshalling base image config")
+		if err := json.Unmarshal(cfgs[idx], &img); err != nil {
+			return nil, nil, nil, errors.Wrap(err, "error unmarshalling base image config")
 		}
 
 		if err := dalec.BuildImageConfig(spec, targetKey, &img); err != nil {
-			return nil, nil, errors.Wrap(err, "error creating image config")
+			return nil, nil, nil, errors.Wrap(err, "error creating image config")
 		}
 
-		ref, err := res.SingleRef()
-		return ref, &img, err
+		ref, err = res.SingleRef()
+		return ref, &img, &baseCfg, err
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return rb.Finalize()
 }
 
 func copySymlinks(post *dalec.PostInstall) llb.StateOption {
@@ -124,13 +296,4 @@ func copySymlinks(post *dalec.PostInstall) llb.StateOption {
 
 		return s
 	}
-
-}
-
-func getBaseOutputImage(spec *dalec.Spec, target, defaultBase string) string {
-	baseRef := defaultBase
-	if spec.Targets[target].Image != nil && spec.Targets[target].Image.Base != "" {
-		baseRef = spec.Targets[target].Image.Base
-	}
-	return baseRef
 }

--- a/load_test.go
+++ b/load_test.go
@@ -557,6 +557,14 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 	err := spec.SubstituteArgs(env)
 	assert.ErrorIs(t, err, errUnknownArg, "args not defined in the spec should error out")
 
+	// Now with the arg explicitly allowed as a passhtrough
+	err = spec.SubstituteArgs(env, func(cfg *SubstituteConfig) {
+		cfg.AllowArg = func(key string) bool {
+			return key == "FOO"
+		}
+	})
+	assert.NilError(t, err)
+
 	spec.Args = map[string]string{}
 
 	spec.Args["FOO"] = ""
@@ -585,7 +593,6 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 	}
 
 	env["BAR"] = bar
-	assert.ErrorIs(t, err, errUnknownArg, "args not defined in the spec should error out")
 
 	spec.Args["BAR"] = ""
 	spec.Args["VAR_WITH_DEFAULT"] = argWithDefault
@@ -603,6 +610,7 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].PackageConfig.Signer.Args["BAR"], bar))
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].PackageConfig.Signer.Args["WHATEVER"], argWithDefault))
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].PackageConfig.Signer.Args["REGULAR"], plainOleValue))
+
 }
 
 func TestCustomRepoFillDefaults(t *testing.T) {

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -144,3 +144,42 @@ This works the same way in the `azlinux3`:
   i. `--build-context mcr.microsoft.com/azurelinux/base/core:3.0=<new ref>`
 2. A build context named `dalec-mariner2-worker`
   i. `--build-context dalec-azlinux3-worker=<new ref>`
+
+#### Windows
+
+For Windows containers, typically the container image OS needs to match
+the Windows host OS.
+
+You can use DALEC to create a single multi-platform image with the different
+Windows versions you want to use.
+Normally you would specify a single base image in the DALEC spec's image config,
+however this is not sufficient to accomplish this task.
+
+With DALEC you can pass in a build-arg `DALEC_WINDOWSCROSS_BASES_PATH` the value
+of which should be the path to a file containing json with the following
+structure to the `windowscross/container` build target:
+
+
+```json
+{
+    "refs": [
+        "mcr.microsoft.com/windows/nanoserver:1809",
+        "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+    ]
+}
+```
+
+:::note
+Values in the "refs" field can be any Windows image.
+
+You can provide any number of images here, however each image must have a
+different value for the `os.version` field in the image config's platform.
+If there are images with the same platform values the build will fail.
+:::
+
+You can also provide this file in a named build context, but you must still
+specifiy the above mentioned build-arg so that DALEC knows how to find the file
+in that named context.
+You can tell DALEC to use a named context by providing the name in a build-arg
+`DALEC_WINDOWSCROSS_BASES_CONTEXT`
+


### PR DESCRIPTION
This allows builders to specify a file that contains a list of base images that the windowscross/container target should produce images for.
The result is a single multiplatform image: https://oci.dag.dev/?image=docker.io/cpuguy83/test@sha256:d88cf477b7f2464d4581f9490a8c1946300093461837272537e83879105f55e6&mt=application%2Fvnd.oci.image.index.v1%2Bjson&size=1693