### PR TITLE
Add support for bazel caches similar to the gobuild cache.

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -343,6 +343,25 @@
 				"null"
 			]
 		},
+		"BazelCache": {
+			"properties": {
+				"scope": {
+					"type": [
+						"string",
+						"null"
+					],
+					"description": "Scope adds extra information to the cache key.\nThis is useful to differentiate between different build contexts if required.\n\nThis is mainly intended for internal testing purposes."
+				}
+			},
+			"additionalProperties": {
+				"not": {}
+			},
+			"type": [
+				"object",
+				"null"
+			],
+			"description": "BazelCache sets up a cache for bazel builds."
+		},
 		"BuildStep": {
 			"required": [
 				"command"
@@ -379,6 +398,10 @@
 		},
 		"CacheConfig": {
 			"properties": {
+				"bazel": {
+					"$ref": "#/$defs/BazelCache",
+					"description": "Bazel specifies a cache for bazel builds."
+				},
 				"dir": {
 					"$ref": "#/$defs/CacheDir",
 					"description": "Dir specifies a generic cache directory configuration."
@@ -407,6 +430,12 @@
 						"gobuild"
 					],
 					"title": "gobuild"
+				},
+				{
+					"required": [
+						"bazel"
+					],
+					"title": "bazel-local"
 				}
 			],
 			"description": "CacheConfig configures a cache to use for a build."
@@ -839,20 +868,17 @@
 			]
 		},
 		"GoBuildCache": {
-			"required": [
-				"scope",
-				"disabled"
-			],
 			"properties": {
 				"disabled": {
 					"type": [
 						"boolean"
 					],
-					"description": "The gobuild cache may be automatically injected into a build of\ngo is detected.\nDisabled explicitly turns this off."
+					"description": "The gobuild cache may be automatically injected into a build if\ngo is detected.\nDisabled explicitly turns this off."
 				},
 				"scope": {
 					"type": [
-						"string"
+						"string",
+						"null"
 					],
 					"description": "Scope adds extra information to the cache key.\nThis is useful to differentiate between different build contexts if required.\n\nThis is mainly intended for internal testing purposes."
 				}

--- a/helpers.go
+++ b/helpers.go
@@ -152,6 +152,9 @@ func WithConstraints(ls ...llb.ConstraintsOpt) llb.ConstraintsOpt {
 
 func WithConstraint(in *llb.Constraints) llb.ConstraintsOpt {
 	return ConstraintsOptFunc(func(c *llb.Constraints) {
+		if in == nil {
+			return
+		}
 		*c = *in
 	})
 }

--- a/load_test.go
+++ b/load_test.go
@@ -1686,7 +1686,7 @@ func TestArtifactBuildValidation(t *testing.T) {
 				Steps:  []BuildStep{{Command: "echo hello"}},
 				Caches: []CacheConfig{{}},
 			},
-			expectErr: "cache 0: invalid cache config: one of (and only one of) dir or gobuild must be set",
+			expectErr: "cache 0: invalid cache config: exactly one of (dir, gobuild, bazel) must be set",
 		},
 		{
 			name: "empty dest",
@@ -1775,7 +1775,7 @@ func TestArtifactBuildValidation(t *testing.T) {
 					},
 				},
 			},
-			expectErr: "cache 0: invalid cache config: one of (and only one of) dir or gobuild must be set",
+			expectErr: "cache 0: invalid cache config: exactly one of (dir, gobuild, bazel) must be set",
 		},
 		{
 			name: "multiple go build caches",

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -178,7 +178,7 @@ func testBazelCache(ctx context.Context, t *testing.T, cfg targetConfig) {
 	ctx = startTestSpan(ctx, t)
 
 	bzlPkg := cfg.GetPackage("bazel")
-	if bzlPkg == "" {
+	if bzlPkg == noPackageAvailable {
 		t.Skip("bazel not available in this distro")
 	}
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -77,6 +77,8 @@ func (cfg *targetConfig) GetPackage(name string) string {
 	return name
 }
 
+const noPackageAvailable = ""
+
 type testLinuxConfig struct {
 	Target     targetConfig
 	LicenseDir string

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -70,8 +70,8 @@ type targetConfig struct {
 }
 
 func (cfg *targetConfig) GetPackage(name string) string {
-	updated := cfg.PackageOverrides[name]
-	if updated != "" {
+	updated, ok := cfg.PackageOverrides[name]
+	if ok {
 		return updated
 	}
 	return name
@@ -1682,6 +1682,12 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
 		testAutoGobuildCache(ctx, t, testConfig.Target)
+	})
+
+	t.Run("bazel remote cache", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testBazelCache(ctx, t, testConfig.Target)
 	})
 }
 

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -22,7 +22,7 @@ func TestAlmalinux9(t *testing.T) {
 			ListExpectedSignFiles: azlinuxListSignFiles("el9"),
 			PackageOverrides: map[string]string{
 				"rust":  "rust cargo",
-				"bazel": "",
+				"bazel": noPackageAvailable,
 			},
 		},
 		LicenseDir: "/usr/share/licenses",
@@ -67,7 +67,7 @@ func TestAlmalinux8(t *testing.T) {
 			ListExpectedSignFiles: azlinuxListSignFiles("el8"),
 			PackageOverrides: map[string]string{
 				"rust":  "rust cargo",
-				"bazel": "",
+				"bazel": noPackageAvailable,
 			},
 		},
 		LicenseDir: "/usr/share/licenses",

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -21,7 +21,8 @@ func TestAlmalinux9(t *testing.T) {
 			},
 			ListExpectedSignFiles: azlinuxListSignFiles("el9"),
 			PackageOverrides: map[string]string{
-				"rust": "rust cargo",
+				"rust":  "rust cargo",
+				"bazel": "",
 			},
 		},
 		LicenseDir: "/usr/share/licenses",
@@ -65,7 +66,8 @@ func TestAlmalinux8(t *testing.T) {
 			},
 			ListExpectedSignFiles: azlinuxListSignFiles("el8"),
 			PackageOverrides: map[string]string{
-				"rust": "rust cargo",
+				"rust":  "rust cargo",
+				"bazel": "",
 			},
 		},
 		LicenseDir: "/usr/share/licenses",

--- a/test/target_debian_test.go
+++ b/test/target_debian_test.go
@@ -22,6 +22,6 @@ func TestBullseye(t *testing.T) {
 		debian.BullseyeConfig,
 		withPackageOverride("golang", "golang-1.19"),
 		withPackageOverride("rust", "cargo-web"),
-		withPackageOverride("bazel", ""),
+		withPackageOverride("bazel", noPackageAvailable),
 	))
 }

--- a/test/target_debian_test.go
+++ b/test/target_debian_test.go
@@ -10,12 +10,18 @@ func TestBookworm(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(debian.BookwormDefaultTargetKey, debian.BookwormConfig, withPackageOverride("rust", "rust-all")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(debian.BookwormDefaultTargetKey, debian.BookwormConfig, withPackageOverride("rust", "rust-all"), withPackageOverride("bazel", "bazel-bootstrap")))
 }
 
 func TestBullseye(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(debian.BullseyeDefaultTargetKey, debian.BullseyeConfig, withPackageOverride("golang", "golang-1.19"), withPackageOverride("rust", "cargo-web")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(
+		debian.BullseyeDefaultTargetKey,
+		debian.BullseyeConfig,
+		withPackageOverride("golang", "golang-1.19"),
+		withPackageOverride("rust", "cargo-web"),
+		withPackageOverride("bazel", ""),
+	))
 }

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -21,7 +21,8 @@ func TestRockylinux9(t *testing.T) {
 			},
 			ListExpectedSignFiles: azlinuxListSignFiles("el9"),
 			PackageOverrides: map[string]string{
-				"rust": "rust cargo",
+				"rust":  "rust cargo",
+				"bazel": "",
 			},
 		},
 		LicenseDir: "/usr/share/licenses",
@@ -65,7 +66,8 @@ func TestRockylinux8(t *testing.T) {
 			},
 			ListExpectedSignFiles: azlinuxListSignFiles("el8"),
 			PackageOverrides: map[string]string{
-				"rust": "rust cargo",
+				"rust":  "rust cargo",
+				"bazel": "",
 			},
 		},
 		LicenseDir: "/usr/share/licenses",

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -22,7 +22,7 @@ func TestRockylinux9(t *testing.T) {
 			ListExpectedSignFiles: azlinuxListSignFiles("el9"),
 			PackageOverrides: map[string]string{
 				"rust":  "rust cargo",
-				"bazel": "",
+				"bazel": noPackageAvailable,
 			},
 		},
 		LicenseDir: "/usr/share/licenses",
@@ -67,7 +67,7 @@ func TestRockylinux8(t *testing.T) {
 			ListExpectedSignFiles: azlinuxListSignFiles("el8"),
 			PackageOverrides: map[string]string{
 				"rust":  "rust cargo",
-				"bazel": "",
+				"bazel": noPackageAvailable,
 			},
 		},
 		LicenseDir: "/usr/share/licenses",

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -139,7 +139,7 @@ func TestJammy(t *testing.T) {
 	ctx := startTestSpan(baseCtx, t)
 	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig,
 		withPackageOverride("rust", "rust-all"),
-		withPackageOverride("bazel", ""),
+		withPackageOverride("bazel", noPackageAvailable),
 	))
 }
 
@@ -160,7 +160,7 @@ func TestFocal(t *testing.T) {
 	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig,
 		withPackageOverride("golang", "golang-1.22"),
 		withPackageOverride("rust", "rust-all"),
-		withPackageOverride("bazel", ""),
+		withPackageOverride("bazel", noPackageAvailable),
 	))
 }
 
@@ -171,6 +171,6 @@ func TestBionic(t *testing.T) {
 	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig,
 		withPackageOverride("golang", "golang-1.18"),
 		withPackageOverride("rust", "rust-all"),
-		withPackageOverride("bazel", ""),
+		withPackageOverride("bazel", noPackageAvailable),
 	))
 }

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -137,26 +137,40 @@ func TestJammy(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig, withPackageOverride("rust", "rust-all")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig,
+		withPackageOverride("rust", "rust-all"),
+		withPackageOverride("bazel", ""),
+	))
 }
 
 func TestNoble(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig, withPackageOverride("rust", "rust-all")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig,
+		withPackageOverride("rust", "rust-all"),
+		withPackageOverride("bazel", "bazel-bootstrap"),
+	))
 }
 
 func TestFocal(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig, withPackageOverride("golang", "golang-1.22"), withPackageOverride("rust", "rust-all")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig,
+		withPackageOverride("golang", "golang-1.22"),
+		withPackageOverride("rust", "rust-all"),
+		withPackageOverride("bazel", ""),
+	))
 }
 
 func TestBionic(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig, withPackageOverride("golang", "golang-1.18"), withPackageOverride("rust", "rust-all")))
+	testLinuxDistro(ctx, t, debLinuxTestConfigFor(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig,
+		withPackageOverride("golang", "golang-1.18"),
+		withPackageOverride("rust", "rust-all"),
+		withPackageOverride("bazel", ""),
+	))
 }

--- a/website/docs/caches.md
+++ b/website/docs/caches.md
@@ -72,3 +72,29 @@ caches:
   - gobuild:
       disabled: true
 ```
+
+## Bazel Cache
+
+The bazel cache is a special type of cache that is used to cache the results of
+the `bazel build` command.
+
+```yaml
+caches:
+  - bazel:
+```
+
+Bazel caches are always in `shared` mode and are always namespaced with the OS and CPU architecture.
+This relies on setting the `--disk_cache` flag on `bazel build` by adding it to the *system* bazelrc file
+when dalec sets up the build environment.
+Dalec does not check if this is overwritten in the user or project bazelrc files.
+If this conflicts with your project, you may need to manually manage the bazel cache with a [cache dir](#dir-cache).
+
+An optional `scope` can be provided which is added to the generated cache key.
+This is intended for internal testing purposes, however may be useful for other
+use-cases as well.
+
+```yaml
+caches:
+  - bazel:
+      scope: my_scope
+```

--- a/website/docs/caches.md
+++ b/website/docs/caches.md
@@ -4,6 +4,22 @@ In addition to the standard step-level caching that buildkit provides, you can
 also configure incremental caching that persists across builds.
 This is similar to Dockerfiles `--mount=type=cache`.
 
+You can provide multiple cache configurations:
+
+```yaml
+caches:
+  - dir:
+      key: my_key
+      dest: /my/cache/dir
+      sharing: shared
+  - dir:
+      key: my_other_key
+      dest: /my/other/cache/dir
+      sharing: private
+  - gobuild:
+  - bazel:
+```
+
 ## Dir Cache
 
 Dir caches are just generic directories where you choose the cache key and sharing mode.


### PR DESCRIPTION
This allows bazel users to keep a cache of bazel artifacts that
persists between builds and can even be shared between different
projects.

One slight difference here is we are not automatically injecting a bazel
cache at any point, it must always be manually added.
We may change this in the future but as I understand it, it will
actually be difficult to detect bazel anyway in most builds due to bazel
either not being available in the package manager or the *right* version
of bazel not being available.