### PR TITLE
Make matches a slice of regexes instead of a single regex

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -272,8 +272,11 @@
 					"description": "Contains is the list of strings to check if they are contained in the output."
 				},
 				"matches": {
-					"type": "string",
-					"description": "Matches is the regular expression to match the output against."
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "Matches is the list of regular expressions to match the output against."
 				},
 				"starts_with": {
 					"type": "string",
@@ -369,8 +372,11 @@
 					"description": "Contains is the list of strings to check if they are contained in the output."
 				},
 				"matches": {
-					"type": "string",
-					"description": "Matches is the regular expression to match the output against."
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "Matches is the list of regular expressions to match the output against."
 				},
 				"starts_with": {
 					"type": "string",

--- a/tests.go
+++ b/tests.go
@@ -58,7 +58,7 @@ type CheckOutput struct {
 	Equals string `yaml:"equals,omitempty" json:"equals,omitempty"`
 	// Contains is the list of strings to check if they are contained in the output.
 	Contains []string `yaml:"contains,omitempty" json:"contains,omitempty"`
-	// Matches is the regular expression to match the output against.
+	// Matches is the list of regular expressions to match the output against.
 	Matches []string `yaml:"matches,omitempty" json:"matches,omitempty"`
 	// StartsWith is the string to check if the output starts with.
 	StartsWith string `yaml:"starts_with,omitempty" json:"starts_with,omitempty"`

--- a/tests.go
+++ b/tests.go
@@ -263,15 +263,13 @@ func (c CheckOutput) Check(dt string, p string) (retErr error) {
 		}
 	}
 	for _, matches := range c.Matches {
-		if matches != "" {
-			regexp, err := regexp.Compile(matches)
-			if err != nil {
-				return err
-			}
+		regexp, err := regexp.Compile(matches)
+		if err != nil {
+			return err
+		}
 
-			if !regexp.Match([]byte(dt)) {
-				return &CheckOutputError{Kind: "matches", Expected: matches, Actual: dt, Path: p}
-			}
+		if !regexp.Match([]byte(dt)) {
+			return &CheckOutputError{Kind: "matches", Expected: matches, Actual: dt, Path: p}
 		}
 	}
 

--- a/tests.go
+++ b/tests.go
@@ -59,7 +59,7 @@ type CheckOutput struct {
 	// Contains is the list of strings to check if they are contained in the output.
 	Contains []string `yaml:"contains,omitempty" json:"contains,omitempty"`
 	// Matches is the regular expression to match the output against.
-	Matches string `yaml:"matches,omitempty" json:"matches,omitempty"`
+	Matches []string `yaml:"matches,omitempty" json:"matches,omitempty"`
 	// StartsWith is the string to check if the output starts with.
 	StartsWith string `yaml:"starts_with,omitempty" json:"starts_with,omitempty"`
 	// EndsWith is the string to check if the output ends with.
@@ -96,7 +96,7 @@ func (c *CheckOutputError) Error() string {
 
 // IsEmpty is used to determine if there are any checks to perform.
 func (c CheckOutput) IsEmpty() bool {
-	return c.Equals == "" && len(c.Contains) == 0 && c.Matches == "" && c.StartsWith == "" && c.EndsWith == "" && !c.Empty
+	return c.Equals == "" && len(c.Contains) == 0 && len(c.Matches) == 0 && c.StartsWith == "" && c.EndsWith == "" && !c.Empty
 }
 
 func (t *TestSpec) validate() error {
@@ -132,11 +132,13 @@ func (c *CheckOutput) processBuildArgs(lex *shell.Lex, args map[string]string, a
 	}
 	c.EndsWith = updated
 
-	updated, err = expandArgs(lex, c.Matches, args, allowArg)
-	if err != nil {
-		return fmt.Errorf("%w: matches", err)
+	for i, matches := range c.Matches {
+		updated, err = expandArgs(lex, matches, args, allowArg)
+		if err != nil {
+			return fmt.Errorf("%w: matches at list index %d", err, i)
+		}
+		c.Matches[i] = updated
 	}
-	c.Matches = updated
 
 	updated, err = expandArgs(lex, c.Equals, args, allowArg)
 	if err != nil {
@@ -260,14 +262,16 @@ func (c CheckOutput) Check(dt string, p string) (retErr error) {
 			return &CheckOutputError{Kind: "contains", Expected: contains, Actual: dt, Path: p}
 		}
 	}
-	if c.Matches != "" {
-		regexp, err := regexp.Compile(c.Matches)
-		if err != nil {
-			return err
-		}
+	for _, matches := range c.Matches {
+		if matches != "" {
+			regexp, err := regexp.Compile(matches)
+			if err != nil {
+				return err
+			}
 
-		if !regexp.Match([]byte(dt)) {
-			return &CheckOutputError{Kind: "matches", Expected: c.Matches, Actual: dt, Path: p}
+			if !regexp.Match([]byte(dt)) {
+				return &CheckOutputError{Kind: "matches", Expected: matches, Actual: dt, Path: p}
+			}
 		}
 	}
 

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -77,7 +77,7 @@ tests:
 
 #### Check that a file matches a regular expression:
 
-Here we check that the content of the file `/etc/foo.conf` matches the regular expression `foo=.*`.
+Here we check that the content of the file `/etc/foo.conf` matches one of the regular expressions (in this case only `foo=.*`).
 
 ```yaml
 name: My Package
@@ -87,7 +87,8 @@ tests:
   - name: My Test case
     files:
       /etc/foo.conf:
-        matches: "foo=.*"
+        matches: 
+          - "foo=.*"
 ```
 
 #### Check that a file does not exist
@@ -136,7 +137,8 @@ tests:
           - foo=bar
         starts_with: foo
         ends_with: bar
-        matches: "foo=.*"
+        matches: 
+          - "foo=.*"
         permissions: 0644
 ```
 
@@ -157,7 +159,8 @@ tests:
           - foo=bar
         starts_with: foo
         ends_with: bar
-        matches: "foo=.*"
+        matches: 
+          - "foo=.*"
         permissions: 0644
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**: Changes the typing of `matches` such that it now takes a slice of strings, allowing for easier writing of regex matches for different cases.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #513 

**Special notes for your reviewer**:
