### PR TITLE
Updating docs to match targets in README

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -11,7 +11,7 @@ Our goal is to provide a secure and reproducible way to build packages and conta
 
 - 🐳 No additional tools are needed except for [Docker](https://docs.docker.com/engine/install/)!
 - 🚀 Easy to use declarative configuration that provides reproducible builds
-- 📦 Build packages and/or containers for [Azure Linux](https://github.com/microsoft/azurelinux) 2 and 3 (formerly known as CBL-Mariner)
+- 📦 Build packages and/or containers for a number of different [targets](https://azure.github.io/dalec/targets) such as Ubuntu, Azure Linux and Windows (cross compilation only)
 - 🔌 Pluggable support for other operating systems
 - 🤏 Minimal image size, resulting in less vulnerabilities and smaller attack surface
 - 🪟 Support for Windows containers


### PR DESCRIPTION
**What this PR does / why we need it**:

The targets listed in the README had an addition from https://github.com/Azure/dalec/pull/468 that wasn't yet reflected in the website docs. This change updates the docs to match the current status as described in the README.


