### PR TITLE
Add support for mounting sources per command

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -405,6 +405,15 @@
 						"null"
 					],
 					"description": "Env is the list of environment variables to set for the command."
+				},
+				"mounts": {
+					"items": {
+						"$ref": "#/$defs/SourceMount"
+					},
+					"type": [
+						"array"
+					],
+					"description": "Mounts is the list of sources to mount into the build step."
 				}
 			},
 			"additionalProperties": {

--- a/spec.go
+++ b/spec.go
@@ -419,6 +419,9 @@ type BuildStep struct {
 	Command string `yaml:"command" json:"command" jsonschema:"required"`
 	// Env is the list of environment variables to set for the command.
 	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+
+	// Mounts is the list of sources to mount into the build step.
+	Mounts []SourceMount `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 }
 
 // SourceMount wraps a [Source] with a target mount point.

--- a/website/docs/sources.md
+++ b/website/docs/sources.md
@@ -260,6 +260,30 @@ sources:
 
 ```
 
+You can also mount other sources in invidual steps:
+
+```yaml
+sources:
+  someDockerImage:
+    path: /bar # Extract `/bar` from he result of running the command in the docker image below
+    image:
+      ref: docker.io/library/alpine:3.14
+      cmd:
+        steps:
+          - command: echo add some extra stuff >> /foo; mkdir /bar; cp /foo /bar
+            mounts: # Mount other sources into each command step
+              - dest: /foo
+                spec:
+                  inline:
+                    file:
+                      uid: 0
+                      gid: 0
+                      permissions: 0644
+                      contents: |
+                        some content
+                        some more content
+```
+
 You can use the docker image source to produce any kind of content for your build.
 
 Docker image sources are considered to be "directory" sources.


### PR DESCRIPTION
The docker image source currently allows you to mount other sources in for *all* commands.
This change allows you to specify a mount for a specific command.

This can help improve performance by only mounting the sources that are needed for a specific command by improving the cache hit rate.

Closes #437