### PR TITLE
Add msft-go to the list of mirror images.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - 'LICENSE'
       - '.github/workflows/retag.yml'
       - '.github/workflows/retag/images.yml'
+      - 'cmd/retagger/**'
 
   push:
     branches:
@@ -30,6 +31,7 @@ on:
       - 'LICENSE'
       - '.github/workflows/retag.yml'
       - '.github/workflows/retag/images.yml'
+      - 'cmd/retagger/**'
 
 permissions:
   contents: read

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '.github/workflows/retag/images.yml'
       - '.github/workflows/retag.yml'
-
+      - 'cmd/retagger/**'
 
 permissions:
   contents: read
@@ -47,47 +47,26 @@ jobs:
       - name: docker info
         run: docker version; docker info
       - if: ${{ github.event_name == 'pull_request' }}
-        name: Setup local registry
+        name: Setup retag registry (pr)
         run: |
           set -ex -o pipefail
           docker run -d --rm --name registry -p 5000:5000 ghcr.io/azure/dalec/mirror/dockerhub/library/registry:latest
           echo "RETAG_REGISTRY=localhost:5000" >> $GITHUB_ENV
+          echo "RETAG_REGISTRY_USE_HTTP=true" >> $GITHUB_ENV
       - if: ${{ github.event_name != 'pull_request' }}
-        name: Setup local registry
+        name: Setup retag registry (non-pr)
         run: |
           set -ex -o pipefail
           repo="ghcr.io/${{ github.repository }}"
           repo="$(tr '[:upper:]' '[:lower:]' <<<"$repo")"
           echo "RETAG_REGISTRY=${repo}" >> $GITHUB_ENV
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.23'
+          cache: true
       - name: Retag images
         run: |
-
-          yq eval '.[] | [.source, .dest ] | @tsv' ./.github/workflows/retag/images.yml | while IFS=$'\t' read -r source dest; do
-            dest="${RETAG_REGISTRY}/$dest"
-            echo "Retagging $source to $dest"
-
-            platform=""
-
-            if [[ "$source" == *"windows"* ]]; then
-              platform="--platform windows/amd64"
-            else
-              platform="--platform linux/amd64"
-            fi
-
-            docker pull ${platform} "$source"
-            docker tag "$source" "$dest"
-
-            docker push ${platform} "$dest" || (
-              echo "Failed to push $dest"
-              img_digest="$(sudo ctr -n moby image list | grep $dest | awk '{ print $3 }')"
-              img_index="$(sudo ctr -n moby content get "$img_digest" | jq)"
-              jq <<<"$img_index"
-              manifest_digest="$(jq -r '.manifests | map(select(.platform.architecture == "amd64")) | first | .digest' <<<"$img_index")"
-              sudo ctr -n moby content get "${manifest_digest}" | jq
-
-              exit 42
-            )
-          done
+          go run ./cmd/retagger .github/workflows/retag/images.yml
       - if: failure()
         name: daemon logs
         run: sudo journalctl -u docker

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -29,6 +29,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update docker
+        run: sudo apt update && sudo apt install -y docker-ce
       - name: Setup containerd snapshotter
         run: |
           sudo mkdir -p /etc/docker
@@ -37,9 +39,13 @@ jobs:
           tmp="$(mktemp)"
           jq '.features["containerd-snapshotter"] = true' /etc/docker/daemon.json | tee "${tmp}"
           sudo cp "${tmp}" /etc/docker/daemon.json
+          jq '.debug = true' /etc/docker/daemon.json | tee "${tmp}"
+          sudo cp "${tmp}" /etc/docker/daemon.json
           rm "${tmp}"
 
           sudo systemctl restart docker
+      - name: docker info
+        run: docker version; docker info
       - if: ${{ github.event_name == 'pull_request' }}
         name: Setup local registry
         run: |
@@ -64,10 +70,24 @@ jobs:
 
             if [[ "$source" == *"windows"* ]]; then
               platform="--platform windows/amd64"
+            else
+              platform="--platform linux/amd64"
             fi
 
             docker pull ${platform} "$source"
             docker tag "$source" "$dest"
 
-            docker push ${platform} "$dest"
+            docker push ${platform} "$dest" || (
+              echo "Failed to push $dest"
+              img_digest="$(sudo ctr -n moby image list | grep $dest | awk '{ print $3 }')"
+              img_index="$(sudo ctr -n moby content get "$img_digest" | jq)"
+              jq <<<"$img_index"
+              manifest_digest="$(jq -r '.manifests | map(select(.platform.architecture == "amd64")) | first | .digest' <<<"$img_index")"
+              sudo ctr -n moby content get "${manifest_digest}" | jq
+
+              exit 42
+            )
           done
+      - if: failure()
+        name: daemon logs
+        run: sudo journalctl -u docker

--- a/.github/workflows/retag/images.yml
+++ b/.github/workflows/retag/images.yml
@@ -54,3 +54,6 @@
 
 - source: "mcr.microsoft.com/cbl-mariner/base/core:2.0"
   dest: mirror/mcr/cbl-mariner/base/core:2.0
+
+- source: "mcr.microsoft.com/oss/go/microsoft/golang:1.23"
+  dest: mirror/mcr/oss/go/microsoft/golang:1.23

--- a/cmd/retagger/main.go
+++ b/cmd/retagger/main.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/signal"
+	"path"
+	"strconv"
+	"sync"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/transfer/registry"
+	"github.com/containerd/platforms"
+	"github.com/cpuguy83/dockercfg"
+	"github.com/distribution/reference"
+	"github.com/goccy/go-yaml"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type retagConfig struct {
+	Source string `json:"source" yaml:"source"`
+	Dest   string `json:"dest" yaml:"dest"`
+}
+
+type runConfig struct {
+	RepoPrefix string
+	SchemeHTTP bool
+}
+
+func boolFromEnv(name string) bool {
+	v := os.Getenv(name)
+	if v == "" {
+		return false
+	}
+	vv, err := strconv.ParseBool(v)
+	if err != nil {
+		panic(fmt.Sprintf("invalid value for %s: %s", name, v))
+	}
+	return vv
+}
+
+func main() {
+	var rcfg runConfig
+
+	flag.StringVar(&rcfg.RepoPrefix, "retag-registry", os.Getenv("RETAG_REGISTRY"), "Prefix for the repository URLs")
+	flag.BoolVar(&rcfg.SchemeHTTP, "http", boolFromEnv("RETAG_REGISTRY_USE_HTTP"), "Use HTTP instead of HTTPS for the destination registry")
+	flag.Parse()
+
+	config := flag.Arg(0)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	if err := run(ctx, config, rcfg); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+type errgroupCollector struct {
+	group sync.WaitGroup
+
+	mu   sync.Mutex
+	errs []error
+}
+
+func (ec *errgroupCollector) Do(f func() error) {
+	ec.group.Add(1)
+
+	go func() {
+		defer ec.group.Done()
+
+		if err := f(); err != nil {
+			ec.mu.Lock()
+			defer ec.mu.Unlock()
+			ec.errs = append(ec.errs, err)
+		}
+	}()
+}
+
+func (ec *errgroupCollector) Wait() error {
+	ec.group.Wait()
+
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	if len(ec.errs) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("encountered %d errors: %w", len(ec.errs), errors.Join(ec.errs...))
+}
+
+func run(ctx context.Context, configPath string, rcfg runConfig) error {
+	dt, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("error reading config file: %w", err)
+	}
+
+	var ls []retagConfig
+	if err := yaml.Unmarshal(dt, &ls); err != nil {
+		return fmt.Errorf("error unmarshalling config: %w", err)
+	}
+
+	var authFn credentialHelperFunc
+	dcfg, err := dockercfg.LoadDefaultConfig()
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error loading Docker config: %w", err)
+		}
+		authFn = func(h string) (string, string, error) {
+			return dockercfg.GetCredentialsFromHelper("", h)
+		}
+	}
+
+	if authFn == nil {
+		authFn = dcfg.GetRegistryCredentials
+	}
+
+	var eg errgroupCollector
+	for _, cfg := range ls {
+		eg.Do(func() (retErr error) {
+			defer func() {
+				if retErr != nil {
+					retErr = fmt.Errorf("error processing %s: %w", cfg.Source, retErr)
+				}
+			}()
+			cfg.Dest = path.Join(rcfg.RepoPrefix, cfg.Dest)
+
+			ref, err := reference.ParseAnyReference(cfg.Source)
+			if err != nil {
+				return fmt.Errorf("error parsing source image %s: %w", cfg.Source, err)
+			}
+
+			src, err := registry.NewOCIRegistry(ctx, ref.String(), registry.WithCredentials(authFn))
+			if err != nil {
+				return fmt.Errorf("error creating source registry for %s: %w", cfg.Source, err)
+			}
+
+			dstOpts := []registry.Opt{registry.WithCredentials(authFn)}
+			if rcfg.SchemeHTTP {
+				// If the destination is a local registry, we can skip TLS verification.
+				dstOpts = append(dstOpts, registry.WithDefaultScheme("http"))
+			}
+			dst, err := registry.NewOCIRegistry(ctx, cfg.Dest, dstOpts...)
+			if err != nil {
+				return fmt.Errorf("error creating destination registry for %s: %w", cfg.Dest, err)
+			}
+
+			name, desc, err := src.Resolve(ctx)
+			if err != nil {
+				return fmt.Errorf("error resolving source image %s: %w", cfg.Source, err)
+			}
+
+			fetcher, err := src.Fetcher(ctx, name)
+			if err != nil {
+				return fmt.Errorf("error creating fetcher for destination %s: %w", cfg.Dest, err)
+			}
+
+			cp := contentProviderFunc(func(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+				r, err := fetcher.Fetch(ctx, desc)
+				if err != nil {
+					return nil, fmt.Errorf("error fetching descriptor %s from source %s: %w", desc.Digest, cfg.Dest, err)
+				}
+				return &contentReaderAt{
+					desc:     desc,
+					ReaderAt: &readerToReaderAt{reader: r, ref: src.Image(), size: desc.Size},
+					Closer:   r,
+				}, nil
+			})
+
+			pusher, err := dst.Pusher(ctx, desc)
+			if err != nil {
+				return fmt.Errorf("error creating pusher for destination %s: %w", cfg.Dest, err)
+			}
+			return remotes.PushContent(ctx, pusher, desc, cp, nil, platforms.All, nil)
+		})
+	}
+
+	return eg.Wait()
+}
+
+type credentialHelperFunc func(host string) (string, string, error)
+
+func (f credentialHelperFunc) GetCredentials(_ context.Context, _, host string) (registry.Credentials, error) {
+	host = dockercfg.ResolveRegistryHost(host)
+	u, p, err := f(host)
+	if err != nil {
+		return registry.Credentials{}, fmt.Errorf("error getting credentials for host %s: %w", host, err)
+	}
+
+	return registry.Credentials{
+		Host:     host,
+		Username: u,
+		Secret:   p,
+	}, nil
+}
+
+type contentReaderAt struct {
+	desc ocispec.Descriptor
+	io.ReaderAt
+	io.Closer
+}
+
+type readerToReaderAt struct {
+	reader io.Reader
+	ref    string
+	pos    int64
+	size   int64
+}
+
+func (r *readerToReaderAt) ReadAt(p []byte, off int64) (n int, retErr error) {
+	defer func() {
+		if retErr != nil && !errors.Is(retErr, io.EOF) {
+			retErr = fmt.Errorf("error reading at offset %d for %s: %w", off, r.ref, retErr)
+		}
+	}()
+	if ra, ok := r.reader.(io.ReaderAt); ok {
+		n, err := ra.ReadAt(p, off)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return n, err
+			}
+			return n, fmt.Errorf("readerAt: %w", err)
+		}
+		return n, nil
+	}
+
+	if r.pos != off {
+		if seeker, ok := r.reader.(io.Seeker); ok {
+			// Seeking and then reading is not a faithful implementation of ReadAt,
+			// but since we aren't planning to do parallel reads, this should be fine.
+			if _, err := seeker.Seek(off, io.SeekStart); err != nil {
+				return 0, fmt.Errorf("error seeking: %w", err)
+			}
+			r.pos = off
+		} else {
+			return 0, fmt.Errorf("reader does not support seeking: %s", r.ref)
+		}
+	}
+
+	// Make sure we read at most the remaining bytes in the content OR at least the length of p.
+	// This is part of the interface of [io.ReaderAt], which states that ReadAt should read len(p) bytes
+	// or return a non-nil error.
+	minRead := min(int(r.size-r.pos), len(p))
+	n, err := io.ReadAtLeast(r.reader, p, int(minRead))
+	if n > 0 {
+		r.pos += int64(n)
+	}
+	return n, err
+}
+
+func (cra *contentReaderAt) Size() int64 {
+	return cra.desc.Size
+}
+
+type contentProviderFunc func(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error)
+
+func (f contentProviderFunc) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	return f(ctx, desc)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ toolchain go1.23.2
 require (
 	github.com/atombender/go-jsonschema v0.17.0
 	github.com/cavaliergopher/rpm v1.3.0
+	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
+	github.com/cpuguy83/dockercfg v0.3.2
+	github.com/distribution/reference v0.6.0
 	github.com/goccy/go-yaml v1.15.23
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -43,7 +46,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect
-	github.com/containerd/containerd/v2 v2.0.4 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -51,7 +53,6 @@ require (
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -72,6 +73,7 @@ require (
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRq
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
+github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
+github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -149,6 +151,8 @@ github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jD
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
Also added a custom retag CLI due to a [bug in docker](https://github.com/Azure/dalec/pull/646#issuecomment-2920725771).
retag CLI is quite a bit more efficient anyway since it doesn't need to unpack tar.gz files and just basically treats the whole source registry as a containerd [content.Provider](https://godoc.org/github.com/containerd/containerd/v2/core/content#Provider)