### PR TITLE
deb: Do not create conffiles

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -369,7 +369,6 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 	}
 
 	if len(artifacts.ConfigFiles) > 0 {
-		buf := bytes.NewBuffer(nil)
 		sorted := dalec.SortMapKeys(artifacts.ConfigFiles)
 		for _, p := range sorted {
 			cfg := artifacts.ConfigFiles[p]
@@ -377,11 +376,7 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 			dir := filepath.Join("/etc", cfg.SubPath)
 			name := cfg.ResolveName(p)
 			writeInstall(p, dir, name)
-			fmt.Fprintln(buf, filepath.Join(dir, name))
 		}
-
-		// See: https://man7.org/linux/man-pages/man5/deb-conffiles.5.html for tracking config files in packages
-		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, "conffiles"), 0o640, buf.Bytes())))
 	}
 
 	if len(artifacts.Manpages) > 0 {

--- a/test/azlinux_test.go
+++ b/test/azlinux_test.go
@@ -1326,6 +1326,28 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 						},
 					},
 				},
+				"src3": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"hello": {
+									Contents: "world",
+								},
+							},
+						},
+					},
+				},
+				"src4": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"hello": {
+									Contents: "world4",
+								},
+							},
+						},
+					},
+				},
 			},
 			Build: dalec.ArtifactBuild{},
 			Artifacts: dalec.Artifacts{
@@ -1333,6 +1355,10 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 					"src1": {},
 					"src2": {
 						SubPath: "sysconfig",
+					},
+					"src3": {},
+					"src4": {
+						SubPath: "dirWithSubpath",
 					},
 				},
 			},
@@ -1342,6 +1368,12 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 					Files: map[string]dalec.FileCheckOutput{
 						"/etc/src1":           {},
 						"/etc/sysconfig/src2": {},
+						"/etc/src3/hello": {
+							CheckOutput: dalec.CheckOutput{Equals: "world"},
+						},
+						"/etc/dirWithSubpath/src4/hello": {
+							CheckOutput: dalec.CheckOutput{Equals: "world4"},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Historically, conffiles is used to help dpkg track configuration files so that user modifications don't get overwritten on upgrades.

Since debhelper v9 this is not needed for anything that goes into /etc as dpkg automatically tracks things under that path. Since we only put conf files into /etc we really don't need conffiles.

This resolves an issue where a spec lists a directory of configs in `artifacts.configFiles` instead of each individual config. With conffiles we end up listing the directory in there which will cause dpkg to error out on install.
