### PR TITLE
Add support for adding users and groups in spec

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -43,7 +43,10 @@ type Artifacts struct {
 	// On linux this would typically be installed to /usr/include/.
 	Headers map[string]ArtifactConfig `yaml:"headers,omitempty" json:"headers,omitempty"`
 
-	// TODO: other types of artifacts (libexec, etc)
+	// Users is a list of users to add to the system when the package is installed.
+	Users []AddUserConfig `yaml:"users,omitempty" json:"users,omitempty"`
+	// Groups is a list of groups to add to the system when the package is installed.
+	Groups []AddGroupConfig `yaml:"groups,omitempty" json:"groups,omitempty"`
 }
 
 type ArtifactSymlinkConfig struct {
@@ -104,6 +107,18 @@ func (a *ArtifactConfig) ResolveName(path string) string {
 		return a.Name
 	}
 	return filepath.Base(path)
+}
+
+// AddUserConfig is the configuration for adding a user to the system.
+type AddUserConfig struct {
+	// Name is the name of the user to add to the system.
+	Name string `yaml:"name" json:"name"`
+}
+
+// AddGroupConfig is the configuration for adding a group to the system.
+type AddGroupConfig struct {
+	// Name is the name of the group to add to the system.
+	Name string `yaml:"name" json:"name"`
 }
 
 // IsEmpty is used to determine if there are any artifacts to include in the package.

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -3,6 +3,34 @@
 	"$id": "https://github.com/Azure/dalec/spec",
 	"$ref": "#/$defs/Spec",
 	"$defs": {
+		"AddGroupConfig": {
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name is the name of the group to add to the system."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"name"
+			],
+			"description": "AddGroupConfig is the configuration for adding a group to the system."
+		},
+		"AddUserConfig": {
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name is the name of the user to add to the system."
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"name"
+			],
+			"description": "AddUserConfig is the configuration for adding a user to the system."
+		},
 		"ArtifactBuild": {
 			"properties": {
 				"steps": {
@@ -154,6 +182,20 @@
 					},
 					"type": "object",
 					"description": "Headers is a list of header files and/or folders to be installed.\nOn linux this would typically be installed to /usr/include/."
+				},
+				"users": {
+					"items": {
+						"$ref": "#/$defs/AddUserConfig"
+					},
+					"type": "array",
+					"description": "Users is a list of users to add to the system when the package is installed."
+				},
+				"groups": {
+					"items": {
+						"$ref": "#/$defs/AddGroupConfig"
+					},
+					"type": "array",
+					"description": "Groups is a list of groups to add to the system when the package is installed."
 				}
 			},
 			"additionalProperties": false,

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -287,3 +287,32 @@ Note that headers are not installed within a subdirectory of `/usr/include/`
 with the name of the package. They are installed directly into `/usr/include/`.
 For instance, for the above examples, the headers would be installed to
 `/usr/include/my_header.h` and `/usr/include/my_headers/` respectively.
+
+### Users
+
+Users allow you to specify a list of users to be created when installing the
+package.
+In most cases this will require a shell to be available on the target system.
+
+Example:
+
+```yaml
+artifacts:
+  users:
+    - name: myuser
+```
+
+### Groups
+
+Groups allow you to specify a list of groups to be created when installing the
+package.
+In most cases this will require a shell to be available on the target system.
+
+Example:
+
+```yaml
+artifacts:
+  groups:
+    - name: mygroup
+```
+


### PR DESCRIPTION
For now this is just the most simple config.
We can expand to other options (e.g. shell, home dir) as needed.

Closes #444