### PR TITLE
Add DALEC_TARGET built-in arg

### DIFF
--- a/frontend/mux.go
+++ b/frontend/mux.go
@@ -232,7 +232,7 @@ func maybeSetDalecTargetKey(client gwclient.Client, key string) gwclient.Client 
 		// this forces the client to use our cached opts from above
 		client = &clientWithCustomOpts{opts: opts, Client: client}
 	}
-	return setClientOptOption(client, keyTopLevelTarget, key)
+	return setClientOptOption(client, map[string]string{keyTopLevelTarget: key, "build-arg:" + dalec.KeyDalecTarget: key})
 }
 
 // list outputs the list of targets that are supported by the mux
@@ -518,9 +518,12 @@ func trimTargetOpt(client gwclient.Client, prefix string) *clientWithCustomOpts 
 	}
 }
 
-func setClientOptOption(client gwclient.Client, key, value string) *clientWithCustomOpts {
+func setClientOptOption(client gwclient.Client, extraOpts map[string]string) *clientWithCustomOpts {
 	opts := client.BuildOpts()
-	opts.Opts[key] = value
+
+	for key, value := range extraOpts {
+		opts.Opts[key] = value
+	}
 	return &clientWithCustomOpts{
 		Client: client,
 		opts:   opts,

--- a/frontend/windows/handle_zip.go
+++ b/frontend/windows/handle_zip.go
@@ -129,6 +129,11 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 		withSourcesMounted("/build", patched, spec.Sources),
 		llb.AddMount("/tmp/scripts", buildScript),
 		dalec.WithConstraints(opts...),
+		dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+			for k, v := range spec.Build.Env {
+				ei.State = ei.State.With(llb.AddEnv(k, v))
+			}
+		}),
 	).AddMount(outputDir, llb.Scratch())
 
 	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt)

--- a/load.go
+++ b/load.go
@@ -12,6 +12,12 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+const (
+	// KeyDalecTarget is the key used the build arg name which may be used to read
+	// the target name.
+	KeyDalecTarget = "DALEC_TARGET"
+)
+
 func knownArg(key string) bool {
 	switch key {
 	case "BUILDKIT_SYNTAX":
@@ -27,6 +33,8 @@ func knownArg(key string) bool {
 	case "SOURCE_DATE_EPOCH":
 		return true
 	case "DALEC_SKIP_TESTS":
+		return true
+	case KeyDalecTarget:
 		return true
 	}
 

--- a/load_test.go
+++ b/load_test.go
@@ -993,6 +993,7 @@ build:
     - command: echo '$OS'
       env:
         OS: ${TARGETOS}
+        TARGET: ${DALEC_TARGET}
 `)
 		spec, err := LoadSpec(dt)
 		if err != nil {

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -520,6 +520,10 @@ echo "$BAR" > bar.txt
 		ctx := startTestSpan(baseCtx, t)
 		testBuildNetworkMode(ctx, t, tcfg)
 	})
+
+	t.Run("test dalec target arg is set", func(t *testing.T) {
+		testDalecTargetArg(ctx, t, tcfg)
+	})
 }
 
 func prepareWindowsSigningState(ctx context.Context, t *testing.T, gwc gwclient.Client, spec *dalec.Spec, extraSrOpts ...srOpt) llb.State {

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -41,9 +41,12 @@ args:
   TARGETARCH:
   TARGETPLATFORM:
   TARGETVARIANT:
+  DALEC_TARGET:
 ```
 
 These arguments are set based on the default docker platform for the machine, *unless* the platform is overridden explicitly in the docker build with `--platform`. For example, upon invoking `docker build` on a Linux amd64 machine, we would have `TARGETOS=linux`, `TARGETARCH=amd64`, `TARGETPLATFORM=linux/amd64`.
+
+`DALEC_TARGET` is set to the target name, such as `mariner2`, `azlinux3`, or `windowscross`.
 
 :::note
 No default value should be included for these build args. These args are opt-in. If you haven't listed them in the args section as shown above, Dalec will **not** substitute values for them.


### PR DESCRIPTION
This sets the name of the target, e.g. `mariner2`, as a build-arg which can be consumed anywhere build-args are accepted in the spec.

This is neccessary in particular for mixed windows/linux builds where something like `GOOS` may neeed to be set (as an example).