### PR TITLE
Fix test output format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           if [ -n "${TEST_SKIP}" ]; then
             skip="-skip=${TEST_SKIP}"
           fi
-          go test -timeout=30m -v -json ${run} ${skip} ./test | go run ./cmd/test2json2gha --slow 120s
+          go test -timeout=30m -v -json ${run} ${skip} ./test | go run ./cmd/test2json2gha --slow 120s --logdir /tmp/testlogs
         env:
           TEST_SUITE: ${{ matrix.suite }}
           TEST_SKIP: ${{ matrix.skip }}
@@ -174,6 +174,13 @@ jobs:
         with:
           name: integration-test-reports-${{matrix.suite}}
           path: /tmp/reports/*
+          retention-days: 1
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-${{matrix.suite}}
+          path: /tmp/testlogs/*
           retention-days: 1
 
 

--- a/cmd/test2json2gha/event.go
+++ b/cmd/test2json2gha/event.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"io"
+	"iter"
+	"math"
 	"os"
+	"path"
+	"strings"
 	"time"
 
+	"github.com/Azure/dalec"
 	"github.com/pkg/errors"
+)
+
+const (
+	pass = "pass"
+	fail = "fail"
+	skip = "skip"
 )
 
 // TestEvent is the go test2json event data structure we receive from `go test`
@@ -18,39 +30,129 @@ type TestEvent struct {
 	Output  string
 }
 
-// TestResult is where we collect all the data about a test
-type TestResult struct {
-	output  *os.File
-	failed  bool
-	pkg     string
-	name    string
-	elapsed float64
-	skipped bool
+type EventHandler interface {
+	HandleEvent(te *TestEvent) error
 }
 
-func (r *TestResult) Close() {
-	r.output.Close()
+type ResultsFormatter interface {
+	FormatResults(results iter.Seq[*TestResult], out io.Writer) error
 }
 
-func collectTestOutput(te *TestEvent, tr *TestResult) error {
+// outputStreamer is an [EventHandler] that writes the test output to the console
+// This allows receiving the test output in real time
+type outputStreamer struct {
+	out io.Writer
+}
+
+func (h *outputStreamer) HandleEvent(te *TestEvent) error {
 	if te.Output != "" {
-		_, err := tr.output.Write([]byte(te.Output))
+		_, err := h.out.Write([]byte(te.Output))
+		return err
+	}
+	return nil
+}
+
+// resultsHandler is an [EventHandler] that gathers all the results from every event
+// handled.
+type resultsHandler struct {
+	results map[string]*TestResult
+}
+
+func (h *resultsHandler) getOutputStream(te *TestEvent) (*TestResult, error) {
+	key := path.Join(te.Package, te.Test)
+	tr := h.results[key]
+	if tr != nil {
+		return tr, nil
+	}
+
+	f, err := os.CreateTemp("", strings.ReplaceAll(key, "/", "-"))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	tr = &TestResult{output: f, pkg: te.Package, name: te.Test}
+	if h.results == nil {
+		h.results = make(map[string]*TestResult)
+	}
+	h.results[key] = tr
+	return tr, nil
+}
+
+func (h *resultsHandler) HandleEvent(te *TestEvent) error {
+	tr, err := h.getOutputStream(te)
+	if err != nil {
+		return err
+	}
+
+	switch te.Action {
+	case fail:
+		tr.failed = true
+	case skip:
+		tr.skipped = true
+	}
+
+	tr.elapsed = te.Elapsed
+
+	if te.Output != "" {
+		_, err := tr.output.WriteString(te.Output)
 		if err != nil {
 			return errors.Wrap(err, "error collecting test event output")
 		}
 	}
 
-	tr.pkg = te.Package
-	tr.name = te.Test
-	if te.Elapsed > 0 {
-		tr.elapsed = te.Elapsed
-	}
+	return nil
+}
 
-	if te.Action == "fail" {
-		tr.failed = true
+func (h *resultsHandler) Results() iter.Seq[*TestResult] {
+	keys := dalec.SortMapKeys(h.results)
+	return func(yield func(*TestResult) bool) {
+		for _, key := range keys {
+			tr := h.results[key]
+			if !yield(tr) {
+				break
+			}
+		}
 	}
-	if te.Action == "skip" {
-		tr.skipped = true
+}
+
+func (h *resultsHandler) Close() {
+	for _, tr := range h.results {
+		tr.Close()
+	}
+}
+
+// TestResult is where we collect all the data about a test
+type TestResult struct {
+	output  *os.File
+	pkg     string
+	name    string
+	failed  bool
+	skipped bool
+	elapsed float64
+}
+
+// [Close] closes the underlying output file and invalidates any readers
+// created from [TestResult.Reader].
+func (r *TestResult) Close() {
+	r.output.Close()
+}
+
+// Reader creates a new reader that contains all the test output
+// Calling [TestResult.Reader] multiple times will return a new, independent reader
+// each time.
+//
+// Calling [TestResult.Close] will close the underlying file, any readers created before or
+// after will be invalid after that and should return an [io.EOF] error on read.
+func (r *TestResult) Reader() io.Reader {
+	return io.NewSectionReader(r.output, 0, math.MaxInt64)
+}
+
+// checkFailed is an [EventHandler] that checks if any test has failed
+// and sets the [checkFailed] to true if so.
+type checkFailed bool
+
+func (c *checkFailed) HandleEvent(te *TestEvent) error {
+	if te.Action == "fail" {
+		*c = true
 	}
 	return nil
 }

--- a/cmd/test2json2gha/event.go
+++ b/cmd/test2json2gha/event.go
@@ -197,7 +197,7 @@ func (r *TestResult) Close() {
 //
 // Calling [TestResult.Close] will close the underlying file, any readers created before or
 // after will be invalid after that and should return an [io.EOF] error on read.
-func (r *TestResult) Reader() io.Reader {
+func (r *TestResult) Reader() *io.SectionReader {
 	return io.NewSectionReader(r.output, 0, math.MaxInt64)
 }
 

--- a/cmd/test2json2gha/event_test.go
+++ b/cmd/test2json2gha/event_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"io"
+	"iter"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+const (
+	testEventJSON = `
+{"Time":"2025-03-31T09:46:20.078814-07:00","Action":"start","Package":"some_package"}
+{"Time":"2025-03-31T09:46:20.327453-07:00","Action":"run","Package":"some_package","Test":"TestGenPass"}
+{"Time":"2025-03-31T09:46:20.327531-07:00","Action":"output","Package":"some_package","Test":"TestGenPass","Output":"=== RUN   TestGenPass\n"}
+{"Time":"2025-03-31T09:46:20.327583-07:00","Action":"output","Package":"some_package","Test":"TestGenPass","Output":"    foo_test.go:38: some log\n"}
+{"Time":"2025-03-31T09:46:20.32762-07:00","Action":"output","Package":"some_package","Test":"TestGenPass","Output":"--- PASS: TestGenPass (0.00s)\n"}
+{"Time":"2025-03-31T09:46:20.327654-07:00","Action":"pass","Package":"some_package","Test":"TestGenPass","Elapsed":0}
+{"Time":"2025-03-31T09:46:20.327706-07:00","Action":"run","Package":"some_package","Test":"TestGenFail"}
+{"Time":"2025-03-31T09:46:20.327713-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"=== RUN   TestGenFail\n"}
+{"Time":"2025-03-31T09:46:20.327757-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"    foo_test.go:42: some error\n"}
+{"Time":"2025-03-31T09:46:20.327773-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"    foo_test.go:43: some fatal error\n"}
+{"Time":"2025-03-31T09:46:20.327918-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"--- FAIL: TestGenFail (0.00s)\n"}
+{"Time":"2025-03-31T09:46:20.327934-07:00","Action":"fail","Package":"some_package","Test":"TestGenFail","Elapsed":0}
+{"Time":"2025-03-31T09:46:20.327943-07:00","Action":"run","Package":"some_package","Test":"TestGenSkip"}
+{"Time":"2025-03-31T09:46:20.327948-07:00","Action":"output","Package":"some_package","Test":"TestGenSkip","Output":"=== RUN   TestGenSkip\n"}
+{"Time":"2025-03-31T09:46:20.327954-07:00","Action":"output","Package":"some_package","Test":"TestGenSkip","Output":"    foo_test.go:47: some skip reason\n"}
+{"Time":"2025-03-31T09:46:20.327971-07:00","Action":"output","Package":"some_package","Test":"TestGenSkip","Output":"--- SKIP: TestGenSkip (0.00s)\n"}
+{"Time":"2025-03-31T09:46:20.327977-07:00","Action":"skip","Package":"some_package","Test":"TestGenSkip","Elapsed":0}
+{"Time":"2025-03-31T09:46:20.328007-07:00","Action":"output","Package":"some_package","Output":"FAIL\n"}
+{"Time":"2025-03-31T09:46:20.328475-07:00","Action":"output","Package":"some_package","Output":"FAIL\tsome_package\t0.249s\n"}
+{"Time":"2025-03-31T09:46:20.32851-07:00","Action":"fail","Package":"some_package","Elapsed":0.25}
+`
+
+	testEventPassOutput    = "=== RUN   TestGenPass\n    foo_test.go:38: some log\n--- PASS: TestGenPass (0.00s)\n"
+	testEventFailOutput    = "=== RUN   TestGenFail\n    foo_test.go:42: some error\n    foo_test.go:43: some fatal error\n--- FAIL: TestGenFail (0.00s)\n"
+	testEventSkipOutput    = "=== RUN   TestGenSkip\n    foo_test.go:47: some skip reason\n--- SKIP: TestGenSkip (0.00s)\n"
+	testEventPackageOutput = "FAIL\nFAIL\tsome_package\t0.249s\n"
+
+	testPackageName = "some_package"
+)
+
+func mockTestResults(t *testing.T) iter.Seq[*TestResult] {
+	h := &resultsHandler{results: make(map[string]*TestResult)}
+	t.Cleanup(func() {
+		h.Close()
+	})
+
+	return h.Results()
+}
+
+func readTestEvents(t *testing.T) iter.Seq[*TestEvent] {
+	dec := json.NewDecoder(strings.NewReader(testEventJSON))
+	te := &TestEvent{}
+
+	return func(yield func(*TestEvent) bool) {
+		t.Helper()
+
+		for {
+			*te = TestEvent{}
+			err := dec.Decode(te)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			assert.NilError(t, err)
+			if !yield(te) {
+				break
+			}
+		}
+	}
+}
+
+func TestOutputStreamer(t *testing.T) {
+
+	var output strings.Builder
+	streamer := &outputStreamer{out: &output}
+
+	for event := range readTestEvents(t) {
+		err := streamer.HandleEvent(event)
+		assert.NilError(t, err)
+	}
+
+	expectedOutput := testEventPassOutput + testEventFailOutput + testEventSkipOutput + testEventPackageOutput
+	assert.Equal(t, output.String(), expectedOutput)
+}
+
+func TestOutputStreamer_HandleEvent(t *testing.T) {
+	var output strings.Builder
+	streamer := &outputStreamer{out: &output}
+
+	for event := range readTestEvents(t) {
+		err := streamer.HandleEvent(event)
+		assert.NilError(t, err)
+	}
+
+	expectedOutput := testEventPassOutput + testEventFailOutput + testEventSkipOutput + testEventPackageOutput
+	assert.Equal(t, output.String(), expectedOutput)
+}
+
+func TestResultsHandler(t *testing.T) {
+	// Validate specific results
+	for r := range mockTestResults(t) {
+		assert.Check(t, cmp.Equal(r.pkg, testPackageName))
+		switch r.name {
+		case "TestGenPass":
+			assert.Check(t, !r.failed)
+			assert.Check(t, !r.skipped)
+			output, err := io.ReadAll(r.Reader())
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(string(output), testEventPassOutput))
+		case "TestGenFail":
+			assert.Check(t, r.failed)
+			assert.Check(t, !r.skipped)
+			output, err := io.ReadAll(r.Reader())
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(string(output), testEventFailOutput))
+		case "TestGenSkip":
+			assert.Check(t, !r.failed)
+			assert.Check(t, r.skipped)
+			output, err := io.ReadAll(r.Reader())
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(string(output), testEventSkipOutput))
+		case "":
+			assert.Check(t, r.failed)
+			output, err := io.ReadAll(r.Reader())
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(string(output), testEventPackageOutput))
+		default:
+			t.Fatalf("unexpected test result: %s", r.name)
+		}
+	}
+}
+
+func TestCheckFailed(t *testing.T) {
+	var failed checkFailed
+
+	for event := range readTestEvents(t) {
+		err := failed.HandleEvent(event)
+		assert.NilError(t, err)
+	}
+
+	assert.Assert(t, bool(failed), "expected checkFailed to be true after a fail event")
+
+	t.Run("HandleMultipleEvents_NoFailures", func(t *testing.T) {
+		var failed checkFailed
+		events := []*TestEvent{
+			{Action: "pass", Package: "mypackage", Test: "Test1", Output: "file1.go:10: Test1 passed\n"},
+			{Action: "skip", Package: "mypackage", Test: "Test3", Output: "file3.go:30: Test3 skipped\n"},
+		}
+
+		for _, event := range events {
+			err := failed.HandleEvent(event)
+			assert.NilError(t, err)
+		}
+
+		assert.Assert(t, !bool(failed), "expected checkFailed to be false when no fail events are present")
+	})
+}

--- a/cmd/test2json2gha/event_test.go
+++ b/cmd/test2json2gha/event_test.go
@@ -26,6 +26,7 @@ const (
 {"Time":"2025-03-31T09:46:20.327706-07:00","Action":"run","Package":"some_package","Test":"TestGenFail"}
 {"Time":"2025-03-31T09:46:20.327713-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"=== RUN   TestGenFail\n"}
 {"Time":"2025-03-31T09:46:20.327757-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"    foo_test.go:42: some error\n"}
+{"Time":"2025-03-31T09:46:20.327758-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"    build.go.go:42: some build message\n"}
 {"Time":"2025-03-31T09:46:20.327773-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"    foo_test.go:43: some fatal error\n"}
 {"Time":"2025-03-31T09:46:20.327918-07:00","Action":"output","Package":"some_package","Test":"TestGenFail","Output":"--- FAIL: TestGenFail (0.00s)\n"}
 {"Time":"2025-03-31T09:46:20.327934-07:00","Action":"fail","Package":"some_package","Test":"TestGenFail","Elapsed":0}
@@ -40,9 +41,12 @@ const (
 `
 
 	testEventPassOutput    = "=== RUN   TestGenPass\n    foo_test.go:38: some log\n--- PASS: TestGenPass (0.00s)\n"
-	testEventFailOutput    = "=== RUN   TestGenFail\n    foo_test.go:42: some error\n    foo_test.go:43: some fatal error\n--- FAIL: TestGenFail (0.00s)\n"
+	testEventFailOutput    = "=== RUN   TestGenFail\n    foo_test.go:42: some error\n    build.go.go:42: some build message\n    foo_test.go:43: some fatal error\n--- FAIL: TestGenFail (0.00s)\n"
 	testEventSkipOutput    = "=== RUN   TestGenSkip\n    foo_test.go:47: some skip reason\n--- SKIP: TestGenSkip (0.00s)\n"
 	testEventPackageOutput = "FAIL\nFAIL\tsome_package\t0.249s\n"
+
+	// This is for the error annotations handler which skips build logs so as not to overflow the github annotation.
+	testLogsAnnotation = "    foo_test.go:42: some error\n    foo_test.go:43: some fatal error\n"
 
 	testPackageName = "some_package"
 )

--- a/cmd/test2json2gha/github.go
+++ b/cmd/test2json2gha/github.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	groupHeader = "::group::"
+	groupFooter = "::endgroup::\n"
+)
+
+// consoleFormatter writes annotations using the github actions console format
+// It creates a gruop for each test.
+// Note, the console format does not support nested groupings, so subtests are in their own group.
+//
+// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+type consoleFormatter struct {
+	modName string
+	verbose bool
+}
+
+func (c *consoleFormatter) FormatResults(results iter.Seq[*TestResult], out io.Writer) error {
+	var rdrs []io.Reader
+
+	for tr := range results {
+		if tr.name == "" {
+			continue
+		}
+
+		if !c.verbose && !tr.failed {
+			// Skip non-failed tests if not verbose
+			continue
+		}
+
+		pkg := strings.TrimPrefix(tr.pkg, c.modName)
+		pkg = strings.TrimPrefix(pkg, "/")
+
+		group := pkg
+		if group != "" && tr.name != "" {
+			group += "."
+		}
+		group += tr.name
+
+		hdr := strings.NewReader(groupHeader + group + "\n")
+		output := tr.Reader()
+		footer := strings.NewReader(groupFooter)
+
+		rdrs = append(rdrs, io.MultiReader(hdr, output, footer))
+	}
+
+	_, err := io.Copy(out, io.MultiReader(rdrs...))
+	if err != nil {
+		return fmt.Errorf("failed to write console results: %w", err)
+	}
+	return nil
+}
+
+type errorAnnotationFormatter struct{}
+
+func (c *errorAnnotationFormatter) FormatResults(results iter.Seq[*TestResult], out io.Writer) error {
+	var rdrs []io.Reader
+	for tr := range results {
+		if !tr.failed || tr.name == "" {
+			continue
+		}
+
+		rdrs = append(rdrs, asErrorAnnotations(tr))
+	}
+
+	_, err := io.Copy(out, io.MultiReader(rdrs...))
+	if err != nil {
+		return fmt.Errorf("failed to write error annotations: %w", err)
+	}
+	return nil
+}
+
+func asErrorAnnotations(tr *TestResult) io.Reader {
+	return &errorAnnotationReader{
+		tr: tr,
+	}
+}
+
+type errorAnnotationReader struct {
+	tr  *TestResult
+	rdr io.Reader
+}
+
+func (a *errorAnnotationReader) Read(p []byte) (n int, err error) {
+	if a.rdr == nil {
+		// First get the last file and line number from the output
+		file, line, err := getLastFileLine(a.tr.Reader())
+		if err != nil {
+			return -1, err
+		}
+
+		// Create the header
+		hdr := strings.NewReader(fmt.Sprintf("::error file=%s,line=%d::", file, line))
+		footer := strings.NewReader("\n")
+
+		// Setup the underlying reader
+		rdr := bufio.NewReader(a.tr.Reader())
+		a.rdr = io.MultiReader(hdr, &urlEncodeNewlineReader{rdr}, footer)
+	}
+
+	return a.rdr.Read(p)
+}
+
+// urlEncodeNewlineReader is a reader that replaces newlines with %0A
+// (the url encoded version of a newline) in the output.
+// This is used to format the output for GitHub Actions annotations.
+// This is a workaround for the fact that GitHub Actions does not support
+// newlines in annotations, so we need to encode them.
+type urlEncodeNewlineReader struct {
+	rdr *bufio.Reader
+}
+
+func (r *urlEncodeNewlineReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	peekSize := len(p)
+	if peekSize > r.rdr.Size() {
+		peekSize = r.rdr.Size()
+	}
+
+	peeked, err := r.rdr.Peek(peekSize)
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			return 0, fmt.Errorf("failed to peek: %w", err)
+		}
+		if len(peeked) == 0 {
+			return 0, io.EOF
+		}
+	}
+
+	// Pre-allocate output with the best-case size (same as peeked length)
+	output := make([]byte, 0, len(peeked))
+	consumed := 0 // Track the number of bytes consumed from peeked
+
+	for i := range peeked {
+		if peeked[i] == '\n' {
+			output = append(output, '%', '0', 'A')
+		} else {
+			output = append(output, peeked[i])
+		}
+
+		consumed++
+		if len(output) >= len(p) {
+			break
+		}
+	}
+
+	// Consume the bytes we processed from the underlying reader
+	_, err = r.rdr.Discard(consumed)
+	if err != nil {
+		return 0, err
+	}
+
+	return copy(p, output), nil
+}
+
+func getLastFileLine(rdr io.Reader) (file string, line int, retErr error) {
+	scanner := bufio.NewScanner(rdr)
+
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		slog.Error("failed to get last file and line", "error", retErr, "scanner data", scanner.Text())
+	}()
+
+	for scanner.Scan() {
+		txt := scanner.Text()
+		f, l, ok := getTestOutputLoc(txt)
+		if !ok {
+			continue
+		}
+
+		file = f
+
+		ll, err := strconv.Atoi(l)
+		if err != nil {
+			slog.Error("failed to parse line number", "line", l, "err", err)
+			continue
+		}
+		line = ll
+	}
+	return file, line, scanner.Err()
+}
+
+func getTestOutputLoc(s string) (string, string, bool) {
+	file, other, ok := strings.Cut(s, ":")
+	if !ok {
+		return "", "", false
+	}
+	line, _, ok := strings.Cut(other, ":")
+	if !ok {
+		return "", "", false
+	}
+
+	return strings.TrimSpace(file), line, true
+}
+
+func getSummaryFile() io.WriteCloser {
+	// https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary
+	v := os.Getenv("GITHUB_STEP_SUMMARY")
+	if v == "" {
+		return &nopWriteCloser{io.Discard}
+	}
+
+	f, err := os.OpenFile(v, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		slog.Error("Error opening step summary file", "error", err)
+		return &nopWriteCloser{io.Discard}
+	}
+	return f
+}

--- a/cmd/test2json2gha/github_test.go
+++ b/cmd/test2json2gha/github_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConsoleFormatter_FormatResults(t *testing.T) {
+	handler := &resultsHandler{}
+
+	for event := range readTestEvents(t) {
+		err := handler.HandleEvent(event)
+		assert.NilError(t, err)
+	}
+
+	var output bytes.Buffer
+	formatter := &consoleFormatter{modName: "mypackage", verbose: false}
+
+	err := formatter.FormatResults(handler.Results(), &output)
+	assert.NilError(t, err)
+
+	expected := "::group::some_package.TestGenFail\n" + testEventFailOutput + "::endgroup::\n"
+	assert.Equal(t, output.String(), expected)
+}
+
+func TestErrorAnnotationFormatter_FormatResults(t *testing.T) {
+	handler := &resultsHandler{results: make(map[string]*TestResult)}
+
+	for event := range readTestEvents(t) {
+		err := handler.HandleEvent(event)
+		assert.NilError(t, err)
+	}
+
+	var output bytes.Buffer
+	formatter := &errorAnnotationFormatter{}
+
+	err := formatter.FormatResults(handler.Results(), &output)
+	assert.NilError(t, err)
+
+	expected := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testEventFailOutput, "\n", "%0A") + "\n"
+	assert.Equal(t, output.String(), expected)
+}
+
+func TestGetLastFileLine(t *testing.T) {
+	input := "file1.go:10: some error\nfile2.go:20: another error\n"
+	rdr := strings.NewReader(input)
+	file, line, err := getLastFileLine(rdr)
+	assert.NilError(t, err)
+	assert.Equal(t, file, "file2.go")
+	assert.Equal(t, line, 20)
+}
+
+func TestGetTestOutputLoc(t *testing.T) {
+	t.Run("ValidInput", func(t *testing.T) {
+		file, line, ok := getTestOutputLoc("file.go:123: some output")
+		assert.Assert(t, ok)
+		assert.Equal(t, file, "file.go")
+		assert.Equal(t, line, "123")
+	})
+
+	t.Run("InvalidInput", func(t *testing.T) {
+		_, _, ok := getTestOutputLoc("invalid input")
+		assert.Assert(t, !ok)
+	})
+}
+
+func TestUrlEncodeNewlineReader(t *testing.T) {
+	input := "line1\nline2\nline3"
+	rdr := &urlEncodeNewlineReader{rdr: bufio.NewReader(strings.NewReader(input))}
+	output, err := io.ReadAll(rdr)
+	assert.NilError(t, err)
+	assert.Equal(t, string(output), "line1%0Aline2%0Aline3")
+}

--- a/cmd/test2json2gha/github_test.go
+++ b/cmd/test2json2gha/github_test.go
@@ -42,22 +42,22 @@ func TestErrorAnnotationFormatter_FormatResults(t *testing.T) {
 	err := formatter.FormatResults(handler.Results(), &output)
 	assert.NilError(t, err)
 
-	expected := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testEventFailOutput, "\n", "%0A") + "\n"
+	expected := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testLogsAnnotation, "\n", "%0A") + "\n"
 	assert.Equal(t, output.String(), expected)
 }
 
 func TestGetLastFileLine(t *testing.T) {
-	input := "file1.go:10: some error\nfile2.go:20: another error\n"
+	input := "    file1_test.go:10: some error\n    file2_test.go:20: another error\n"
 	rdr := strings.NewReader(input)
 	file, line, err := getLastFileLine(rdr)
 	assert.NilError(t, err)
-	assert.Equal(t, file, "file2.go")
+	assert.Equal(t, file, "file2_test.go")
 	assert.Equal(t, line, 20)
 }
 
 func TestGetTestOutputLoc(t *testing.T) {
 	t.Run("ValidInput", func(t *testing.T) {
-		file, line, ok := getTestOutputLoc("file.go:123: some output")
+		file, line, ok := getTestOutputLoc("    file.go:123: some output")
 		assert.Assert(t, ok)
 		assert.Equal(t, file, "file.go")
 		assert.Equal(t, line, "123")

--- a/cmd/test2json2gha/main.go
+++ b/cmd/test2json2gha/main.go
@@ -1,32 +1,36 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
-	"path"
-	"path/filepath"
 	"runtime/debug"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/vearutop/dynhist-go"
 )
+
+type config struct {
+	slowThreshold time.Duration
+	modName       string
+	verbose       bool
+	stream        bool
+}
 
 func main() {
 	tmp, err := os.MkdirTemp("", "test2json2gha-")
 	if err != nil {
 		panic(err)
 	}
+	var cfg config
 
-	var slowThreshold time.Duration
-	flag.DurationVar(&slowThreshold, "slow", 500*time.Millisecond, "Threshold to mark test as slow")
+	flag.DurationVar(&cfg.slowThreshold, "slow", 500*time.Millisecond, "Threshold to mark test as slow")
+	flag.BoolVar(&cfg.verbose, "verbose", false, "Enable verbose output")
+	flag.BoolVar(&cfg.stream, "stream", false, "Enable streaming output")
 
 	flag.Parse()
 
@@ -34,9 +38,8 @@ func main() {
 	slog.SetDefault(logger)
 
 	info, _ := debug.ReadBuildInfo()
-	var mod string
 	if info != nil {
-		mod = info.Main.Path
+		cfg.modName = info.Main.Path
 	}
 
 	// Set TMPDIR so that [os.CreateTemp] can use an empty string as the dir
@@ -45,14 +48,12 @@ func main() {
 
 	cleanup := func() { os.RemoveAll(tmp) }
 
-	anyFail, err := do(os.Stdin, os.Stdout, mod, slowThreshold)
+	anyFail, err := do(os.Stdin, os.Stdout, cfg)
+	cleanup()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v", err)
-		cleanup()
 		os.Exit(1)
 	}
-
-	cleanup()
 
 	if anyFail {
 		// In case pipefail is not enabled, make sure we exit non-zero
@@ -60,223 +61,84 @@ func main() {
 	}
 }
 
-func do(in io.Reader, out io.Writer, modName string, slowThreshold time.Duration) (bool, error) {
+func do(in io.Reader, out io.Writer, cfg config) (bool, error) {
 	dec := json.NewDecoder(in)
 
-	te := &TestEvent{}
-
-	outs := make(map[string]*TestResult)
+	results := &resultsHandler{}
 	defer func() {
-		for _, tr := range outs {
-			tr.Close()
-		}
+		var wg waitGroup
+
+		wg.Go(func() {
+			var rf ResultsFormatter
+			rf = &consoleFormatter{modName: cfg.modName, verbose: cfg.verbose}
+			if err := rf.FormatResults(results.Results(), out); err != nil {
+				slog.Error("Error writing annotations", "error", err)
+			}
+
+			rf = &errorAnnotationFormatter{}
+			if err := rf.FormatResults(results.Results(), out); err != nil {
+				slog.Error("Error writing error annotations", "error", err)
+			}
+		})
+
+		wg.Go(func() {
+			summary := getSummaryFile()
+			formatter := &summaryFormatter{slowThreshold: cfg.slowThreshold}
+			if err := formatter.FormatResults(results.Results(), getSummaryFile()); err != nil {
+				slog.Error("Error writing summary", "error", err)
+			}
+			summary.Close()
+		})
+
+		wg.Go(func() {
+
+		})
+
+		wg.Wait()
+
+		results.Close()
 	}()
 
-	getOutputStream := func() (*TestResult, error) {
-		key := path.Join(te.Package, te.Test)
-		tr := outs[key]
-		if tr == nil {
-			f, err := os.CreateTemp("", strings.Replace(key, "/", "-", -1))
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-			tr = &TestResult{output: f}
-			outs[key] = tr
-		}
-		return tr, nil
+	var anyFailed checkFailed
+	handlers := []EventHandler{
+		results,
+		&anyFailed,
 	}
 
+	if cfg.stream {
+		handlers = append(handlers, &outputStreamer{out: out})
+	}
+
+	te := &TestEvent{}
 	for {
-		*te = TestEvent{}
-		if err := dec.Decode(te); err != nil {
-			if err == io.EOF {
+		*te = TestEvent{} // Reset the event struct to avoid reusing old data
+
+		err := dec.Decode(te)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return false, errors.WithStack(err)
 		}
 
-		tr, err := getOutputStream()
-		if err != nil {
-			return false, err
-		}
-		if err := collectTestOutput(te, tr); err != nil {
-			slog.Error("Error handing event test event", "error", err)
-		}
-	}
-
-	buf := bufio.NewWriter(out)
-
-	summaryF := getSummaryFile()
-	defer summaryF.Close()
-
-	var failCount, skipCount int
-	var elapsed float64
-
-	failBuf := bytes.NewBuffer(nil)
-	hist := &dynhist.Collector{
-		PrintSum:     true,
-		WeightFunc:   dynhist.ExpWidth(1.2, 0.9),
-		BucketsLimit: 10,
-	}
-
-	slowBuf := bytes.NewBuffer(nil)
-	slow := slowThreshold.Seconds()
-
-	for _, tr := range outs {
-		if tr.skipped {
-			skipCount++
-		}
-
-		if tr.failed {
-			failCount++
-		}
-
-		hist.Add(tr.elapsed)
-		elapsed += tr.elapsed
-
-		if tr.name == "" {
-			// Don't write generic package-level details unless its a failure
-			// since there is nothing interesting here.
-			if !tr.failed {
-				continue
+		for _, h := range handlers {
+			if err := h.HandleEvent(te); err != nil {
+				slog.Error("Error handling event", "error", err)
 			}
 		}
-
-		if err := writeResult(tr, buf, failBuf, modName); err != nil {
-			slog.Error("Error writing result", "error", err)
-			continue
-		}
-
-		if tr.elapsed > slow {
-			fmt.Fprintf(slowBuf, "%s %.3fs\n", tr.name, tr.elapsed)
-		}
-
-		if err := buf.Flush(); err != nil {
-			slog.Error(err.Error())
-		}
 	}
 
-	fmt.Fprintln(summaryF, "## Test metrics")
-	separator := strings.Repeat("&nbsp;", 4)
-	fmt.Fprintln(summaryF, mdBold("Skipped:"), skipCount, separator, mdBold("Failed:"), failCount, separator, mdBold("Total:"), len(outs), separator, mdBold("Elapsed:"), fmt.Sprintf("%.3fs", elapsed))
-
-	fmt.Fprintln(summaryF, mdPreformat(hist.String()))
-
-	if failBuf.Len() > 0 {
-		fmt.Fprintln(summaryF, "## Failures")
-		fmt.Fprintln(summaryF, failBuf.String())
-	}
-
-	if slowBuf.Len() > 0 {
-		fmt.Fprintln(summaryF, "## Slow Tests")
-		fmt.Fprintln(summaryF, slowBuf.String())
-	}
-
-	return failCount > 0, nil
+	return bool(anyFailed), nil
 }
 
-func (c *nopWriteCloser) Close() error { return nil }
-
-func getSummaryFile() io.WriteCloser {
-	// https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary
-	v := os.Getenv("GITHUB_STEP_SUMMARY")
-	if v == "" {
-		return &nopWriteCloser{io.Discard}
-	}
-
-	f, err := os.OpenFile(v, os.O_WRONLY|os.O_APPEND, 0)
-	if err != nil {
-		slog.Error("Error opening step summary file", "error", err)
-		return &nopWriteCloser{io.Discard}
-	}
-	return f
+type waitGroup struct {
+	sync.WaitGroup
 }
 
-func writeResult(tr *TestResult, out, failBuf io.Writer, modName string) error {
-	if tr.name == "" {
-		return nil
-	}
-
-	if _, err := tr.output.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("error seeking to beginning of test output: %w", err)
-	}
-
-	pkg := strings.TrimPrefix(tr.pkg, modName)
-	pkg = strings.TrimPrefix(pkg, "/")
-
-	group := pkg
-	if group != "" && tr.name != "" {
-		group += "."
-	}
-	group += tr.name
-	var prefix string
-	if tr.failed {
-		// Adds a red X emoji to the front of the group name to more easily spot
-		// failures
-		prefix = "\u274c "
-	}
-
-	fmt.Fprintf(out, "::group::%s %.3fs\n", prefix+group, tr.elapsed)
-	defer func() {
-		fmt.Fprintln(out, "::endgroup::")
+func (wg *waitGroup) Go(f func()) {
+	wg.Add(1)
+	go func() {
+		f()
+		wg.Done()
 	}()
-
-	var rdr io.Reader = tr.output
-
-	if !tr.failed {
-		if _, err := io.Copy(out, rdr); err != nil {
-			return fmt.Errorf("error writing test output to output stream: %w", err)
-		}
-		return nil
-	}
-
-	failLog := bytes.NewBuffer(nil)
-	rdr = io.TeeReader(rdr, failLog)
-	defer func() {
-		fmt.Fprintln(failBuf, mdLog(tr.name+fmt.Sprintf(" %3.fs", tr.elapsed), failLog))
-	}()
-
-	scanner := bufio.NewScanner(rdr)
-
-	var (
-		file, line string
-	)
-
-	buf := bytes.NewBuffer(nil)
-
-	for scanner.Scan() {
-		txt := scanner.Text()
-		f, l, ok := getTestOutputLoc(txt)
-		if ok {
-			file = f
-			line = l
-		}
-
-		// %0A is the url encoded form of \n.
-		// This allows a multi-line message as an annotation
-		// See https://github.com/actions/toolkit/issues/193#issuecomment-605394935
-		buf.WriteString(txt + "%0A")
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading test output: %w", err)
-	}
-
-	file = filepath.Join(pkg, file)
-	fmt.Fprintf(out, "::error file=%s,line=%s::%s\n", file, line, buf)
-
-	return nil
-}
-
-func getTestOutputLoc(s string) (string, string, bool) {
-	file, other, ok := strings.Cut(s, ":")
-	if !ok {
-		return "", "", false
-	}
-	line, _, ok := strings.Cut(other, ":")
-	if !ok {
-		return "", "", false
-	}
-
-	return strings.TrimSpace(file), line, true
 }

--- a/cmd/test2json2gha/main_test.go
+++ b/cmd/test2json2gha/main_test.go
@@ -19,7 +19,7 @@ func TestDo(t *testing.T) {
 	passGroup := "::group::some_package.TestGenPass\n" + testEventPassOutput + "::endgroup::\n"
 	failGroup := "::group::some_package.TestGenFail\n" + testEventFailOutput + "::endgroup::\n"
 	skipGroup := "::group::some_package.TestGenSkip\n" + testEventSkipOutput + "::endgroup::\n"
-	annotation := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testEventFailOutput, "\n", "%0A") + "\n"
+	annotation := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testLogsAnnotation, "\n", "%0A") + "\n"
 
 	t.Run("verbose=false", func(t *testing.T) {
 		input := strings.NewReader(testEventJSON)

--- a/cmd/test2json2gha/main_test.go
+++ b/cmd/test2json2gha/main_test.go
@@ -125,4 +125,27 @@ some_package: 0.250s
 
 		assert.Equal(t, string(output), expect)
 	})
+
+	t.Run("LogDir", func(t *testing.T) {
+		input := strings.NewReader(testEventJSON)
+		var output bytes.Buffer
+
+		logDir := t.TempDir()
+		cfg := config{
+			slowThreshold: 500,
+			modName:       "github.com/Azure/dalec/cmd/test2json2gha",
+			verbose:       false,
+			stream:        false,
+			logDir:        logDir,
+		}
+
+		anyFail, err := do(input, &output, cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, anyFail, "expected anyFail to be true due to failed tests")
+
+		// Validate that logs are written to the specified directory
+		entries, err := os.ReadDir(logDir)
+		assert.NilError(t, err)
+		assert.Assert(t, len(entries) > 0, "expected log files to be written to the log directory")
+	})
 }

--- a/cmd/test2json2gha/main_test.go
+++ b/cmd/test2json2gha/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+const (
+	testModuleName = "some/module/name"
+)
+
+func TestDo(t *testing.T) {
+	passGroup := "::group::some_package.TestGenPass\n" + testEventPassOutput + "::endgroup::\n"
+	failGroup := "::group::some_package.TestGenFail\n" + testEventFailOutput + "::endgroup::\n"
+	skipGroup := "::group::some_package.TestGenSkip\n" + testEventSkipOutput + "::endgroup::\n"
+	annotation := "::error file=foo_test.go,line=43::" + strings.ReplaceAll(testEventFailOutput, "\n", "%0A") + "\n"
+
+	t.Run("verbose=false", func(t *testing.T) {
+		input := strings.NewReader(testEventJSON)
+		var output bytes.Buffer
+
+		cfg := config{
+			slowThreshold: 200 * time.Millisecond,
+			modName:       testModuleName,
+			verbose:       false,
+			stream:        false,
+		}
+
+		anyFail, err := do(input, &output, cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, anyFail, "expected anyFail to be true due to failed tests")
+
+		// Non-verbose output should only include the grouped fail events + error annotations
+		expected := failGroup + annotation
+		assert.Equal(t, output.String(), expected)
+	})
+
+	t.Run("verbose=true", func(t *testing.T) {
+		input := strings.NewReader(testEventJSON)
+		var output bytes.Buffer
+
+		cfg := config{
+			slowThreshold: 200 * time.Millisecond,
+			modName:       testModuleName,
+			verbose:       true,
+			stream:        false,
+		}
+
+		anyFail, err := do(input, &output, cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, anyFail, "expected anyFail to be true due to failed tests")
+
+		// verbose output should include grouped events for all test results + error annotations
+		expected := failGroup + passGroup + skipGroup + annotation
+		t.Log(output.String())
+		assert.Equal(t, output.String(), expected)
+	})
+
+	t.Run("stream=true", func(t *testing.T) {
+		input := strings.NewReader(testEventJSON)
+		var output bytes.Buffer
+
+		cfg := config{
+			slowThreshold: 200 * time.Millisecond,
+			modName:       testModuleName,
+			verbose:       false,
+			stream:        true,
+		}
+
+		anyFail, err := do(input, &output, cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, anyFail, "expected anyFail to be true due to failed tests")
+
+		// Stream output should include all the raw events + the grouped fail events + the annotation
+		expected := testEventPassOutput + testEventFailOutput + testEventSkipOutput + testEventPackageOutput + failGroup + annotation
+		assert.Equal(t, output.String(), expected)
+	})
+
+	t.Run("summary", func(t *testing.T) {
+		dir := t.TempDir()
+		f, err := os.CreateTemp(dir, "summary")
+		assert.NilError(t, err)
+		defer f.Close()
+
+		t.Setenv("GITHUB_STEP_SUMMARY", f.Name())
+
+		input := strings.NewReader(testEventJSON)
+
+		cfg := config{
+			slowThreshold: 200 * time.Millisecond,
+			modName:       testModuleName,
+			verbose:       false,
+			stream:        false,
+		}
+
+		anyFail, err := do(input, io.Discard, cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, anyFail, "expected anyFail to be true due to failed tests")
+
+		output, err := os.ReadFile(f.Name())
+		assert.NilError(t, err)
+
+		expect := `## Test metrics
+**Skipped:** 1 &nbsp;&nbsp;&nbsp;&nbsp; **Failed:** 2 &nbsp;&nbsp;&nbsp;&nbsp; **Total:** 4 &nbsp;&nbsp;&nbsp;&nbsp; **Elapsed:** 0.250s
+
+` + "```" + `
+[ min  max] cnt total%  sum (4 events)
+[0.00 0.00] 3 75.00% 0.00 ...........................................................................
+[0.25 0.25] 1 25.00% 0.25 .........................
+` + "```" + `
+
+## Slow tests
+
+` + "```" + `
+some_package: 0.250s
+` + "```" + `
+
+`
+
+		assert.Equal(t, string(output), expect)
+	})
+}

--- a/cmd/test2json2gha/markdown.go
+++ b/cmd/test2json2gha/markdown.go
@@ -3,32 +3,18 @@ package main
 import (
 	"fmt"
 	"io"
-	"strings"
 )
 
 func mdBold(v string) string {
 	return "**" + v + "**"
 }
 
-func mdDetails(s string) string {
-	return fmt.Sprintf("\n<details>\n%s\n</details>\n", s)
-}
-
-func mdSummary(s string) string {
-	return "<summary>" + s + "</summary>\n"
-}
-
 func mdPreformat(s string) string {
-	return fmt.Sprintf("\n```\n%s\n```\n", s)
+	return fmt.Sprintf("\n```\n%s```\n", s)
 }
 
 type nopWriteCloser struct {
 	io.Writer
 }
 
-func mdLog(head string, content fmt.Stringer) string {
-	sb := &strings.Builder{}
-	sb.WriteString(mdSummary(head))
-	sb.WriteString(mdPreformat(content.String()))
-	return mdDetails(sb.String())
-}
+func (c *nopWriteCloser) Close() error { return nil }

--- a/cmd/test2json2gha/summary.go
+++ b/cmd/test2json2gha/summary.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"iter"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/vearutop/dynhist-go"
+)
+
+type summaryFormatter struct {
+	slowThreshold time.Duration
+}
+
+func (f *summaryFormatter) FormatResults(results iter.Seq[*TestResult], out io.Writer) error {
+	hist := &dynhist.Collector{
+		PrintSum:     true,
+		WeightFunc:   dynhist.ExpWidth(1.2, 0.9),
+		BucketsLimit: 10,
+	}
+
+	slowBuf := &strings.Builder{}
+
+	var (
+		totalTime    float64
+		skipped      int
+		failed       int
+		totalResults int
+	)
+	for result := range results {
+		hist.Add(result.elapsed)
+		totalTime += result.elapsed
+		totalResults++
+
+		if result.skipped {
+			skipped++
+		}
+		if result.failed {
+			failed++
+		}
+
+		if result.elapsed > f.slowThreshold.Seconds() {
+			slowBuf.WriteString(fmt.Sprintf("%s: %.3fs\n", path.Join(result.pkg, result.name), result.elapsed))
+		}
+	}
+
+	fmt.Fprintln(out, "## Test metrics")
+	separator := strings.Repeat("&nbsp;", 4)
+	fmt.Fprintln(out, mdBold("Skipped:"), skipped, separator, mdBold("Failed:"), failed, separator, mdBold("Total:"), totalResults, separator, mdBold("Elapsed:"), fmt.Sprintf("%.3fs", totalTime))
+
+	fmt.Fprintln(out, mdPreformat(hist.String()))
+
+	if slowBuf.Len() > 0 {
+		fmt.Fprintln(out, "## Slow tests")
+		fmt.Fprintln(out, mdPreformat(slowBuf.String()))
+	}
+
+	return nil
+}

--- a/cmd/test2json2gha/summary_test.go
+++ b/cmd/test2json2gha/summary_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSummaryFormatter_FormatResults(t *testing.T) {
+	results := []*TestResult{
+		{pkg: "mypackage", name: "Test1", elapsed: 0.5, skipped: false, failed: false},
+		{pkg: "mypackage", name: "Test2", elapsed: 1.5, skipped: false, failed: true},
+		{pkg: "mypackage", name: "Test3", elapsed: 0.2, skipped: true, failed: false},
+		{pkg: "mypackage", name: "Test4", elapsed: 2.0, skipped: false, failed: false},
+	}
+
+	expected := `## Test metrics
+**Skipped:** 1 &nbsp;&nbsp;&nbsp;&nbsp; **Failed:** 1 &nbsp;&nbsp;&nbsp;&nbsp; **Total:** 4 &nbsp;&nbsp;&nbsp;&nbsp; **Elapsed:** 4.200s
+
+` + "```" + `
+[ min  max] cnt total%  sum (4 events)
+[0.20 0.20] 1 25.00% 0.20 .........................
+[0.50 0.50] 1 25.00% 0.50 .........................
+[1.50 1.50] 1 25.00% 1.50 .........................
+[2.00 2.00] 1 25.00% 2.00 .........................
+` + "```" + `
+
+## Slow tests
+
+` + "```" + `
+mypackage/Test2: 1.500s
+mypackage/Test4: 2.000s
+` + "```" + `
+
+`
+
+	formatter := &summaryFormatter{slowThreshold: 1 * time.Second}
+	var output bytes.Buffer
+
+	err := formatter.FormatResults(slices.Values(results), &output)
+	assert.NilError(t, err)
+	t.Log(output.String())
+	assert.Equal(t, output.String(), expected)
+}

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -27,7 +27,7 @@ func testBuildNetworkMode(ctx context.Context, t *testing.T, cfg targetConfig) {
 	for _, tc := range cases {
 		name := "mode=" + tc.mode
 		if tc.mode == "" {
-			name += "<unset>"
+			name += "unset"
 		}
 
 		t.Run(name, func(t *testing.T) {

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -214,5 +214,4 @@ func testAzlinuxBaseDeps(ctx context.Context, t *testing.T, cfg targetConfig) {
 		req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Container))
 		solveT(ctx, t, client, req)
 	})
-
 }


### PR DESCRIPTION
Fixes a few issues with the test output parsing in CI:

1. Do not output successful tests to the console. This makes the console basically impossible to render because its too much data.
2. Upload all test logs as artifacts to the CI system (as a replacement to 1).
3. Fix handling of new-lines on errors... mainly we were converting newlines to HTML escaped ones for annotations, but this messed up the console view and made it illegible.
4. Move error annotations to a completely separate output
5. Do not output build logs to the error annotations as this overflows the max annotation size and hides the error. Instead only show logs directly generated from test files.
6. Add option to stream the test output to the console as it is received.
7. Basically rewrites most of it to make things easier to read and adds tests.