### PR TITLE
Add custom marshalling for changelog date

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -436,11 +436,8 @@
 					"description": "Changes is the list of changes in the changelog entry."
 				},
 				"date": {
-					"type": [
-						"string"
-					],
-					"description": "Date is the date of the changelog entry.",
-					"format": "date-time"
+					"$ref": "#/$defs/Date",
+					"description": "Date is the date of the changelog entry.\nDates are formatted as YYYY-MM-DD"
 				}
 			},
 			"additionalProperties": {
@@ -615,6 +612,15 @@
 				"null"
 			],
 			"description": "CreateArtifactDirectories describes various directories that should be created on install."
+		},
+		"Date": {
+			"additionalProperties": {
+				"not": {}
+			},
+			"type": [
+				"object",
+				"null"
+			]
 		},
 		"FileCheckOutput": {
 			"properties": {

--- a/packaging/linux/deb/template_changelog.go
+++ b/packaging/linux/deb/template_changelog.go
@@ -49,7 +49,7 @@ type changelogWrapper struct {
 }
 
 var dummyChangelogEntry = dalec.ChangelogEntry{
-	Date:   time.Unix(0, 0),
+	Date:   dalec.Date{Time: time.Unix(0, 0)},
 	Author: "Dalec Dummy Changelog <>",
 	Changes: []string{
 		"Dummy changelog entry",

--- a/spec_test.go
+++ b/spec_test.go
@@ -16,7 +16,6 @@ func TestDate(t *testing.T) {
 	assert.NilError(t, err)
 
 	d := Date{Time: expectTime}
-	assert.NilError(t, err)
 	assert.Check(t, cmp.Equal(d.Format(time.DateOnly), expect))
 
 	dtJSON, err := json.Marshal(d)

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,37 @@
+package dalec
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestDate(t *testing.T) {
+	expect := "2023-10-01"
+	expectTime, err := time.Parse(time.DateOnly, expect)
+	assert.NilError(t, err)
+
+	d := Date{Time: expectTime}
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(d.Format(time.DateOnly), expect))
+
+	dtJSON, err := json.Marshal(d)
+	assert.NilError(t, err)
+
+	dtYAML, err := yaml.Marshal(d)
+	assert.NilError(t, err)
+
+	var d2 Date
+	err = json.Unmarshal(dtJSON, &d2)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(d2.Format(time.DateOnly), expect))
+
+	d3 := Date{}
+	err = yaml.Unmarshal(dtYAML, &d3)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(d3.Format(time.DateOnly), expect))
+}


### PR DESCRIPTION
This is mostly so that when marshaling the
changelog, the date is formatted in a way that we
are expecting and not a full RFC 3339 date-time.
