### PR TITLE
rpm: fix issue when installing base deps conflicts with package deps

### DIFF
--- a/targets/linux/deb/distro/container.go
+++ b/targets/linux/deb/distro/container.go
@@ -1,6 +1,7 @@
 package distro
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/dalec"
@@ -8,7 +9,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 )
 
-func (c *Config) BuildContainer(client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, debSt llb.State, opts ...llb.ConstraintsOpt) (llb.State, error) {
+func (c *Config) BuildContainer(ctx context.Context, client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, debSt llb.State, opts ...llb.ConstraintsOpt) (llb.State, error) {
 	bi, err := spec.GetSingleBase(targetKey)
 	if err != nil {
 		return llb.Scratch(), err

--- a/targets/linux/distro_handler.go
+++ b/targets/linux/distro_handler.go
@@ -35,7 +35,7 @@ type DistroConfig interface {
 
 	// BuildContainer consumes an llb.State containing the built package from the
 	// given *dalec.Spec, and installs it in a target container.
-	BuildContainer(client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts,
+	BuildContainer(ctx context.Context, client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts,
 		spec *dalec.Spec, targetKey string,
 		pkgState llb.State, opts ...llb.ConstraintsOpt) (llb.State, error)
 
@@ -106,7 +106,7 @@ func HandleContainer(c DistroConfig) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			ctr, err := c.BuildContainer(client, worker, sOpt, spec, targetKey, deb)
+			ctr, err := c.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, deb)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -161,7 +161,7 @@ func HandlePackage(cfg DistroConfig) gwclient.BuildFunc {
 				return ref, nil, err
 			}
 
-			ctr, err := cfg.BuildContainer(client, worker, sOpt, spec, targetKey, pkgSt)
+			ctr, err := cfg.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, pkgSt)
 			if err != nil {
 				return ref, nil, err
 			}

--- a/targets/linux/rpm/azlinux/azlinux3.go
+++ b/targets/linux/rpm/azlinux/azlinux3.go
@@ -25,7 +25,7 @@ var Azlinux3Config = &distro.Config{
 
 	ReleaseVer:         "3.0",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"distroless-packages-minimal", "prebuilt-ca-certificates"},
+	BasePackages:       []string{"distroless-packages-minimal", "(prebuilt-ca-certificates or ca-certificates)"},
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,
 }

--- a/targets/linux/rpm/azlinux/mariner2.go
+++ b/targets/linux/rpm/azlinux/mariner2.go
@@ -22,7 +22,7 @@ var Mariner2Config = &distro.Config{
 
 	ReleaseVer:         "2.0",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"distroless-packages-minimal", "prebuilt-ca-certificates"},
+	BasePackages:       []string{"distroless-packages-minimal", "(prebuilt-ca-certificates or ca-certificates)"},
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,
 }


### PR DESCRIPTION
This now uses a virtual package to install base dependencies. In doing so the base dependcies can now be more expressive.

This is needed by azlinux/mariner so that packages can depend on `ca-certificates` without causing a conflict with the base package `prebuilt-ca-certificates`