### PR TITLE
deb: Upgrade before install container packages

### DIFF
--- a/targets/linux/deb/distro/container.go
+++ b/targets/linux/deb/distro/container.go
@@ -58,7 +58,7 @@ func (c *Config) BuildContainer(ctx context.Context, client gwclient.Client, wor
 			// passes (as it is looking at these files).
 			llb.AddMount("/etc/dpkg/dpkg.cfg.d/excludes", tmp, llb.SourcePath("tmp")).SetRunOption(cfg)
 		}),
-		InstallLocalPkg(debSt, opts...),
+		InstallLocalPkg(debSt, true, opts...),
 	).Root().
 		With(c.createSymlinks(worker, spec, targetKey, opts...)), nil
 }

--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -82,7 +82,7 @@ rm -rf /var/lib/apt/lists/partial/*
 apt update
 
 if [ "${DALEC_UPGRADE}" = "true" ]; then
-		apt dist-upgrade -y
+	apt dist-upgrade -y
 fi
 
 if apt install -y ${1}; then


### PR DESCRIPTION
This makes sure the container is fully up to
date in case the container image is stale.