### PR TITLE
Allow target-specific provides/conflicts/replaces

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -1962,6 +1962,16 @@
 					"$ref": "#/$defs/Artifacts",
 					"description": "Artifacts describes all of the artifact configurations to include for this specific target."
 				},
+				"conflicts": {
+					"additionalProperties": {
+						"$ref": "#/$defs/PackageConstraints"
+					},
+					"type": [
+						"object",
+						"null"
+					],
+					"description": "Conflicts is the list of packages that this target conflicts with."
+				},
 				"dependencies": {
 					"$ref": "#/$defs/PackageDependencies",
 					"description": "Dependencies are the different dependencies that need to be specified in the package."
@@ -1977,6 +1987,26 @@
 				"package_config": {
 					"$ref": "#/$defs/PackageConfig",
 					"description": "PackageConfig is the configuration to use for artifact targets, such as\nrpms, debs, or zip files containing Windows binaries"
+				},
+				"provides": {
+					"additionalProperties": {
+						"$ref": "#/$defs/PackageConstraints"
+					},
+					"type": [
+						"object",
+						"null"
+					],
+					"description": "Provides is the list of packages that this target provides."
+				},
+				"replaces": {
+					"additionalProperties": {
+						"$ref": "#/$defs/PackageConstraints"
+					},
+					"type": [
+						"object",
+						"null"
+					],
+					"description": "Replaces is the list of packages that this target replaces/obsoletes."
 				},
 				"tests": {
 					"items": {

--- a/helpers.go
+++ b/helpers.go
@@ -628,3 +628,24 @@ func HasGolang(spec *Spec, targetKey string) bool {
 	}
 	return false
 }
+
+func (s *Spec) GetProvides(targetKey string) map[string]PackageConstraints {
+	if p := s.Targets[targetKey].Provides; p != nil {
+		return p
+	}
+	return s.Provides
+}
+
+func (s *Spec) GetReplaces(targetKey string) map[string]PackageConstraints {
+	if r := s.Targets[targetKey].Replaces; r != nil {
+		return r
+	}
+	return s.Replaces
+}
+
+func (s *Spec) GetConflicts(targetKey string) map[string]PackageConstraints {
+	if c := s.Targets[targetKey].Conflicts; c != nil {
+		return c
+	}
+	return s.Conflicts
+}

--- a/load.go
+++ b/load.go
@@ -250,6 +250,16 @@ func (s *Spec) SubstituteArgs(env map[string]string, opts ...SubstituteOpt) erro
 		}
 	}
 
+	for k, v := range s.Conflicts {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, cfg.AllowArg)
+			if err != nil {
+				appendErr(errors.Wrapf(err, "replaces %s version %d", k, i))
+			}
+			s.Conflicts[k].Version[i] = updated
+		}
+	}
+
 	return goerrors.Join(errs...)
 }
 

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -185,11 +185,12 @@ func (w *controlWrapper) AllRuntimeDeps() fmt.Stringer {
 
 func (w *controlWrapper) Replaces() fmt.Stringer {
 	b := &strings.Builder{}
-	if len(w.Spec.Replaces) == 0 {
+	replaces := w.Spec.GetReplaces(w.Target)
+	if len(replaces) == 0 {
 		return b
 	}
 
-	ls := appendConstraints(w.Spec.Replaces)
+	ls := appendConstraints(replaces)
 
 	fmt.Fprintln(b, multiline("Replaces", ls))
 	return b
@@ -197,22 +198,24 @@ func (w *controlWrapper) Replaces() fmt.Stringer {
 
 func (w *controlWrapper) Conflicts() fmt.Stringer {
 	b := &strings.Builder{}
-	if len(w.Spec.Conflicts) == 0 {
+	conflicts := w.Spec.GetConflicts(w.Target)
+	if len(conflicts) == 0 {
 		return b
 	}
 
-	ls := appendConstraints(w.Spec.Conflicts)
+	ls := appendConstraints(conflicts)
 	fmt.Fprintln(b, multiline("Conflicts", ls))
 	return b
 }
 
 func (w *controlWrapper) Provides() fmt.Stringer {
 	b := &strings.Builder{}
-	if len(w.Spec.Provides) == 0 {
+	provides := w.Spec.GetProvides(w.Target)
+	if len(provides) == 0 {
 		return b
 	}
 
-	ls := appendConstraints(w.Spec.Provides)
+	ls := appendConstraints(provides)
 	fmt.Fprintln(b, multiline("Provides", ls))
 	return b
 }

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -2,9 +2,11 @@ package deb
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Azure/dalec"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppendConstraints(t *testing.T) {
@@ -68,4 +70,228 @@ func TestAppendConstraints(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
+	t.Run("target specific", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Replaces: map[string]dalec.PackageConstraints{
+						"pkg-a": {Version: []string{">> 1.0.0"}},
+					},
+					Conflicts: map[string]dalec.PackageConstraints{
+						"pkg-b": {Version: []string{"<< 2.0.0"}},
+					},
+					Provides: map[string]dalec.PackageConstraints{
+						"pkg-c": {},
+					},
+				},
+				"target2": {
+					Replaces: map[string]dalec.PackageConstraints{
+						"pkg-d": {Version: []string{"= 3.0.0"}},
+					},
+					Conflicts: map[string]dalec.PackageConstraints{
+						"pkg-e": {Arch: []string{"amd64", "arm64"}},
+					},
+					Provides: map[string]dalec.PackageConstraints{
+						"pkg-f": {Version: []string{">= 4.0.0"}},
+					},
+				},
+			},
+		}
+
+		// Test target1
+		wrapper1 := &controlWrapper{spec, "target1"}
+
+		// Test Replaces
+		replaces := wrapper1.Replaces().String()
+		require.Contains(t, replaces, "Replaces: pkg-a (>> 1.0.0)")
+
+		// Test Conflicts
+		conflicts := wrapper1.Conflicts().String()
+		require.Contains(t, conflicts, "Conflicts: pkg-b (<< 2.0.0)")
+
+		// Test Provides
+		provides := wrapper1.Provides().String()
+		require.Contains(t, provides, "Provides: pkg-c")
+
+		// Test target2
+		wrapper2 := &controlWrapper{spec, "target2"}
+
+		// Test Replaces
+		replaces = wrapper2.Replaces().String()
+		require.Contains(t, replaces, "Replaces: pkg-d (= 3.0.0)")
+
+		// Test Conflicts
+		conflicts = wrapper2.Conflicts().String()
+		require.Contains(t, conflicts, "Conflicts: pkg-e [amd64 arm64]")
+
+		// Test Provides
+		provides = wrapper2.Provides().String()
+		require.Contains(t, provides, "Provides: pkg-f (>= 4.0.0)")
+	})
+
+	t.Run("non-target specific", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Replaces: map[string]dalec.PackageConstraints{
+				"pkg-g": {Version: []string{">> 1.0.0"}},
+			},
+			Conflicts: map[string]dalec.PackageConstraints{
+				"pkg-h": {Version: []string{"<< 2.0.0"}},
+			},
+			Provides: map[string]dalec.PackageConstraints{
+				"pkg-i": {Version: []string{">= 3.0.0"}, Arch: []string{"amd64"}},
+			},
+		}
+
+		// Test with any target name
+		wrapper := &controlWrapper{spec, "any-target"}
+
+		// Test Replaces
+		replaces := wrapper.Replaces().String()
+		require.Contains(t, replaces, "Replaces: pkg-g (>> 1.0.0)")
+
+		// Test Conflicts
+		conflicts := wrapper.Conflicts().String()
+		require.Contains(t, conflicts, "Conflicts: pkg-h (<< 2.0.0)")
+
+		// Test Provides
+		provides := wrapper.Provides().String()
+		require.Contains(t, provides, "Provides: pkg-i (>= 3.0.0) [amd64]")
+	})
+
+	t.Run("empty values", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			// No Replaces, Conflicts, or Provides defined
+		}
+
+		wrapper := &controlWrapper{spec, "target1"}
+
+		// Test empty values
+		require.Equal(t, "", wrapper.Replaces().String())
+		require.Equal(t, "", wrapper.Conflicts().String())
+		require.Equal(t, "", wrapper.Provides().String())
+	})
+
+	t.Run("multiline format", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Replaces: map[string]dalec.PackageConstraints{
+				"pkg-a": {Version: []string{">> 1.0.0"}},
+				"pkg-b": {Version: []string{"<< 2.0.0"}},
+				"pkg-c": {Version: []string{">= 3.0.0"}},
+			},
+		}
+
+		wrapper := &controlWrapper{spec, "any-target"}
+		replaces := wrapper.Replaces().String()
+
+		// Test multiline formatting
+		lines := strings.Split(strings.TrimSpace(replaces), "\n")
+		require.Equal(t, 3, len(lines))
+		require.Contains(t, lines[0], "Replaces: pkg-a (>> 1.0.0),")
+		require.Contains(t, lines[1], "         pkg-b (<< 2.0.0),")
+		require.Contains(t, lines[2], "         pkg-c (>= 3.0.0)")
+	})
+
+	t.Run("target precedence", func(t *testing.T) {
+		// Create spec with both root-level and target-specific values
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			// Root-level definitions
+			Replaces: map[string]dalec.PackageConstraints{
+				"root-pkg-r": {Version: []string{">= 1.0.0"}},
+				"common-pkg": {Version: []string{">= 2.0.0"}}, // Will be overridden in target1
+			},
+			Conflicts: map[string]dalec.PackageConstraints{
+				"root-pkg-c": {Version: []string{"<= 3.0.0"}},
+				"common-pkg": {Version: []string{"<= 4.0.0"}}, // Will be overridden in target1
+			},
+			Provides: map[string]dalec.PackageConstraints{
+				"root-pkg-p": {Version: []string{"= 5.0.0"}},
+				"common-pkg": {Version: []string{"= 6.0.0"}}, // Will be overridden in target1
+			},
+			Targets: map[string]dalec.Target{
+				// target1 overrides values
+				"target1": {
+					Replaces: map[string]dalec.PackageConstraints{
+						"target-pkg-r": {Version: []string{">= 1.1.0"}},
+						"common-pkg":   {Version: []string{">= 2.1.0"}}, // Overrides root
+					},
+					Conflicts: map[string]dalec.PackageConstraints{
+						"target-pkg-c": {Version: []string{"<= 3.1.0"}},
+						"common-pkg":   {Version: []string{"<= 4.1.0"}}, // Overrides root
+					},
+					Provides: map[string]dalec.PackageConstraints{
+						"target-pkg-p": {Version: []string{"= 5.1.0"}},
+						"common-pkg":   {Version: []string{"= 6.1.0"}}, // Overrides root
+					},
+				},
+				// target2 has explicit empty maps to override the root values
+				"target2": {
+					Replaces:  map[string]dalec.PackageConstraints{},
+					Conflicts: map[string]dalec.PackageConstraints{},
+					Provides:  map[string]dalec.PackageConstraints{},
+				},
+			},
+		}
+
+		// Test target1 (should see target-specific values taking precedence)
+		wrapper1 := &controlWrapper{spec, "target1"}
+
+		// Test Replaces - should contain target-specific values and not root values for common-pkg
+		replaces := wrapper1.Replaces().String()
+		require.Contains(t, replaces, "common-pkg (>= 2.1.0)")
+		require.Contains(t, replaces, "target-pkg-r (>= 1.1.0)")
+		require.NotContains(t, replaces, "root-pkg-r")
+		require.NotContains(t, replaces, "(>= 2.0.0)") // common-pkg old version
+
+		// Test Conflicts - should contain target-specific values and not root values for common-pkg
+		conflicts := wrapper1.Conflicts().String()
+		require.Contains(t, conflicts, "common-pkg (<= 4.1.0)")
+		require.Contains(t, conflicts, "target-pkg-c (<= 3.1.0)")
+		require.NotContains(t, conflicts, "root-pkg-c")
+		require.NotContains(t, conflicts, "(<= 4.0.0)") // common-pkg old version
+
+		// Test Provides - should contain target-specific values and not root values for common-pkg
+		provides := wrapper1.Provides().String()
+		require.Contains(t, provides, "common-pkg (= 6.1.0)")
+		require.Contains(t, provides, "target-pkg-p (= 5.1.0)")
+		require.NotContains(t, provides, "root-pkg-p")
+		require.NotContains(t, provides, "(= 6.0.0)") // common-pkg old version
+
+		// Test with non-existent target to get root values
+		// Current implementation only falls back to root if target doesn't exist
+		wrapperNonExistent := &controlWrapper{spec, "non-existent-target"}
+
+		// Test Replaces - should contain root values
+		replaces = wrapperNonExistent.Replaces().String()
+		require.Contains(t, replaces, "common-pkg (>= 2.0.0)")
+		require.Contains(t, replaces, "root-pkg-r (>= 1.0.0)")
+
+		// Test Conflicts - should contain root values
+		conflicts = wrapperNonExistent.Conflicts().String()
+		require.Contains(t, conflicts, "common-pkg (<= 4.0.0)")
+		require.Contains(t, conflicts, "root-pkg-c (<= 3.0.0)")
+
+		// Test Provides - should contain root values
+		provides = wrapperNonExistent.Provides().String()
+		require.Contains(t, provides, "common-pkg (= 6.0.0)")
+		require.Contains(t, provides, "root-pkg-p (= 5.0.0)")
+
+		// Test target2 - should return empty values because the maps are explicitly empty
+		wrapper2 := &controlWrapper{spec, "target2"}
+		require.Equal(t, "", wrapper2.Replaces().String())
+		require.Equal(t, "", wrapper2.Conflicts().String())
+		require.Equal(t, "", wrapper2.Provides().String())
+	})
 }

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -101,7 +101,7 @@ conflicts:
 
 #### provides
 
-The `provides` field is used to define the packages that are provided by this package package. This is an optional field.
+The `provides` field is used to define the packages that are provided by this package. This is an optional field.
 This is useful when the package name may not align with a more common name for the package or when the package is a
 replacement for another package.
 

--- a/website/docs/spec.md
+++ b/website/docs/spec.md
@@ -81,6 +81,54 @@ website: https://github.com/foo/bar
 Any field at the top-level that begins with `x-` will be ignored by Dalec. This allows for custom fields to be added to the spec. For example, `x-foo: bar`. Any other field that is not recognized by Dalec will result in a validation error.
 :::
 
+### Additional metadata
+
+#### conflics
+
+The `conflicts` field is used to define the packages that conflict with this package. This is an optional field.
+This is required when this package provides one or more files that are provided by another package.
+This helps the package manager know when two packages cannot be installed at the same time.
+
+```yaml
+conflicts:
+  foo:
+  bar:
+    # Add version constraints to the conflicting package
+    version:
+      - ">=1.0.0"
+      - "<2.0.0"
+```
+
+#### provides
+
+The `provides` field is used to define the packages that are provided by this package package. This is an optional field.
+This is useful when the package name may not align with a more common name for the package or when the package is a
+replacement for another package.
+
+```yaml
+  provides:
+    foo:
+    bar:
+      # With version constraints
+      version:
+        - = 1.0.0
+```
+
+#### replaces
+
+The `replaces` field is used to define the packages that are replaced by this package. This is an optional field.
+This is useful when this package should be chosen over another package with a different name and can be combined with
+`conflicts` to ensure that the other package is removed when this package is installed.
+
+```yaml
+  replaces:
+    foo:
+    bar:
+      # With version constraints
+      version:
+        - < 1.0.0
+```
+
 ## Targets section
 
 Targets section is used to define configuration per target. Each target can have its own configuration.

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -81,7 +81,6 @@ targets:
         - golang
 ```
 
-
 ## Extensibility
 
 Dalec can’t feasibly support every Linux distribution. Instead, it gives you the flexibility to specify a custom builder image for any target, directing the build process to that specified image.
@@ -175,6 +174,24 @@ targets:
 ```
 
 For more details on how Artifacts are structured and configured, see the [Artifacts](artifacts.md) documentation.
+
+### Target defined package metdata
+
+`conflicts`, `replaces`, and `provides` can be defined at the target level in addition to the [globalspec level](spec.md#additional-metadata).
+This allows you to define package metadata that is specific to a target.
+
+```yaml
+targets:
+  mariner2:
+    package:
+      conflicts:
+        - "foo"
+        - "bar"
+      replaces:
+        - foo"
+      provides:
+        - "qux"
+```
 
 ## Special considerations
 


### PR DESCRIPTION
Packages in different targets may have different names or possibly versions. This allows the user to specify a target-specific provides/conflicts/replaces.
