### PR TITLE
Make sure rpm/deb use disable_auto_requires from target-specific artifacts when available

### DIFF
--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -122,7 +122,8 @@ func (w *controlWrapper) depends(buf *strings.Builder, depsSpec *dalec.PackageDe
 		miscDeps = "${misc:Depends}"
 	)
 
-	if !w.Spec.Artifacts.DisableAutoRequires {
+	artifacts := w.Spec.GetArtifacts(w.Target)
+	if !artifacts.DisableAutoRequires {
 		if _, exists := rtDeps[shlibsDeps]; !exists {
 			if needsClone {
 				rtDeps = maps.Clone(rtDeps)
@@ -154,7 +155,7 @@ func multiline(field string, values []string) string {
 }
 
 func (w *controlWrapper) recommends(buf *strings.Builder, depsSpec *dalec.PackageDependencies) {
-	if len(depsSpec.Recommends) == 0 {
+	if depsSpec == nil || len(depsSpec.Recommends) == 0 {
 		return
 	}
 
@@ -182,11 +183,6 @@ func (w *controlWrapper) AllRuntimeDeps() fmt.Stringer {
 	b := &strings.Builder{}
 
 	deps := w.Spec.GetPackageDeps(w.Target)
-
-	if deps == nil {
-		return b
-	}
-
 	w.depends(b, deps)
 	w.recommends(b, deps)
 

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -235,6 +235,9 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 						"target-pkg-p": {Version: []string{"= 5.1.0"}},
 						"common-pkg":   {Version: []string{"= 6.1.0"}}, // Overrides root
 					},
+					Artifacts: &dalec.Artifacts{
+						DisableAutoRequires: true,
+					},
 				},
 				// target2 has explicit empty maps to override the root values
 				"target2": {
@@ -269,6 +272,9 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		require.NotContains(t, provides, "root-pkg-p")
 		require.NotContains(t, provides, "(= 6.0.0)") // common-pkg old version
 
+		deps := wrapper1.AllRuntimeDeps()
+		require.NotContains(t, deps.String(), "${shlibs:Depends}")
+
 		// Test with non-existent target to get root values
 		// Current implementation only falls back to root if target doesn't exist
 		wrapperNonExistent := &controlWrapper{spec, "non-existent-target"}
@@ -293,5 +299,8 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		require.Equal(t, "", wrapper2.Replaces().String())
 		require.Equal(t, "", wrapper2.Conflicts().String())
 		require.Equal(t, "", wrapper2.Provides().String())
+
+		deps = wrapper2.AllRuntimeDeps()
+		require.Contains(t, deps.String(), "${shlibs:Depends}")
 	})
 }

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -908,7 +908,8 @@ func (w *specWrapper) DisableStrip() string {
 }
 
 func (w *specWrapper) DisableAutoReq() string {
-	if w.Spec.Artifacts.DisableAutoRequires {
+	artifacts := w.Spec.GetArtifacts(w.Target)
+	if artifacts.DisableAutoRequires {
 		return "AutoReq: no"
 	}
 	return ""

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -625,6 +625,23 @@ getent group testgroup >/dev/null || groupadd --system testgroup
 
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("disable auto requires", func(t *testing.T) {
+		w := &specWrapper{Spec: &dalec.Spec{
+			Artifacts: dalec.Artifacts{
+				DisableAutoRequires: true,
+			},
+		}}
+
+		got := w.DisableAutoReq()
+		want := "AutoReq: no"
+		assert.Equal(t, want, got)
+
+		w = &specWrapper{Spec: &dalec.Spec{}}
+		got = w.DisableAutoReq()
+		want = ""
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestTemplate_Requires(t *testing.T) {
@@ -951,6 +968,9 @@ func TestTemplate_TargetSpecificOverrides(t *testing.T) {
 		Targets: map[string]dalec.Target{
 			// target1 overrides values
 			"target1": {
+				Artifacts: &dalec.Artifacts{
+					DisableAutoRequires: true,
+				},
 				Replaces: map[string]dalec.PackageConstraints{
 					"target-pkg-r": {Version: []string{">= 1.1.0"}},
 					"common-pkg":   {Version: []string{">= 2.1.0"}}, // Overrides root
@@ -996,6 +1016,8 @@ func TestTemplate_TargetSpecificOverrides(t *testing.T) {
 		assert.Assert(t, cmp.Contains(provides, "Provides: target-pkg-p == 5.1.0"))
 		assert.Assert(t, !strings.Contains(provides, "root-pkg-p"))
 		assert.Assert(t, !strings.Contains(provides, "= 6.0.0")) // common-pkg old version
+
+		assert.Assert(t, cmp.Equal(w.DisableAutoReq(), "AutoReq: no"))
 	})
 
 	t.Run("target2 should use empty maps", func(t *testing.T) {


### PR DESCRIPTION
This was looking at just the top-level artifacts instead of checking if the target-specific artifacts had a disable_auto_requires field.