### PR TITLE
Merge Dependency Fields from Global Spec Dependencies into Targets

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -417,8 +417,8 @@ func SortedMapValues[T any](m map[string]T) []T {
 	return out
 }
 
-// MergeDependencies merges two sets of package dependencies, a child and a parent.
-// If a dependency is set in both, the one from depsB is used, otherwise, the dependency from depsA is used.
+// MergeDependencies merges two sets of package dependencies, a base and a target.
+// If a dependency is set in both, the one from `target` is used, otherwise, the dependency from parent is used.
 // MergeDependencies(nil, child) = child, MergeDependencies(parent, nil) = parent
 func MergeDependencies(base, target *PackageDependencies) *PackageDependencies {
 	var (

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -74,6 +74,49 @@ func TestMergeDependencies(t *testing.T) {
 				Test: []string{"test1"},
 			},
 		},
+		{
+			name: "custom repo in target",
+			base: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg1": {},
+				},
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+			},
+			target: &PackageDependencies{
+				ExtraRepos: []PackageRepositoryConfig{
+					{
+						Config: map[string]Source{
+							"custom.repo": {
+								HTTP: &SourceHTTP{
+									URL: "my.repo.com/custom.repo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg1": {},
+				},
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+				ExtraRepos: []PackageRepositoryConfig{
+					{
+						Config: map[string]Source{
+							"custom.repo": {
+								HTTP: &SourceHTTP{
+									URL: "my.repo.com/custom.repo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,85 @@
+package dalec
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestMergeDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     *PackageDependencies
+		target   *PackageDependencies
+		expected *PackageDependencies
+	}{
+		{
+			name:     "both nil",
+			base:     nil,
+			target:   nil,
+			expected: nil,
+		},
+		{
+			name: "base nil",
+			base: nil,
+			target: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg1": {},
+				},
+			},
+			expected: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg1": {},
+				},
+			},
+		},
+		{
+			name: "target nil",
+			base: &PackageDependencies{
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+			},
+			target: nil,
+			expected: &PackageDependencies{
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+			},
+		},
+		{
+			name: "merge dependencies",
+			base: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg1": {},
+				},
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+			},
+			target: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg3": {},
+				},
+				Test: []string{"test1"},
+			},
+			expected: &PackageDependencies{
+				Build: map[string]PackageConstraints{
+					"pkg3": {},
+				},
+				Runtime: map[string]PackageConstraints{
+					"pkg2": {},
+				},
+				Test: []string{"test1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeDependencies(tt.base, tt.target)
+			assert.Check(t, cmp.DeepEqual(tt.expected, result))
+		})
+	}
+}


### PR DESCRIPTION
This applies an inheritance type relationship between package dependencies for individual dalec targets and package dependencies specified in the default spec `dependencies` block. Basically, if a dependency field is specified for a particular target, it will be used, otherwise the field from the global dependencies will be inherited. Fields themselves are not merged together; this is an "override if unset in specific target" type of behavior.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
