### PR TITLE
Automatically convert version constraint differences for deb/rpm

### DIFF
--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -33,9 +33,9 @@ func TestAppendConstraints(t *testing.T) {
 		{
 			name: "single dependency with version constraints",
 			deps: map[string]dalec.PackageConstraints{
-				"packageA": {Version: []string{">= 1.0", "< 2.0"}},
+				"packageA": {Version: []string{">= 1.0", "<< 2.0"}},
 			},
-			want: []string{"packageA (< 2.0) | packageA (>= 1.0)"},
+			want: []string{"packageA (<< 2.0) | packageA (>= 1.0)"},
 		},
 		{
 			name: "single dependency with architecture constraints",
@@ -47,9 +47,9 @@ func TestAppendConstraints(t *testing.T) {
 		{
 			name: "single dependency with version and architecture constraints",
 			deps: map[string]dalec.PackageConstraints{
-				"packageA": {Version: []string{">= 1.0", "< 2.0"}, Arch: []string{"amd64", "arm64"}},
+				"packageA": {Version: []string{">= 1.0", "<< 2.0"}, Arch: []string{"amd64", "arm64"}},
 			},
-			want: []string{"packageA (< 2.0) [amd64 arm64] | packageA (>= 1.0) [amd64 arm64]"},
+			want: []string{"packageA (<< 2.0) [amd64 arm64] | packageA (>= 1.0) [amd64 arm64]"},
 		},
 		{
 			name: "multiple dependencies with constraints",

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -212,6 +213,34 @@ func (w *specWrapper) Recommends() fmt.Stringer {
 	return b
 }
 
+// NOTE: This is very basic and does not handle things like grouped constraints
+// Given this is just trying to shim things to allow either the rpm format or the deb format
+// in its basic form, this is sufficient for now.
+func formatVersionConstraint(v string) string {
+	prefix, suffix, ok := strings.Cut(v, " ")
+	if !ok {
+		if len(prefix) >= 1 {
+			_, err := strconv.Atoi(prefix[:1])
+			if err == nil {
+				// This is just a version number, assume it should use the equal symbol
+				return "== " + v
+			}
+		}
+		return v
+	}
+
+	switch prefix {
+	case "<<":
+		return "< " + suffix
+	case ">>":
+		return "> " + suffix
+	case "=":
+		return "== " + suffix
+	default:
+		return v
+	}
+}
+
 func writeDep(b *strings.Builder, kind, name string, constraints dalec.PackageConstraints) {
 	do := func() {
 		if len(constraints.Version) == 0 {
@@ -220,7 +249,7 @@ func writeDep(b *strings.Builder, kind, name string, constraints dalec.PackageCo
 		}
 
 		for _, c := range constraints.Version {
-			fmt.Fprintf(b, "%s: %s %s\n", kind, name, c)
+			fmt.Fprintf(b, "%s: %s %s\n", kind, name, formatVersionConstraint(c))
 		}
 	}
 

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -907,7 +907,7 @@ func TestTemplate_Provides(t *testing.T) {
 		Version: []string{"= 2.0.0"},
 	}
 	got = w.Provides().String()
-	want = "Provides: test-provides = 2.0.0\n\n"
+	want = "Provides: test-provides == 2.0.0\n\n"
 	assert.Equal(t, got, want)
 }
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -44,18 +44,7 @@ type workerConfig struct {
 	// to see if a custom worker is provided in a context
 	ContextName    string
 	TestRepoConfig func(string) map[string]dalec.Source
-	Constraints    constraintsSymbols
 	Platform       *ocispecs.Platform
-}
-
-type constraintsSymbols struct {
-	Equal string
-
-	GreaterThan        string
-	GreaterThanOrEqual string
-
-	LessThan        string
-	LessThanOrEqual string
 }
 
 type targetConfig struct {
@@ -1835,19 +1824,19 @@ func testPinnedBuildDeps(ctx context.Context, t *testing.T, cfg testLinuxConfig)
 	}{
 		{
 			name:        "exact dep available",
-			constraints: cfg.Worker.Constraints.Equal + " " + formatEqualForDistro("1.1.1", "1"),
+			constraints: "== " + formatEqualForDistro("1.1.1", "1"),
 			want:        "1.1.1",
 		},
 
 		{
 			name:        "lt dep available",
-			constraints: cfg.Worker.Constraints.LessThan + " 1.3.0",
+			constraints: "< 1.3.0",
 			want:        "1.2.0",
 		},
 
 		{
 			name:        "gt dep available",
-			constraints: cfg.Worker.Constraints.GreaterThan + " 1.2.0",
+			constraints: "> 1.2.0",
 			want:        "1.3.0",
 		},
 	}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -38,7 +38,6 @@ func TestAlmalinux9(t *testing.T) {
 			CreateRepo:     createYumRepo(almalinux.ConfigV9),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "almalinux",
@@ -83,7 +82,6 @@ func TestAlmalinux8(t *testing.T) {
 			CreateRepo:     createYumRepo(almalinux.ConfigV8),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "almalinux",

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -13,14 +13,6 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var azlinuxConstraints = constraintsSymbols{
-	Equal:              "==",
-	GreaterThan:        ">",
-	GreaterThanOrEqual: ">=",
-	LessThan:           "<",
-	LessThanOrEqual:    "<=",
-}
-
 var azlinuxTestRepoConfig = func(keyPath string) map[string]dalec.Source {
 	return map[string]dalec.Source{
 		"local.repo": {
@@ -67,7 +59,6 @@ func TestMariner2(t *testing.T) {
 			CreateRepo:     createYumRepo(azlinux.Mariner2Config),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "mariner",
@@ -108,7 +99,6 @@ func TestAzlinux3(t *testing.T) {
 			CreateRepo:     createYumRepo(azlinux.Azlinux3Config),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "azurelinux",

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -38,7 +38,6 @@ func TestRockylinux9(t *testing.T) {
 			CreateRepo:     createYumRepo(rockylinux.ConfigV9),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "rocky",
@@ -83,7 +82,6 @@ func TestRockylinux8(t *testing.T) {
 			CreateRepo:     createYumRepo(rockylinux.ConfigV8),
 			SignRepo:       signRepoAzLinux,
 			TestRepoConfig: azlinuxTestRepoConfig,
-			Constraints:    azlinuxConstraints,
 		},
 		Release: OSRelease{
 			ID:        "rocky",

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -11,16 +11,6 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var (
-	debConstraintsSymbols = constraintsSymbols{
-		Equal:              "=",
-		GreaterThan:        ">>",
-		GreaterThanOrEqual: ">=",
-		LessThan:           "<<",
-		LessThanOrEqual:    "<=",
-	}
-)
-
 func withPackageOverride(oldPkg, newPkg string) func(cfg *testLinuxConfig) {
 	return func(cfg *testLinuxConfig) {
 		if cfg.Target.PackageOverrides == nil {
@@ -56,7 +46,6 @@ func debLinuxTestConfigFor(targetKey string, cfg *distro.Config, opts ...func(*t
 			CreateRepo:     ubuntuCreateRepo(cfg),
 			SignRepo:       signRepoUbuntu,
 			TestRepoConfig: ubuntuTestRepoConfig,
-			Constraints:    debConstraintsSymbols,
 		},
 
 		Platforms: []ocispecs.Platform{

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -60,13 +60,6 @@ func TestWindows(t *testing.T) {
 		SignRepo:       signRepoUbuntu,
 		TestRepoConfig: ubuntuTestRepoConfig,
 		Platform:       &windowsAmd64,
-		Constraints: constraintsSymbols{
-			Equal:              "=",
-			GreaterThan:        ">>",
-			GreaterThanOrEqual: ">=",
-			LessThan:           "<<",
-			LessThanOrEqual:    "<=",
-		},
 		CreateRepo: func(pkg llb.State, opts ...llb.StateOption) llb.StateOption {
 			return func(in llb.State) llb.State {
 				repoFile := []byte(`


### PR DESCRIPTION
This makes it so you don't need to specify a difference set of constraints for deb/rpm packages.  Especially important because fields like `replaces` and `conflicts` are not currently distro specific (though I'm realizing now they probably need to be).