### PR TITLE
ci: Use buildkit source policy

### DIFF
--- a/.github/actions/format-repo/action.yml
+++ b/.github/actions/format-repo/action.yml
@@ -1,0 +1,20 @@
+name: 'Format Repository for OCI'
+description: 'Formats a GitHub repository name into an OCI compliant reference for ghcr.io'
+
+outputs:
+  result:
+    description: 'The OCI compliant repository name (lowercase)'
+    value: ${{ steps.format.outputs.result }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Format repository name
+      id: format
+      shell: bash
+      run: |
+        # Get the repository from GitHub context
+        REPO="${GITHUB_REPOSITORY}"
+        # Convert to lowercase
+        OCI_NAME=$(echo "${REPO}" | tr '[:upper:]' '[:lower:]')
+        echo "result=${OCI_NAME}" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-source-policy/action.yml
+++ b/.github/actions/setup-source-policy/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup BuildKit Source Policy'
+description: 'Sets up BUILDKIT_SOURCE_POLICY environment variable with processed policy.json'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Format repository name
+      id: format-repo
+      uses: ./.github/actions/format-repo
+    
+    - name: Process policy file
+      id: process-policy
+      shell: bash
+      run: |
+        # Get the formatted repo from the previous step
+        FORMATTED_REPO="${{ steps.format-repo.outputs.oci-name }}"
+        
+        # Set REPO_PREFIX for envsubst
+        export REPO_PREFIX="ghcr.io/${FORMATTED_REPO}"
+        
+        # Get the full path to policy.json
+        POLICY_PATH="${GITHUB_WORKSPACE}/.github/actions/setup-source-policy/policy.json"
+        
+        # Process the policy file with envsubst and save to a temporary file
+        TEMP_POLICY_PATH="${RUNNER_TEMP}/processed_policy.json"
+        envsubst < "${POLICY_PATH}" > "${TEMP_POLICY_PATH}"
+        
+        # Set BUILDKIT_SOURCE_POLICY as a global environment variable
+        echo "BUILDKIT_SOURCE_POLICY=${TEMP_POLICY_PATH}" >> $GITHUB_ENV

--- a/.github/actions/setup-source-policy/policy.json
+++ b/.github/actions/setup-source-policy/policy.json
@@ -1,0 +1,13 @@
+{
+    "rules": [
+        {
+            "action": "CONVERT",
+            "selector": {
+                "identifier": "docker-image://docker.io/*"
+            },
+            "updates": {
+                "identifier": "docker-image://${REPO_PREFIX}/dockerhub/mirror/$1"
+            }
+        }
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
           go-version: '1.23'
           cache: false
 
+
       - name: Configure dockerd
         run: |
           set -ex -o pipefail
@@ -119,6 +120,7 @@ jobs:
           sudo systemctl restart docker
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup jaeger
         run: |
           set -e
@@ -144,6 +146,8 @@ jobs:
         run: go mod download
       - name: Setup QEMU
         run: docker run --rm --privileged tonistiigi/binfmt:latest --install all
+      - name: Setup source policy
+        uses: ./.github/actions/setup-source-policy
       - name: Run integration tests
         run: |
           set -ex
@@ -217,13 +221,17 @@ jobs:
         with:
           # We need to fetch all commits so that we can diff against the base branch
           fetch-depth: 0
+
       - name: Expose GitHub tokens for caching
         uses: crazy-max/ghaction-github-runtime@b3a9207c0e1ef41f4cf215303c976869d0c2c1c4 # v3.0.0
+      - name: Setup source policy
+        uses: ./.github/actions/setup-source-policy
       - name: Setup builder
         run: |
           # Sometimes the builder runs out of space... so cleanup anything we can first.
           docker image prune -a -f
 
+          # TODO: Add the registry image to mirror list and replace here.
           docker run -d --net=host registry
 
           # If diff/merge are enabled we need to use a buildx builder to make sure the feature is supported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,13 +226,14 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@b3a9207c0e1ef41f4cf215303c976869d0c2c1c4 # v3.0.0
       - name: Setup source policy
         uses: ./.github/actions/setup-source-policy
+      - uses: ./.github/actions/format-repo
+        id: format-repo
       - name: Setup builder
         run: |
           # Sometimes the builder runs out of space... so cleanup anything we can first.
           docker image prune -a -f
 
-          # TODO: Add the registry image to mirror list and replace here.
-          docker run -d --net=host registry
+          docker run -d --net=host ghcr.io/${{ steps.format-repo.outputs.result }}/dockerhub/mirror/library/registry:latest
 
           # If diff/merge are enabled we need to use a buildx builder to make sure the feature is supported.
           # Otherwise we can just use the default docker builder.


### PR DESCRIPTION
This allows us to inject images from the ghcr mirror instead of hitting dockerhub.
