### PR TITLE
deb: Fix patches when patch is in subdir

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -54,8 +54,9 @@ func sourcePatchesDir(sOpt dalec.SourceOpts, base llb.State, dir, name string, s
 		copySrc := patch.Source
 		if patch.Path != "" {
 			src.Includes = append(src.Includes, patch.Path)
-			copySrc = filepath.Base(patch.Path)
+			copySrc = patch.Path
 		}
+
 		st, err := src.AsState(patch.Source, sOpt, opts...)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating patch state")

--- a/packaging/linux/deb/pkg.go
+++ b/packaging/linux/deb/pkg.go
@@ -101,7 +101,6 @@ func SourcePackage(ctx context.Context, sOpt dalec.SourceOpts, worker llb.State,
 		llb.AddMount("/work/pkg/debian", dr, llb.SourcePath("debian")), // This cannot be readonly because the debian directory gets modified by dpkg-buildpackage
 		llb.AddMount("/work/pkg/debian/patches", patches, llb.Readonly),
 		llb.AddEnv("DH_VERBOSE", "1"),
-		mountSources(sources, "/work/pkg", sanitizeSourceKey),
 		dalec.RunOptFunc(func(ei *llb.ExecInfo) {
 			// Mount all the tar+gz'd sources into the build which will get picked p by debbuild
 			for key, src := range debSources {

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -325,10 +325,40 @@ index 0000000..5260cb1
 +
 +echo "Added another new file"
 `)
-		src2Patch3Context := llb.Scratch().File(
-			llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content),
-		)
-		src2Patch3ContextName := "patch-context"
+
+		src2Patch4Content := []byte(`
+diff --git a/file4 b/file4
+new file mode 100700
+index 0000000..5260cb1
+--- /dev/null
++++ b/file4
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++
++echo "Added yet another new file"
+`)
+
+		src2Patch5Content := []byte(`
+diff --git a/file5 b/file5
+new file mode 100700
+index 0000000..5260cb1
+--- /dev/null
++++ b/file5
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++
++echo "Added yet again...another new file"
+`)
+
+		const src2Patch4File = "patches/patch4"
+		const src2Patch5File = "patches/patch5"
+		const patchContextName = "patch-context"
+
+		patchContext := llb.Scratch().
+			File(llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content)).
+			File(llb.Mkdir("patches", 0o755)).
+			File(llb.Mkfile(src2Patch4File, 0o600, src2Patch4Content)).
+			File(llb.Mkfile(src2Patch5File, 0o600, src2Patch5Content))
 
 		spec := dalec.Spec{
 			Name:        "test-container-build",
@@ -395,8 +425,20 @@ index 0000000..5260cb1
 				},
 				"src2-patch3": {
 					Context: &dalec.SourceContext{
-						Name: src2Patch3ContextName,
+						Name: patchContextName,
 					},
+				},
+				"src2-patch4": {
+					Context: &dalec.SourceContext{
+						Name: patchContextName,
+					},
+					Includes: []string{src2Patch4File},
+				},
+				"src2-patch5": {
+					Context: &dalec.SourceContext{
+						Name: patchContextName,
+					},
+					Path: src2Patch5File,
 				},
 				"src3": {
 					Inline: &dalec.SourceInline{
@@ -412,6 +454,8 @@ index 0000000..5260cb1
 					{Source: "src2-patch1"},
 					{Source: "src2-patch2", Path: "the-patch"},
 					{Source: "src2-patch3", Path: src2Patch3File},
+					{Source: "src2-patch4", Path: src2Patch4File},
+					{Source: "src2-patch5", Path: filepath.Base(src2Patch5File)},
 				},
 			},
 
@@ -637,7 +681,7 @@ echo "$BAR" > bar.txt
 			sr := newSolveRequest(
 				withSpec(ctx, t, &spec),
 				withBuildTarget(testConfig.Target.Container),
-				withBuildContext(ctx, t, src2Patch3ContextName, src2Patch3Context),
+				withBuildContext(ctx, t, patchContextName, patchContext),
 			)
 			sr.Evaluate = true
 


### PR DESCRIPTION
When a patch is in a subdir, the wrong path was used to extract the
patch from the source from.

Additionally, the call to `mountSources` was causing issues afer this
fix.
`mountSources` is just in this case is an optimization so to prevent
dpkg-source from having to re-extract data we already have available.
Since this is causing an issue I decided to just remove it for now.

I believe the two changes included in this PR are playing off each other (ie, one change requires a change in the other).
We'll need to look into this before including this optimization again.