### PR TITLE
Breaking: Do not include package name in lib artifact paths

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -266,7 +266,7 @@ func fixupArtifactPerms(spec *dalec.Spec, target string, cfg *SourcePkgConfig) [
 	checkAndWritePerms(artifacts.Headers, HeadersPath)
 	checkAndWritePerms(artifacts.Licenses, filepath.Join(LicensesPath, spec.Name))
 	checkAndWritePerms(artifacts.Docs, filepath.Join(DocsPath, spec.Name))
-	checkAndWritePerms(artifacts.Libs, filepath.Join(LibsPath, spec.Name))
+	checkAndWritePerms(artifacts.Libs, filepath.Join(LibsPath))
 	checkAndWritePerms(artifacts.Libexec, LibexecPath)
 	checkAndWritePerms(artifacts.DataDirs, DataDirsPath)
 
@@ -583,7 +583,7 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 		for _, key := range sorted {
 			cfg := artifacts.Libs[key]
 			resolved := cfg.ResolveName(key)
-			writeInstall(key, filepath.Join(LibsPath, spec.Name, cfg.SubPath), resolved)
+			writeInstall(key, filepath.Join(LibsPath, cfg.SubPath), resolved)
 		}
 	}
 

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -614,7 +614,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 	libs := dalec.SortMapKeys(artifacts.Libs)
 	for _, l := range libs {
 		cfg := artifacts.Libs[l]
-		root := filepath.Join(`%{buildroot}/%{_libdir}`, w.Name)
+		root := filepath.Join(`%{buildroot}/%{_libdir}`)
 		copyArtifact(root, l, &cfg)
 	}
 
@@ -756,7 +756,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	libKeys := dalec.SortMapKeys(artifacts.Libs)
 	for _, l := range libKeys {
 		cfg := artifacts.Libs[l]
-		path := filepath.Join(`%{_libdir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
+		path := filepath.Join(`%{_libdir}`, cfg.SubPath, cfg.ResolveName(l))
 		fmt.Fprintln(b, path)
 	}
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -1812,10 +1812,10 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 				{
 					Name: "Check that lib files exist under package dir",
 					Files: map[string]dalec.FileCheckOutput{
-						filepath.Join(libDir, "test-library-files/lib1"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib1"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib1",
 						}},
-						filepath.Join(libDir, "test-library-files/lib2"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib2"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib2",
 						}},
 					},
@@ -1867,10 +1867,10 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 				{
 					Name: "Check that lib files exist under package dir",
 					Files: map[string]dalec.FileCheckOutput{
-						filepath.Join(libDir, "test-library-files/lib1"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib1"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib1",
 						}},
-						filepath.Join(libDir, "test-library-files/lib2"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib2"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib2",
 						}},
 					},
@@ -1931,13 +1931,13 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 				{
 					Name: "Check that lib files exist under package dir",
 					Files: map[string]dalec.FileCheckOutput{
-						filepath.Join(libDir, "test-library-files/lib1"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib1"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib1",
 						}},
-						filepath.Join(libDir, "test-library-files/lib2"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib2"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib2",
 						}},
-						filepath.Join(libDir, "test-library-files/lib3"): {CheckOutput: dalec.CheckOutput{
+						filepath.Join(libDir, "lib3"): {CheckOutput: dalec.CheckOutput{
 							Equals: "this is lib3",
 						}},
 					},


### PR DESCRIPTION
Libs should be able to be installed directly into `/usr/lib` rather than forcing everything to go into `/usr/lib/<package name>`.

Fixes #548 