### PR TITLE
Allow container builds to use pre-built pkgs defined by target

### DIFF
--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/packaging/linux/deb"
 	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"
 )
 
@@ -127,7 +128,11 @@ aptitude install -y -f -o "Aptitude::ProblemResolver::Hints::=reject ${pkg_name}
 	})
 }
 
-func (d *Config) InstallBuildDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+func (d *Config) InstallBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+	return d.installBuildDeps(sOpt, spec, targetKey, opts...)
+}
+
+func (d *Config) installBuildDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	return func(in llb.State) llb.State {
 		buildDeps := spec.GetBuildDeps(targetKey)
 		if len(buildDeps) == 0 {

--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -33,7 +33,7 @@ func (d *Config) BuildPkg(ctx context.Context, client gwclient.Client, worker ll
 		}
 	}
 
-	worker = worker.With(d.InstallBuildDeps(sOpt, spec, targetKey, append(opts, frontend.IgnoreCache(client))...))
+	worker = worker.With(d.InstallBuildDeps(ctx, client, spec, sOpt, targetKey, append(opts, frontend.IgnoreCache(client))...))
 
 	var cfg deb.SourcePkgConfig
 	extraPaths, err := prepareGo(ctx, client, &cfg, worker, spec, targetKey, opts...)
@@ -213,7 +213,7 @@ func (cfg *Config) HandleSourcePkg(ctx context.Context, client gwclient.Client) 
 			return nil, nil, err
 		}
 
-		worker = worker.With(cfg.InstallBuildDeps(sOpt, spec, targetKey, pg, frontend.IgnoreCache(client)))
+		worker = worker.With(cfg.InstallBuildDeps(ctx, client, spec, sOpt, targetKey, pg, frontend.IgnoreCache(client)))
 
 		var cfg deb.SourcePkgConfig
 		extraPaths, err := prepareGo(ctx, client, &cfg, worker, spec, targetKey, pg, frontend.IgnoreCache(client))

--- a/targets/linux/distro_handler.go
+++ b/targets/linux/distro_handler.go
@@ -43,6 +43,9 @@ type DistroConfig interface {
 	// Some distros may need to pass in a separate worker before mounting the target container.
 	RunTests(ctx context.Context, client gwclient.Client, worker llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts, ctr llb.State,
 		targetKey string, opts ...llb.ConstraintsOpt) (gwclient.Reference, error)
+
+	// InstallBuildDeps installs the build dependencies for a given spec.
+	InstallBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption
 }
 
 func BuildImageConfig(ctx context.Context, sOpt dalec.SourceOpts, spec *dalec.Spec, platform *ocispecs.Platform, targetKey string) (*dalec.DockerImageSpec, error) {
@@ -90,17 +93,35 @@ func HandleContainer(c DistroConfig) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			pg := dalec.ProgressGroup(spec.Name)
-			pc := dalec.Platform(platform)
+			var opts []llb.ConstraintsOpt
+			opts = append(opts, dalec.ProgressGroup(spec.Name))
+			opts = append(opts, dalec.Platform(platform))
 
-			worker, err := c.Worker(sOpt, pg, pc)
+			worker, err := c.Worker(sOpt, opts...)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			deb, err := c.BuildPkg(ctx, client, worker, sOpt, spec, targetKey, pg, pc)
+			// We need to get the build context from the client.
+			inputs, err := client.Inputs(ctx)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, fmt.Errorf("error getting llb state from client with provided build context: %w", err)
+			}
+
+			// If we have a build context named after the target, then we should use that pre-built
+			// package when building the container.
+			var pkgSt llb.State
+			if input, ok := inputs[targetKey]; ok {
+				pkgSt = input
+				opts = append(opts, dalec.ProgressGroup(fmt.Sprintf("Using pre-built package from %s context", targetKey)))
+				// ensure that worker state has the correct dependencies installed
+				worker = worker.With(c.InstallBuildDeps(ctx, client, spec, sOpt, targetKey, opts...))
+			} else {
+				var err error
+				pkgSt, err = c.BuildPkg(ctx, client, worker, sOpt, spec, targetKey, opts...)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 
 			img, err := BuildImageConfig(ctx, sOpt, spec, platform, targetKey)
@@ -108,12 +129,12 @@ func HandleContainer(c DistroConfig) gwclient.BuildFunc {
 				return nil, nil, err
 			}
 
-			ctr, err := c.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, deb, pg, pc)
+			ctr, err := c.BuildContainer(ctx, client, worker, sOpt, spec, targetKey, pkgSt, opts...)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			ref, err := c.RunTests(ctx, client, worker, spec, sOpt, ctr, targetKey, pg, pc)
+			ref, err := c.RunTests(ctx, client, worker, spec, sOpt, ctr, targetKey, opts...)
 			return ref, img, err
 		})
 	}

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -229,6 +229,10 @@ func (cfg *Config) installBuildDepsPackage(worker llb.State, target string, pack
 }
 
 func (cfg *Config) InstallBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+	return cfg.installBuildDeps(ctx, client, spec, sOpt, targetKey, opts...)
+}
+
+func (cfg *Config) installBuildDeps(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	deps := spec.GetBuildDeps(targetKey)
 	if len(deps) == 0 {
 		return func(in llb.State) llb.State { return in }

--- a/targets/windows/handle_zip.go
+++ b/targets/windows/handle_zip.go
@@ -146,7 +146,7 @@ func addGoCache(spec *dalec.Spec, targetKey string) {
 
 func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, client gwclient.Client, sOpt dalec.SourceOpts, targetKey string, opts ...llb.ConstraintsOpt) (llb.State, error) {
 	opts = append(opts, frontend.IgnoreCache(client, targets.IgnoreCacheKeyPkg))
-	worker = worker.With(distroConfig.InstallBuildDeps(sOpt, spec, targetKey, opts...))
+	worker = worker.With(distroConfig.InstallBuildDeps(ctx, client, spec, sOpt, targetKey, opts...))
 
 	sources, err := specToSourcesLLB(worker, spec, sOpt, opts...)
 	if err != nil {

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -164,6 +164,12 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		})
 	})
 
+	t.Run("prebuilt packages", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		testPrebuiltPackages(ctx, t, testConfig)
+	})
+
 	t.Run("test-dalec-empty-artifacts", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)
@@ -2801,5 +2807,95 @@ func testPackageProvidesReplaces(ctx context.Context, t *testing.T, cfg testLinu
 		})
 		assert.NilError(t, err)
 		assert.Assert(t, found, "no rpm or deb found in package")
+	})
+}
+
+func testPrebuiltPackages(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
+	t.Run("Use pre-built packages from target named context", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := &dalec.Spec{
+			Name:        "test-prebuilt-package",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/azure/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Test using pre-built packages",
+			Sources: map[string]dalec.Source{
+				"hello": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/bin/sh\necho 'Hello from pre-built package'",
+							Permissions: 0o755,
+						},
+					},
+				},
+			},
+			Artifacts: dalec.Artifacts{
+				Binaries: map[string]dalec.ArtifactConfig{
+					"hello": {},
+				},
+			},
+			Tests: []*dalec.TestSpec{
+				{
+					Name: "Test that binary from pre-built package works",
+					Steps: []dalec.TestStep{
+						{
+							Command: "/usr/bin/hello",
+							Stdout: dalec.CheckOutput{
+								Contains: []string{"Hello from pre-built package"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Get the target name (rpm, deb, etc.)
+		targetName := filepath.Base(testConfig.Target.Package)
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			// Build the package first with a unique marker file.
+			spec.Build.Steps = []dalec.BuildStep{
+				{
+					Command: "echo 'unique marker' > /etc/marker.txt",
+				},
+			}
+			// Add this to make sure marker.txt gets included in the package.
+			spec.Artifacts.ConfigFiles = map[string]dalec.ArtifactConfig{
+				"/etc/marker.txt": {},
+			}
+
+			pkgSr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(testConfig.Target.Package))
+			pkgRes := solveT(ctx, t, client, pkgSr)
+			pkgRef, err := pkgRes.SingleRef()
+			assert.NilError(t, err)
+
+			pkgSt, _ := pkgRef.ToState()
+
+			// Use the built package directly as a named build context.
+			// This is how the prebuilt package gets picked up and used
+			// for the container build.
+			containerSr := newSolveRequest(
+				withSpec(ctx, t, spec),
+				withBuildTarget(testConfig.Target.Container),
+				withBuildContext(ctx, t, targetName, pkgSt),
+			)
+
+			// Build the container.
+			containerRes := solveT(ctx, t, client, containerSr)
+			containerRef, err := containerRes.SingleRef()
+			assert.NilError(t, err)
+
+			// Verify that the container has the marker file from the pre-built package.
+			contents, err := containerRef.ReadFile(ctx, gwclient.ReadRequest{
+				Filename: "/etc/marker.txt",
+			})
+			assert.NilError(t, err)
+			assert.Check(t, strings.Contains(string(contents), "unique marker"))
+		})
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds functionality that allows a user to pass in a pre-built package via a target and then uses that same package when building the container. Allows for users to separate package builds from container builds.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #597 

