### PR TITLE
Add syntax directive to example in docs

### DIFF
--- a/website/docs/container-only-builds.md
+++ b/website/docs/container-only-builds.md
@@ -6,6 +6,7 @@ title: Container-only builds
 It is possible to use Dalec when you wish to build a minimal image from scratch or based on one of Dalec's supported distros (see [Targets](targets.md) for a list of these) with only certain packages installed. To do this, simply define a Dalec spec with only runtime dependencies specified. The resulting image will contain only the specified packages and their dependencies.
 
 ```yaml
+# syntax=ghcr.io/azure/dalec/frontend:latest
 name: my-minimal-image
 version: 0.1.0
 description: A minimal distroless image with only curl and shell access


### PR DESCRIPTION
A user tried to build with this example spec, only to receive an error complaining about dockerfile syntax errors. This change lets the user build the example without modifying it first.
