### PR TITLE
azlinux: use weak dependency for prebuilt-ca-certificates

### DIFF
--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -35,6 +35,7 @@ BuildArch: noarch
 {{- .Provides -}}
 {{- .Replaces -}}
 {{- .Requires -}}
+{{- .Recommends -}}
 
 %description
 {{.Description}}
@@ -184,6 +185,26 @@ func (w *specWrapper) Requires() fmt.Stringer {
 		writeDep(b, "Requires", name, constraints)
 	}
 
+	b.WriteString("\n")
+	return b
+}
+
+func (w *specWrapper) Recommends() fmt.Stringer {
+	b := &strings.Builder{}
+	deps := w.GetPackageDeps(w.Target)
+	if deps == nil {
+		return b
+	}
+
+	if len(deps.Recommends) == 0 {
+		return b
+	}
+
+	keys := dalec.SortMapKeys(deps.Recommends)
+	for _, name := range keys {
+		constraints := deps.Recommends[name]
+		writeDep(b, "Recommends", name, constraints)
+	}
 	b.WriteString("\n")
 	return b
 }

--- a/targets/linux/rpm/almalinux/common.go
+++ b/targets/linux/rpm/almalinux/common.go
@@ -30,3 +30,29 @@ var (
 func Handlers(ctx context.Context, client gwclient.Client, m *frontend.BuildMux) error {
 	return frontend.LoadBuiltinTargets(targets)(ctx, client, m)
 }
+
+func basePackages(name string) []dalec.Spec {
+	const (
+		base    = "dalec-base-"
+		license = "Apache-2.0"
+
+		version = "0.0.1"
+		rev     = "1"
+	)
+
+	return []dalec.Spec{
+		{
+			Name:        base + name,
+			Version:     version,
+			Revision:    rev,
+			License:     license,
+			Description: "DALEC base packages for " + name,
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					"almalinux-release": {},
+					"tzdata":            {},
+				},
+			},
+		},
+	}
+}

--- a/targets/linux/rpm/almalinux/v8.go
+++ b/targets/linux/rpm/almalinux/v8.go
@@ -24,7 +24,7 @@ var ConfigV8 = &distro.Config{
 
 	ReleaseVer:         "8",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"almalinux-release", "tzdata"},
+	BasePackages:       basePackages(v8TargetKey),
 	RepoPlatformConfig: &defaultPlatformConfig,
 	InstallFunc:        distro.DnfInstall,
 }

--- a/targets/linux/rpm/almalinux/v9.go
+++ b/targets/linux/rpm/almalinux/v9.go
@@ -24,7 +24,7 @@ var ConfigV9 = &distro.Config{
 
 	ReleaseVer:         "9",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"almalinux-release", "tzdata"},
+	BasePackages:       basePackages(v9TargetKey),
 	RepoPlatformConfig: &defaultPlatformConfig,
 	InstallFunc:        distro.DnfInstall,
 }

--- a/targets/linux/rpm/azlinux/azlinux3.go
+++ b/targets/linux/rpm/azlinux/azlinux3.go
@@ -25,7 +25,7 @@ var Azlinux3Config = &distro.Config{
 
 	ReleaseVer:         "3.0",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"distroless-packages-minimal", "(prebuilt-ca-certificates or ca-certificates)"},
+	BasePackages:       basePackages(AzLinux3TargetKey),
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,
 }

--- a/targets/linux/rpm/azlinux/common.go
+++ b/targets/linux/rpm/azlinux/common.go
@@ -31,3 +31,32 @@ var (
 func Handlers(ctx context.Context, client gwclient.Client, m *frontend.BuildMux) error {
 	return frontend.LoadBuiltinTargets(targets)(ctx, client, m)
 }
+
+func basePackages(name string) []dalec.Spec {
+	const (
+		distMin  = "distroless-packages-minimal"
+		prebuilt = "prebuilt-ca-certificates"
+		base     = "dalec-base-"
+		license  = "Apache-2.0"
+		version  = "0.0.1"
+		rev      = "1"
+	)
+
+	return []dalec.Spec{
+		{
+			Name:        base + name,
+			Version:     version,
+			Revision:    rev,
+			License:     license,
+			Description: "DALEC base packages for " + name,
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					distMin: {},
+				},
+				Recommends: map[string]dalec.PackageConstraints{
+					prebuilt: {},
+				},
+			},
+		},
+	}
+}

--- a/targets/linux/rpm/azlinux/mariner2.go
+++ b/targets/linux/rpm/azlinux/mariner2.go
@@ -22,7 +22,7 @@ var Mariner2Config = &distro.Config{
 
 	ReleaseVer:         "2.0",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"distroless-packages-minimal", "(prebuilt-ca-certificates or ca-certificates)"},
+	BasePackages:       basePackages(Mariner2TargetKey),
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,
 }

--- a/targets/linux/rpm/distro/distro.go
+++ b/targets/linux/rpm/distro/distro.go
@@ -24,7 +24,7 @@ type Config struct {
 	BuilderPackages []string
 
 	// Dependencies to install in base image
-	BasePackages       []string
+	BasePackages       []dalec.Spec
 	RepoPlatformConfig *dalec.RepoPlatformConfig
 
 	DefaultOutputImage string

--- a/targets/linux/rpm/rockylinux/common.go
+++ b/targets/linux/rpm/rockylinux/common.go
@@ -29,3 +29,29 @@ var (
 func Handlers(ctx context.Context, client gwclient.Client, m *frontend.BuildMux) error {
 	return frontend.LoadBuiltinTargets(targets)(ctx, client, m)
 }
+
+func basePackages(name string) []dalec.Spec {
+	const (
+		base    = "dalec-base-"
+		license = "Apache-2.0"
+
+		version = "0.0.1"
+		rev     = "1"
+	)
+
+	return []dalec.Spec{
+		{
+			Name:        base + name,
+			Version:     version,
+			Revision:    rev,
+			License:     license,
+			Description: "DALEC base packages for " + name,
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					"rocky-release": {},
+					"tzdata":        {},
+				},
+			},
+		},
+	}
+}

--- a/targets/linux/rpm/rockylinux/v8.go
+++ b/targets/linux/rpm/rockylinux/v8.go
@@ -24,7 +24,7 @@ var ConfigV8 = &distro.Config{
 
 	ReleaseVer:         "8",
 	BuilderPackages:    builderPackages,
-	BasePackages:       []string{"rocky-release", "tzdata"},
+	BasePackages:       basePackages(v8TargetKey),
 	RepoPlatformConfig: &defaultPlatformConfig,
 	InstallFunc:        distro.DnfInstall,
 }

--- a/targets/linux/rpm/rockylinux/v9.go
+++ b/targets/linux/rpm/rockylinux/v9.go
@@ -24,7 +24,7 @@ var ConfigV9 = &distro.Config{
 
 	ReleaseVer:         "9",
 	BuilderPackages:    append(builderPackages, "systemd-rpm-macros"),
-	BasePackages:       []string{"rocky-release", "tzdata"},
+	BasePackages:       basePackages(v9TargetKey),
 	RepoPlatformConfig: &defaultPlatformConfig,
 	InstallFunc:        distro.DnfInstall,
 }


### PR DESCRIPTION
As it turns out, the previous "fix" was causing dnf to *always* choose `ca-certificates`, presumably because it is what it sees first in the package repo.

By using a weak dependency we can allow the built package to depend on ca-certificates and ignore the prebuilt-ca-certificates but by default install the prebuilt ones.

The end result of the previous case is we end up with bash and some other tools int he final image, which is undesirable.

ref: https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/
