### PR TITLE
Add recover for panics from handlers

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,10 +16,6 @@ variable "DALEC_DISABLE_DIFF_MERGE" {
     default = "0"
 }
 
-variable "DALEC_NO_CACHE_EXPORT" {
-    default = "0"
-}
-
 target "frontend" {
     target = "frontend"
     tags = [FRONTEND_REF]
@@ -76,9 +72,6 @@ target "runc-azlinux" {
     tags = tgt == "container" ? ["runc:mariner2"] : []
     // only output non-container targets to the fs
     output = tgt != "container" ? ["_output"] : []
-
-    cache-from = ["type=gha,scope=dalec/runc/mariner2/${tgt}"]
-    cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/runc/mariner2/${tgt},mode=max"] : []
 }
 
 target "runc-jammy" {
@@ -102,9 +95,6 @@ target "runc-jammy" {
     tags = tgt == "container" ? ["runc:jammy"] : []
     // only output non-container targets to the fs
     output = tgt != "container" ? ["_output"] : []
-
-    cache-from = ["type=gha,scope=dalec/runc/jammy/${tgt}"]
-    cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/runc/jammy/${tgt},mode=max"] : []
 }
 
 target "runc-test" {
@@ -148,8 +138,6 @@ target "test-fixture" {
       "dalec_frontend" = "target:frontend"
     }
     target = tgt
-    cache-from = ["type=gha,scope=dalec/${f}/${tgt}/${f}"]
-    cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/${f}/${tgt}/${f},mode=max"] : []
 }
 
 variable "BUILD_SPEC" {
@@ -174,9 +162,6 @@ target "build" {
     tags = tgt == "container" ? ["build:${distro}"] : []
     // only output non-container targets to the fs
     output = tgt != "container" ? ["_output"] : []
-
-    cache-from = ["type=gha,scope=dalec/${BUILD_SPEC}/${distro}/${tgt}"]
-    cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/${BUILD_SPEC}/${distro}/${tgt},mode=max"] : []
 }
 
 target "examples" {
@@ -215,8 +200,6 @@ dependencies:
     }
     target = "${distro}/container/depsonly"
     tags = ["local/dalec/deps-only:${distro}"]
-    cache-from = ["type=gha,scope=dalec/deps-only-${distro}"]
-    cache-to = DALEC_NO_CACHE_EXPORT != "1" ? ["type=gha,scope=dalec/deps-only-${distro},mode=max"] : []
 }
 
 target "test-deps-only" {
@@ -240,13 +223,11 @@ variable "CI_FRONTEND_CACHE_SCOPE" {
 
 target "frontend-ci" {
     inherits = ["frontend"]
-    cache-from = ["type=gha,scope=${CI_FRONTEND_CACHE_SCOPE}"]
     output = ["type=registry"]
 }
 
 target "frontend-ci-full" {
     inherits = ["frontend-ci"]
-    cache-to = ["type=gha,scope=${CI_FRONTEND_CACHE_SCOPE},mode=max"]
     platforms = ["linux/amd64", "linux/arm64"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,6 +17,7 @@ variable "DALEC_DISABLE_DIFF_MERGE" {
 }
 
 target "frontend" {
+    // uses default Dockerfile
     target = "frontend"
     tags = [FRONTEND_REF]
 }

--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -536,7 +536,13 @@ func (d *clientWithCustomOpts) CurrentFrontend() (*llb.State, error) {
 
 // Handler returns a [gwclient.BuildFunc] that uses the mux to route requests to appropriate handlers
 func (m *BuildMux) Handler(opts ...func(context.Context, gwclient.Client, *BuildMux) error) gwclient.BuildFunc {
-	return func(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
+	return func(ctx context.Context, client gwclient.Client) (_ *gwclient.Result, retErr error) {
+		defer func() {
+			if r := recover(); r != nil {
+				retErr = errors.Errorf("recovered panic in handler: %+v", r)
+			}
+		}()
+
 		if !SupportsDiffMerge(client) {
 			dalec.DisableDiffMerge(true)
 		}


### PR DESCRIPTION
This allows the error to actually propagate back to the client instead of the ominous "exit code 2" and having to search through the daemon logs to see what happened.

Closes #181
Closes #505