### PR TITLE
Fix case where it was not possible to unmarshal without strict mode

### DIFF
--- a/load.go
+++ b/load.go
@@ -267,7 +267,8 @@ func (s *Spec) SubstituteArgs(env map[string]string, opts ...SubstituteOpt) erro
 func LoadSpec(dt []byte) (*Spec, error) {
 	var spec Spec
 
-	if err := yaml.UnmarshalWithOptions(dt, &spec, yaml.Strict()); err != nil {
+	spec.decodeOpts = append(spec.decodeOpts, yaml.Strict())
+	if err := yaml.Unmarshal(dt, &spec); err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling spec")
 	}
 
@@ -370,7 +371,7 @@ func (s *Spec) UnmarshalYAML(dt []byte) error {
 	type internalSpec Spec
 	var s2 internalSpec
 
-	dec := yaml.NewDecoder(parsed, yaml.Strict())
+	dec := yaml.NewDecoder(parsed, s.decodeOpts...)
 	if err := dec.Decode(&s2); err != nil {
 		return fmt.Errorf("%w:\n\n%s", errors.Wrap(err, "error unmarshalling parsed document"), parsed.String())
 	}

--- a/load_test.go
+++ b/load_test.go
@@ -548,6 +548,24 @@ sources:
 			t.Fatal("expected error, but received none")
 		}
 	})
+
+	t.Run("can be unmarshalled with unknown fields", func(t *testing.T) {
+		dt := []byte(`
+sources:
+  test:
+    noSuchField: "some value"
+`)
+		var spec Spec
+
+		if err := yaml.Unmarshal(dt, &spec); err != nil {
+			t.Fatal(err)
+		}
+
+		spec.decodeOpts = []yaml.DecodeOption{yaml.Strict()}
+		if err := yaml.Unmarshal(dt, &spec); err == nil {
+			t.Fatal("expected error due to strict unmarshalling, but received none")
+		}
+	})
 }
 
 func TestSpec_SubstituteBuildArgs(t *testing.T) {

--- a/spec.go
+++ b/spec.go
@@ -101,6 +101,8 @@ type Spec struct {
 	Tests []*TestSpec `yaml:"tests,omitempty" json:"tests,omitempty"`
 
 	extensions extensionFields `yaml:"-" json:"-"`
+
+	decodeOpts []yaml.DecodeOption `yaml:"-" json:"-"`
 }
 
 type extensionFields map[string]rawYAML


### PR DESCRIPTION
We need to be able to unmarshal without strict mode because clients may be trying to unmarshal data from different versions of dalec.
