### PR TITLE
Use passed in context in test instead of creating new ones

### DIFF
--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -1233,10 +1233,10 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 						SubPath: "subpath",
 						Name:    "custom_name",
 					},
-					"subpath_only": dalec.ArtifactConfig{
+					"subpath_only": {
 						SubPath: "custom",
 					},
-					"nested_subpath": dalec.ArtifactConfig{
+					"nested_subpath": {
 						SubPath: "libexec-test/abcdefg",
 					},
 				},
@@ -1734,7 +1734,6 @@ func testPinnedBuildDeps(ctx context.Context, t *testing.T, cfg testLinuxConfig)
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := startTestSpan(baseCtx, t)
 
 			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 				worker := getWorker(ctx, t, gwc)
@@ -2162,7 +2161,7 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 								Inline: &dalec.SourceInline{
 									Dir: &dalec.SourceInlineDir{
 										Files: map[string]*dalec.SourceInlineFile{
-											"some_file": &dalec.SourceInlineFile{
+											"some_file": {
 												Contents: "some file",
 											},
 										},
@@ -2177,7 +2176,7 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 								Inline: &dalec.SourceInline{
 									Dir: &dalec.SourceInlineDir{
 										Files: map[string]*dalec.SourceInlineFile{
-											"another_file": &dalec.SourceInlineFile{
+											"another_file": {
 												Contents: "some other file",
 											},
 										},

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -55,7 +55,6 @@ func newSimpleSpec() *dalec.Spec {
 func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
 
 		newSigningSpec := func() *dalec.Spec {
 			spec := newSimpleSpec()


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed some minor refactoring opportunities in the test code. The main update is making sure the test functions use the context that is passed into it. The context that is passed in the same as what the code is unnecessarily initializing later on. 

TLDR; using the passed in context is more consistent and easier to manage than creating new contexts.