### PR TITLE
Reduce soem verbosity in builds

### DIFF
--- a/source.go
+++ b/source.go
@@ -650,7 +650,7 @@ func Tar(work llb.State, src llb.State, dest string, opts ...llb.ConstraintsOpt)
 	out := filepath.Join(outBase, filepath.Dir(dest))
 	worker := work.Run(
 		llb.AddMount("/src", src, llb.Readonly),
-		ShArgs("tar -C /src -cvzf /tmp/st ."),
+		ShArgs("tar -C /src -czf /tmp/st ."),
 		WithConstraints(opts...),
 	).
 		Run(


### PR DESCRIPTION
Most of these things were here for debugging purposes when first adding the relevant code and is no longer needed.