### PR TITLE
Pass spec and platform to use for building zip file name

### DIFF
--- a/targets/windows/handle_zip.go
+++ b/targets/windows/handle_zip.go
@@ -39,7 +39,7 @@ func handleZip(ctx context.Context, client gwclient.Client) (*gwclient.Result, e
 			return nil, nil, fmt.Errorf("unable to build binaries: %w", err)
 		}
 
-		st := getZipLLB(worker, spec.Name, bin, pg)
+		st := getZipLLB(worker, platform, spec, bin, pg)
 
 		def, err := st.Marshal(ctx)
 		if err != nil {
@@ -137,8 +137,9 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt)
 }
 
-func getZipLLB(worker llb.State, name string, artifacts llb.State, opts ...llb.ConstraintsOpt) llb.State {
-	outName := filepath.Join(outputDir, name+".zip")
+func getZipLLB(worker llb.State, platform *ocispecs.Platform, spec *dalec.Spec, artifacts llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	fileName := fmt.Sprintf("%s_%s-%s_%s.zip", spec.Name, spec.Version, spec.Revision, platform.Architecture)
+	outName := filepath.Join(outputDir, fileName)
 	zipped := worker.Run(
 		dalec.ShArgs("zip "+outName+" *"),
 		llb.Dir("/tmp/artifacts"),

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Azure/dalec"
@@ -120,6 +122,12 @@ deb [trusted=yes] copy:/opt/repo/ /
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
 		testWindowsDefaultPlatform(ctx, t)
+	})
+
+	t.Run("test zip filename", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testWindowsZipFilename(ctx, t)
 	})
 }
 
@@ -680,5 +688,37 @@ func testWindowsDefaultPlatform(ctx context.Context, t *testing.T) {
 	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
 		solveT(ctx, t, gwc, sr)
+	})
+}
+
+func testWindowsZipFilename(ctx context.Context, t *testing.T) {
+	spec := newSimpleSpec()
+	spec.Build.Steps = []dalec.BuildStep{
+		{
+			Command: "echo \"hello world\" >> output.ps1",
+		},
+	}
+	spec.Artifacts.Binaries = map[string]dalec.ArtifactConfig{
+		"output.ps1": {},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
+		res := solveT(ctx, t, gwc, sr)
+		ref, err := res.SingleRef()
+		if err != nil {
+			t.Fatalf("shouldn't get an error wile calling SingleRef()")
+		}
+		filename := fmt.Sprintf("/%s_%s-%s_%s.zip", spec.Name, spec.Version, spec.Revision, runtime.GOARCH)
+		stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: filename})
+		if err != nil {
+			t.Fatalf("should have gotten a file: %s: %s", filename, err)
+		}
+		if stat == nil {
+			t.Fatalf("should have gotten stat when getting %s", filename)
+		}
+		if stat.Path != filepath.Base(filename) {
+			t.Fatalf("expected paths to match: %s - %s", stat.Path, filename)
+		}
 	})
 }

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -706,19 +706,11 @@ func testWindowsZipFilename(ctx context.Context, t *testing.T) {
 		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
 		res := solveT(ctx, t, gwc, sr)
 		ref, err := res.SingleRef()
-		if err != nil {
-			t.Fatalf("shouldn't get an error wile calling SingleRef()")
-		}
+		assert.NilError(t, err)
 		filename := fmt.Sprintf("/%s_%s-%s_%s.zip", spec.Name, spec.Version, spec.Revision, runtime.GOARCH)
 		stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: filename})
-		if err != nil {
-			t.Fatalf("should have gotten a file: %s: %s", filename, err)
-		}
-		if stat == nil {
-			t.Fatalf("should have gotten stat when getting %s", filename)
-		}
-		if stat.Path != filepath.Base(filename) {
-			t.Fatalf("expected paths to match: %s - %s", stat.Path, filename)
-		}
+		assert.NilError(t, err)
+		assert.Assert(t, stat != nil)
+		assert.Equal(t, stat.Path, filepath.Base(filename))
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Passes platform and spec to the function that builds the zip from the LLB.  This is needed to build a more proper filename like:

```
<name>_<ver>-<rev>_<arch>.zip
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
