### PR TITLE
fix: test2json: detect test timeouts and other package-level errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: download deps
         run: go mod download
       - name: Run integration tests
-        run: go test -v -json ./test | go run ./cmd/test2json2gha
+        run: go test -v -timeout=30m -json ./test | go run ./cmd/test2json2gha
       - name: dump logs
         if: failure()
         run: sudo journalctl -u docker


### PR DESCRIPTION
This was ignoring all non-test events, unfortunately this means if there is a panic or a test timeout we may not detect the failure.

Fixes #476 