### PR TITLE
Add option to disable strip on binaries

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -47,6 +47,9 @@ type Artifacts struct {
 	Users []AddUserConfig `yaml:"users,omitempty" json:"users,omitempty"`
 	// Groups is a list of groups to add to the system when the package is installed.
 	Groups []AddGroupConfig `yaml:"groups,omitempty" json:"groups,omitempty"`
+
+	// DisableStrip is used to disable stripping of artifacts.
+	DisableStrip bool `yaml:"disable_strip,omitempty" json:"disable_strip,omitempty"`
 }
 
 type ArtifactSymlinkConfig struct {

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -209,6 +209,12 @@
 					],
 					"description": "DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/"
 				},
+				"disable_strip": {
+					"type": [
+						"boolean"
+					],
+					"description": "DisableStrip is used to disable stripping of artifacts."
+				},
 				"docs": {
 					"additionalProperties": {
 						"$ref": "#/$defs/ArtifactConfig"

--- a/packaging/linux/deb/template_rules.go
+++ b/packaging/linux/deb/template_rules.go
@@ -182,3 +182,14 @@ func (w *rulesWrapper) OverrideSystemd() (fmt.Stringer, error) {
 
 	return b, nil
 }
+
+func (w *rulesWrapper) OverrideStrip() fmt.Stringer {
+	artifacts := w.Spec.GetArtifacts(w.target)
+
+	buf := &strings.Builder{}
+
+	if artifacts.DisableStrip {
+		buf.WriteString("override_dh_strip:\n")
+	}
+	return buf
+}

--- a/packaging/linux/deb/template_rules_test.go
+++ b/packaging/linux/deb/template_rules_test.go
@@ -190,3 +190,17 @@ Depends: ${misc:Depends},
 	actual = strings.TrimSpace(buf.String())
 	assert.Check(t, cmp.Equal(actual, strings.TrimSpace(expect)))
 }
+
+func TestRules_OverrideStrip(t *testing.T) {
+	w := &rulesWrapper{
+		Spec: &dalec.Spec{},
+	}
+
+	got := w.OverrideStrip()
+	assert.Equal(t, got.String(), "")
+
+	w.Spec.Artifacts.DisableStrip = true
+	got = w.OverrideStrip()
+	expect := "override_dh_strip:\n"
+	assert.Equal(t, got.String(), expect)
+}

--- a/packaging/linux/deb/templates/debian_rules.tmpl
+++ b/packaging/linux/deb/templates/debian_rules.tmpl
@@ -34,6 +34,8 @@ override_dh_dwz:
 
 {{ .OverrideSystemd }}
 
+{{ .OverrideStrip }}
+
 %:
 	dh $@ -v
 

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -18,6 +18,7 @@ const gomodsName = "__gomods"
 const buildScriptName = "build.sh"
 
 var specTmpl = template.Must(template.New("spec").Funcs(tmplFuncs).Parse(strings.TrimSpace(`
+{{.DisableStrip}}
 Name: {{.Name}}
 Version: {{.Version}}
 Release: {{.Release}}%{?dist}
@@ -774,6 +775,14 @@ func (w *specWrapper) Files() fmt.Stringer {
 	}
 	b.WriteString("\n")
 	return b
+}
+
+func (w *specWrapper) DisableStrip() string {
+	artifacts := w.Spec.GetArtifacts(w.Target)
+	if artifacts.DisableStrip {
+		return "%global __strip /bin/true"
+	}
+	return ""
 }
 
 // WriteSpec generates an rpm spec from the provided [dalec.Spec] and distro target and writes it to the passed in writer

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -838,5 +838,22 @@ OrderWithRequires(postun): systemd
 		want := "Requires(post): /usr/sbin/groupadd, /usr/bin/getent\n"
 		assert.Equal(t, got, want)
 	})
+}
 
+func TestTemplate_DisableStrip(t *testing.T) {
+	spec := &dalec.Spec{
+		Artifacts: dalec.Artifacts{
+			DisableStrip: true,
+		},
+	}
+
+	w := &specWrapper{Spec: spec}
+	want := `%global __strip /bin/true`
+	got := w.DisableStrip()
+	assert.Equal(t, got, want)
+
+	spec.Artifacts.DisableStrip = false
+	want = ""
+	got = w.DisableStrip()
+	assert.Equal(t, got, want)
 }

--- a/targets/linux/rpm/almalinux/common.go
+++ b/targets/linux/rpm/almalinux/common.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	builderPackages = []string{
+		"binutils",
 		"rpm-build",
 		"ca-certificates",
 	}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -77,5 +77,6 @@ func TestAlmalinux8(t *testing.T) {
 			ID:        "almalinux",
 			VersionID: "8",
 		},
+		SkipStripTest: true,
 	})
 }

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -77,5 +77,6 @@ func TestRockylinux8(t *testing.T) {
 			ID:        "rocky",
 			VersionID: "8",
 		},
+		SkipStripTest: true,
 	})
 }

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -315,3 +315,12 @@ artifacts:
   groups:
     - name: mygroup
 ```
+
+## Automatic Stripping
+
+Some builds may not work with binary stripping, in which case you can disable
+automatic stripping by setting `disable_strip: true`
+This is a global setting that applies to all artifacts only.
+
+If you want some binaries stripped and others not, you will need to manually
+strip them in the build phase.


### PR DESCRIPTION
This is required for some builds, namely building go. On debian targets there is a pretty easy work-around (without this change), but for rpm there is not.
