### PR TITLE
spec: fix "libs" json definition

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -31,7 +31,7 @@ type Artifacts struct {
 
 	// Libs is the list of library files to be installed.
 	// On linux this would typically be installed to /usr/lib/<package name>
-	Libs map[string]ArtifactConfig `yaml:"libs,omitempty" json:"libraries,omitempty"`
+	Libs map[string]ArtifactConfig `yaml:"libs,omitempty" json:"libs,omitempty"`
 
 	// Links is the list of symlinks to be installed with the package
 	// Links should only be used if the *package* should contain the link.

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -242,7 +242,7 @@
 					],
 					"description": "Libexec is the list of additional binaries that may be invoked by the main package binary."
 				},
-				"libraries": {
+				"libs": {
 					"additionalProperties": {
 						"$ref": "#/$defs/ArtifactConfig"
 					},


### PR DESCRIPTION
This should be `libs`, not `libraries`, to match the yaml definition.