### PR TITLE
Properly pass through target platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
 
       - name: download deps
         run: go mod download
+      - name: Setup QEMU
+        run: docker run --rm --privileged tonistiigi/binfmt:latest --install all
       - name: Run integration tests
         run: |
           set -ex

--- a/frontend/build.go
+++ b/frontend/build.go
@@ -167,8 +167,12 @@ func BuildWithPlatformFromUIClient(ctx context.Context, client gwclient.Client, 
 // image in the build context matching the image ref.
 //
 // This follows the behavior of of the dockerfile frontend.
-func GetBaseImage(sOpt dalec.SourceOpts, ref string) llb.State {
+func GetBaseImage(sOpt dalec.SourceOpts, ref string, opts ...llb.ConstraintsOpt) llb.State {
 	return llb.Scratch().Async(func(ctx context.Context, _ llb.State, c *llb.Constraints) (llb.State, error) {
+		for _, o := range opts {
+			o.SetConstraintsOption(c)
+		}
+
 		fromClient, err := sOpt.GetContext(ref, dalec.WithConstraint(c))
 		if err != nil {
 			return llb.Scratch(), err
@@ -177,7 +181,8 @@ func GetBaseImage(sOpt dalec.SourceOpts, ref string) llb.State {
 		if fromClient != nil {
 			return *fromClient, nil
 		}
-		return llb.Image(ref, llb.WithMetaResolver(sOpt.Resolver), dalec.WithConstraint(c)), nil
+
+		return llb.Image(ref, dalec.WithConstraint(c), llb.WithMetaResolver(sOpt.Resolver)), nil
 	})
 }
 

--- a/frontend/debug/handle_gomod.go
+++ b/frontend/debug/handle_gomod.go
@@ -16,7 +16,7 @@ const keyGomodWorker = "context:gomod-worker"
 // Gomods outputs all the gomodule dependencies for the spec
 func Gomods(ctx context.Context, client gwclient.Client) (*client.Result, error) {
 	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
-		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		sOpt, err := frontend.SourceOptFromClient(ctx, client, platform)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -34,7 +34,7 @@ func Gomods(ctx context.Context, client gwclient.Client) (*client.Result, error)
 				Run(llb.Shlex("apk add --no-cache go git ca-certificates patch")).Root()
 		}
 
-		st, err := spec.GomodDeps(sOpt, worker)
+		st, err := spec.GomodDeps(sOpt, worker, dalec.Platform(platform))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -634,3 +634,12 @@ func BaseImageConfig(platform *ocispecs.Platform) *DockerImageSpec {
 
 	return img
 }
+
+// Platform returns a [llb.ConstraintsOpt] that sets the platform to the provided platform
+// If the platform is nil, the [llb.ConstraintOpt] is a no-op.
+func Platform(platform *ocispecs.Platform) llb.ConstraintsOpt {
+	if platform == nil {
+		return constraintsOptFunc(func(c *llb.Constraints) {})
+	}
+	return llb.Platform(*platform)
+}

--- a/source.go
+++ b/source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/gitutil"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -225,12 +226,13 @@ var (
 
 type LLBGetter func(sOpts SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error)
 
-type ForwarderFunc func(llb.State, *SourceBuild) (llb.State, error)
+type ForwarderFunc func(llb.State, *SourceBuild, ...llb.ConstraintsOpt) (llb.State, error)
 
 type SourceOpts struct {
-	Resolver   llb.ImageMetaResolver
-	Forward    ForwarderFunc
-	GetContext func(string, ...llb.LocalOption) (*llb.State, error)
+	Resolver       llb.ImageMetaResolver
+	Forward        ForwarderFunc
+	GetContext     func(string, ...llb.LocalOption) (*llb.State, error)
+	TargetPlatform *ocispecs.Platform
 }
 
 func (s *Source) asState(name string, forMount bool, sOpt SourceOpts, opts ...llb.ConstraintsOpt) (llb.State, error) {

--- a/source_build.go
+++ b/source_build.go
@@ -61,7 +61,7 @@ func (src *SourceBuild) AsState(name string, sOpt SourceOpts, opts ...llb.Constr
 		st = llb.Scratch()
 	}
 
-	st, err = sOpt.Forward(st, src)
+	st, err = sOpt.Forward(st, src, opts...)
 	if err != nil {
 		return llb.Scratch(), err
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -837,7 +837,7 @@ func getSourceOp(ctx context.Context, t *testing.T, src Source) []*pb.Op {
 		if src.Build.Source.Inline == nil || src.Build.Source.Inline.File == nil {
 			t.Fatal("Cannot test from a Dockerfile without inline content")
 		}
-		sOpt.Forward = func(_ llb.State, build *SourceBuild) (llb.State, error) {
+		sOpt.Forward = func(_ llb.State, build *SourceBuild, _ ...llb.ConstraintsOpt) (llb.State, error) {
 			// Note, we can't really test anything other than inline here because we don't have access to the actual buildkit client,
 			// so we can't extract extract the dockerfile from the input state (nor do we have any input state)
 			src := []byte(src.Build.Source.Inline.File.Contents)

--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -91,12 +91,13 @@ func (cfg *Config) HandleDepsOnly(ctx context.Context, client gwclient.Client) (
 
 		pg := dalec.ProgressGroup("Build " + targetKey + " deps-only container for: " + spec.Name)
 
-		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		sOpt, err := frontend.SourceOptFromClient(ctx, client, platform)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		worker, err := cfg.Worker(sOpt, pg)
+		pc := dalec.Platform(platform)
+		worker, err := cfg.Worker(sOpt, pg, pc)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -109,12 +110,12 @@ func (cfg *Config) HandleDepsOnly(ctx context.Context, client gwclient.Client) (
 					DnfDownloadAllDeps("/tmp/rpms/RPMS/$(uname -m)"))).Root()
 			rpmDir = llb.Scratch().File(llb.Copy(withDownloads, "/tmp/rpms", "/", dalec.WithDirContentsOnly()))
 		}
-		ctr, err := cfg.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, rpmDir, pg)
+		ctr, err := cfg.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, rpmDir, pg, pc)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		def, err := ctr.Marshal(ctx, pg)
+		def, err := ctr.Marshal(ctx, pc)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -228,7 +228,7 @@ func (cfg *Config) installBuildDepsPackage(worker llb.State, target string, pack
 	}
 }
 
-func (cfg *Config) InstallBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+func (cfg *Config) InstallBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	deps := spec.GetBuildDeps(targetKey)
 	if len(deps) == 0 {
 		return func(in llb.State) llb.State { return in }
@@ -236,7 +236,7 @@ func (cfg *Config) InstallBuildDeps(ctx context.Context, client gwclient.Client,
 
 	repos := spec.GetBuildRepos(targetKey)
 
-	sOpt, err := frontend.SourceOptFromClient(ctx, client)
+	sOpt, err := frontend.SourceOptFromClient(ctx, client, sOpt.TargetPlatform)
 	if err != nil {
 		return nil
 	}

--- a/targets/linux/rpm/distro/pkg.go
+++ b/targets/linux/rpm/distro/pkg.go
@@ -25,7 +25,7 @@ func (c *Config) Validate(spec *dalec.Spec) error {
 }
 
 func (c *Config) BuildPkg(ctx context.Context, client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
-	worker = worker.With(c.InstallBuildDeps(ctx, client, spec, targetKey, opts...))
+	worker = worker.With(c.InstallBuildDeps(ctx, client, spec, sOpt, targetKey, opts...))
 
 	br, err := rpm.SpecToBuildrootLLB(worker, spec, sOpt, targetKey, opts...)
 	if err != nil {
@@ -61,7 +61,7 @@ func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, worker 
 	}
 
 	withTestDeps := cfg.InstallTestDeps(worker, sOpt, targetKey, spec, opts...)
-	err = frontend.RunTests(ctx, client, spec, ref, withTestDeps, targetKey)
+	err = frontend.RunTests(ctx, client, spec, ref, withTestDeps, targetKey, sOpt.TargetPlatform)
 	return ref, errors.Wrap(err, "TESTS FAILED")
 }
 

--- a/targets/windows/handle_container.go
+++ b/targets/windows/handle_container.go
@@ -47,7 +47,7 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 		return nil, fmt.Errorf("multi-platform output is not supported")
 	}
 
-	sOpt := frontend.SourceOptFromUIClient(ctx, client, dc)
+	sOpt := frontend.SourceOptFromUIClient(ctx, client, dc, nil)
 
 	spec, err := frontend.LoadSpec(ctx, dc, nil)
 	if err != nil {

--- a/targets/windows/handle_zip.go
+++ b/targets/windows/handle_zip.go
@@ -23,7 +23,7 @@ const (
 
 func handleZip(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
-		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		sOpt, err := frontend.SourceOptFromClient(ctx, client, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/targets/windows/handler.go
+++ b/targets/windows/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/dalec/frontend"
 	"github.com/Azure/dalec/targets/linux/deb/distro"
 	"github.com/containerd/platforms"
-	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	bktargets "github.com/moby/buildkit/frontend/subrequests/targets"
@@ -72,17 +71,12 @@ func Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 
 func handleWorker(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 	return frontend.BuildWithPlatform(ctx, client, func(ctx context.Context, client gwclient.Client, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string) (gwclient.Reference, *dalec.DockerImageSpec, error) {
-		sOpt, err := frontend.SourceOptFromClient(ctx, client)
+		sOpt, err := frontend.SourceOptFromClient(ctx, client, nil)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		var opts []llb.ConstraintsOpt
-		if platform != nil {
-			opts = append(opts, llb.Platform(*platform))
-		}
-
-		st, err := distroConfig.Worker(sOpt, opts...)
+		st, err := distroConfig.Worker(sOpt)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -100,9 +94,7 @@ func handleWorker(ctx context.Context, client gwclient.Client) (*gwclient.Result
 			return nil, nil, err
 		}
 
-		_, _, dt, err := client.ResolveImageConfig(ctx, workerImgRef, sourceresolver.Opt{
-			Platform: platform,
-		})
+		_, _, dt, err := client.ResolveImageConfig(ctx, workerImgRef, sourceresolver.Opt{})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/dalec/targets/linux/rpm/almalinux"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestAlmalinux9(t *testing.T) {
@@ -40,6 +41,11 @@ func TestAlmalinux9(t *testing.T) {
 			ID:        "almalinux",
 			VersionID: "9",
 		},
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("el9"),
 	})
 }
 
@@ -78,5 +84,10 @@ func TestAlmalinux8(t *testing.T) {
 			VersionID: "8",
 		},
 		SkipStripTest: true,
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("el8"),
 	})
 }

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -73,6 +73,11 @@ func TestMariner2(t *testing.T) {
 			ID:        "mariner",
 			VersionID: "2.0",
 		},
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("cm2"),
 	}
 
 	testLinuxDistro(ctx, t, cfg)
@@ -109,6 +114,11 @@ func TestAzlinux3(t *testing.T) {
 			ID:        "azurelinux",
 			VersionID: "3.0",
 		},
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("azl3"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testAzlinuxExtra(ctx, t, cfg)

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/dalec/targets/linux/rpm/rockylinux"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestRockylinux9(t *testing.T) {
@@ -40,6 +41,11 @@ func TestRockylinux9(t *testing.T) {
 			ID:        "rocky",
 			VersionID: "9",
 		},
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("el9"),
 	})
 }
 
@@ -78,5 +84,10 @@ func TestRockylinux8(t *testing.T) {
 			VersionID: "8",
 		},
 		SkipStripTest: true,
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+		PackageOutputPath: rpmTargetOutputPath("el8"),
 	})
 }

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -58,6 +58,13 @@ func debLinuxTestConfigFor(targetKey string, cfg *distro.Config, opts ...func(*t
 			TestRepoConfig: ubuntuTestRepoConfig,
 			Constraints:    debConstraintsSymbols,
 		},
+
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+			{OS: "linux", Architecture: "arm", Variant: "v7"},
+		},
+		PackageOutputPath: debTargetOutputPath(cfg.VersionID),
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
This makes sure that the requested target platform is propagated everywhere it needs to be.

There are some room for improvements here.
For example, source packages really should not
depend on the target platform and we could get
away with using the native platform there.
These kinds of improvements will require some
code restructuring which is out of scope for this
change.
