### PR TITLE
Add support for disabling automatic runtime dependency injection

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -57,8 +57,8 @@ type Artifacts struct {
 	// Some tooling, such as `rpmbuild`, will look at all artifacts and
 	// automatically inject missing dependencies into the package metadata.
 	// For instance, if you include a `.sh` script, rpmbuild with automatically
-	// add `bash` as a depdendency for the package.
-	// It also does this for librabries being linked against.
+	// add `bash` as a dependency for the package.
+	// It also does this for libraries being linked against.
 	//
 	// This is useful if you want to have more control over the dependencies
 	// that are included in the package.

--- a/artifacts.go
+++ b/artifacts.go
@@ -50,6 +50,20 @@ type Artifacts struct {
 
 	// DisableStrip is used to disable stripping of artifacts.
 	DisableStrip bool `yaml:"disable_strip,omitempty" json:"disable_strip,omitempty"`
+
+	// DisableAutoRequires is used to disable automatic dependency discovery for
+	// the produced package.
+	//
+	// Some tooling, such as `rpmbuild`, will look at all artifacts and
+	// automatically inject missing dependencies into the package metadata.
+	// For instance, if you include a `.sh` script, rpmbuild with automatically
+	// add `bash` as a depdendency for the package.
+	// It also does this for librabries being linked against.
+	//
+	// This is useful if you want to have more control over the dependencies
+	// that are included in the package.
+	// However, you must be careful to manually include all dependencies that are required.
+	DisableAutoRequires bool `yaml:"disable_auto_requires,omitempty" json:"disable_auto_requires,omitempty"`
 }
 
 type ArtifactSymlinkConfig struct {

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -236,7 +236,7 @@
 					"type": [
 						"boolean"
 					],
-					"description": "DisableAutoRequires is used to disable automatic dependency discovery for\nthe produced package.\n\nSome tooling, such as `rpmbuild`, will look at all artifacts and\nautomatically inject missing dependencies into the package metadata.\nFor instance, if you include a `.sh` script, rpmbuild with automatically\nadd `bash` as a depdendency for the package.\nIt also does this for librabries being linked against.\n\nThis is useful if you want to have more control over the dependencies\nthat are included in the package.\nHowever, you must be careful to manually include all dependencies that are required."
+					"description": "DisableAutoRequires is used to disable automatic dependency discovery for\nthe produced package.\n\nSome tooling, such as `rpmbuild`, will look at all artifacts and\nautomatically inject missing dependencies into the package metadata.\nFor instance, if you include a `.sh` script, rpmbuild with automatically\nadd `bash` as a dependency for the package.\nIt also does this for libraries being linked against.\n\nThis is useful if you want to have more control over the dependencies\nthat are included in the package.\nHowever, you must be careful to manually include all dependencies that are required."
 				},
 				"disable_strip": {
 					"type": [

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -232,6 +232,12 @@
 					],
 					"description": "DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/"
 				},
+				"disable_auto_requires": {
+					"type": [
+						"boolean"
+					],
+					"description": "DisableAutoRequires is used to disable automatic dependency discovery for\nthe produced package.\n\nSome tooling, such as `rpmbuild`, will look at all artifacts and\nautomatically inject missing dependencies into the package metadata.\nFor instance, if you include a `.sh` script, rpmbuild with automatically\nadd `bash` as a depdendency for the package.\nIt also does this for librabries being linked against.\n\nThis is useful if you want to have more control over the dependencies\nthat are included in the package.\nHowever, you must be careful to manually include all dependencies that are required."
+				},
 				"disable_strip": {
 					"type": [
 						"boolean"

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -133,7 +133,7 @@ func (w *controlWrapper) depends(buf *strings.Builder, depsSpec *dalec.PackageDe
 		}
 	}
 
-	// We _must_ add miscDeps regardless of `DisableAutoRequires` because
+	// We must add miscDeps regardless of `DisableAutoRequires` because
 	// debhelper programs that are to be invoked in a post-install script
 	// will not be able to function without it.
 	if _, exists := rtDeps[miscDeps]; !exists {

--- a/packaging/linux/deb/template_rules_test.go
+++ b/packaging/linux/deb/template_rules_test.go
@@ -113,7 +113,9 @@ func TestRules_OverrideSystemd(t *testing.T) {
 }
 
 func TestDepends(t *testing.T) {
-	control := &controlWrapper{}
+	control := &controlWrapper{
+		Spec: &dalec.Spec{},
+	}
 
 	buf := &strings.Builder{}
 	control.depends(buf, nil)

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -26,6 +26,7 @@ Version: {{.Version}}
 Release: {{.Release}}%{?dist}
 License: {{ .License }}
 Summary: {{ .Description }}
+{{ .DisableAutoReq }}
 {{ optionalField "URL" .Website -}}
 {{ optionalField "Vendor" .Vendor -}}
 {{ optionalField "Packager" .Packager -}}
@@ -902,6 +903,13 @@ func (w *specWrapper) DisableStrip() string {
 	artifacts := w.Spec.GetArtifacts(w.Target)
 	if artifacts.DisableStrip {
 		return "%global __strip /bin/true"
+	}
+	return ""
+}
+
+func (w *specWrapper) DisableAutoReq() string {
+	if w.Spec.Artifacts.DisableAutoRequires {
+		return "AutoReq: no"
 	}
 	return ""
 }

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -754,6 +754,7 @@ Version: 0.0.1
 Release: 1%{?dist}
 License: MIT
 Summary: A helpful tool
+
 %description
 A helpful tool
 
@@ -777,6 +778,7 @@ Version: 0.0.1
 Release: 1%{?dist}
 License: MIT
 Summary: A helpful tool
+
 Packager: Awesome Packager
 %description
 A helpful tool

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -338,8 +338,8 @@ strip them in the build phase.
 Some package tooling, such as `rpmbuild` or `debbuild` both used in core DALEC,
 will attempt to automatically resolve runtime dependencies for you based on
 the artifacts you have specified.
-This can be linked libraries or even detecting you've included a shell script
-and adding a dependency on the shell.
+This can include detecting binaries with linked libraries or even that
+a shell script is included in the artifacts.
 
 You can disable this behavior by setting `disable_auto_requires: true`
 

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -332,3 +332,28 @@ This is a global setting that applies to all artifacts only.
 
 If you want some binaries stripped and others not, you will need to manually
 strip them in the build phase.
+
+## Automatic Dependency Resolution
+
+Some package tooling, such as `rpmbuild` or `debbuild` both used in core DALEC,
+will attempt to automatically resolve runtime dependencies for you based on
+the artifacts you have specified.
+This can be linked libraries or even detecting you've included a shell script
+and adding a dependency on the shell.
+
+You can disable this behavior by setting `disable_auto_requires: true`
+
+```
+artifacts:
+  disable_auto_requires: true
+```
+
+You must be careful when using this as it will now be up to you to ensure
+that all runtime dependencies are specified in the spec rather than
+relying on the tooling to do it for you.
+
+How this works under the hood is dependent on the build tooling.
+For rpmbuild setting this to true will set `AutoReq: no` in the resulting rpm
+spec file.
+For debbuild, DALEC will not include `${shlibs:Depends}` in the control file,
+which DALEC normally includes by default.


### PR DESCRIPTION
This commit adds a new configuration option to the `artifacts` section `disable_automatic_requires` which, when set to true, disables the automatic injection of runtime dependencies into the generated packages.
