### PR TITLE
Use the appropriate OS exit code for internal buildkit setup errors

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -40,7 +40,8 @@ func main() {
 
 	if err := fs.Parse(os.Args); err != nil {
 		bklog.L.WithError(err).Fatal("error parsing frontend args")
-		os.Exit(137)
+		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
+
 	}
 
 	subCmd := fs.Arg(1)
@@ -74,6 +75,6 @@ func dalecMain() {
 		frontend.WithTargetForwardingHandler,
 	)); err != nil {
 		bklog.L.WithError(err).Fatal("error running frontend")
-		os.Exit(137)
+		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
 	}
 }

--- a/test/fixtures/phony/main.go
+++ b/test/fixtures/phony/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	if err := grpcclient.RunFromEnvironment(ctx, mux.Handle); err != nil {
 		bklog.L.WithError(err).Fatal("error running frontend")
-		os.Exit(137)
+		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
 	}
 }
 

--- a/test/fixtures/signer/main.go
+++ b/test/fixtures/signer/main.go
@@ -118,6 +118,6 @@ func main() {
 		})
 	}); err != nil {
 		bklog.L.WithError(err).Fatal("error running frontend")
-		os.Exit(137)
+		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use exit code 70 for internal software (buildkit setup) errors. 137 is a SIGKILL exit code (e.g. OOM) so it doesn't really match here.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #662 

**Special notes for your reviewer**:
