### PR TITLE
Add base packages to be installed in base image for debian/ubuntu con…

### DIFF
--- a/targets/linux/deb/debian/bookworm.go
+++ b/targets/linux/deb/debian/bookworm.go
@@ -20,6 +20,7 @@ var (
 		VersionID:          bookwormVersionID,
 		ContextRef:         BookwormWorkerContextName,
 		DefaultOutputImage: bookwormRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 	}
 )

--- a/targets/linux/deb/debian/bullseye.go
+++ b/targets/linux/deb/debian/bullseye.go
@@ -21,7 +21,8 @@ var (
 		VersionID:          bullseyeVersionID,
 		ContextRef:         BullseyeWorkerContextName,
 		DefaultOutputImage: bullseyeRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 
 		// Ubuntu typically has backports repos already in it but Debian does not.
 		// Without this the go modules test will fail since there is no viable

--- a/targets/linux/deb/debian/common.go
+++ b/targets/linux/deb/debian/common.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	basePackages = []string{
+	builderPackages = []string{
 		"aptitude",
 		"dpkg-dev",
 		"devscripts",
@@ -19,6 +19,14 @@ var (
 		"dh-apparmor",
 		"dh-make",
 		"dh-exec",
+	}
+
+	// We want to install ca-certificates in the base image
+	// to ensure that certain operations (such as fetching custom repo configs over https)
+	// can be completed when the dalec-built packages are installed into the
+	// base image.
+	basePackages = []string{
+		"ca-certificates",
 	}
 
 	targets = map[string]gwclient.BuildFunc{

--- a/targets/linux/deb/distro/distro.go
+++ b/targets/linux/deb/distro/distro.go
@@ -30,6 +30,7 @@ type Config struct {
 	AptCachePrefix string
 
 	BuilderPackages    []string
+	BasePackages       []string
 	RepoPlatformConfig *dalec.RepoPlatformConfig
 
 	DefaultOutputImage string

--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -95,9 +95,11 @@ if ! command -v aptitude > /dev/null; then
 fi
 
 cleanup() {
+	exit_code=$?
 	if [ "${needs_cleanup}" = "1" ]; then
 		apt remove -y aptitude
 	fi
+	exit $exit_code
 }
 
 trap cleanup EXIT

--- a/targets/linux/deb/ubuntu/bionic.go
+++ b/targets/linux/deb/ubuntu/bionic.go
@@ -20,6 +20,7 @@ var (
 		VersionID:          bionicVersionID,
 		ContextRef:         BionicWorkerContextName,
 		DefaultOutputImage: bionicRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 	}
 )

--- a/targets/linux/deb/ubuntu/common.go
+++ b/targets/linux/deb/ubuntu/common.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	basePackages = []string{
+	builderPackages = []string{
 		"aptitude",
 		"dpkg-dev",
 		"devscripts",
@@ -19,6 +19,14 @@ var (
 		"dh-apparmor",
 		"dh-make",
 		"dh-exec",
+	}
+
+	// We want to install ca-certificates in the base image
+	// to ensure that certain operations (such as fetching custom repo configs over https)
+	// can be completed when the dalec-built packages are installed into the
+	// base image.
+	basePackages = []string{
+		"ca-certificates",
 	}
 
 	targets = map[string]gwclient.BuildFunc{

--- a/targets/linux/deb/ubuntu/focal.go
+++ b/targets/linux/deb/ubuntu/focal.go
@@ -20,6 +20,7 @@ var (
 		VersionID:          focalVersionID,
 		ContextRef:         FocalWorkerContextName,
 		DefaultOutputImage: focalRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 	}
 )

--- a/targets/linux/deb/ubuntu/jammy.go
+++ b/targets/linux/deb/ubuntu/jammy.go
@@ -20,6 +20,7 @@ var (
 		VersionID:          JammyVersionID,
 		ContextRef:         JammyWorkerContextName,
 		DefaultOutputImage: jammyRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 	}
 )

--- a/targets/linux/deb/ubuntu/noble.go
+++ b/targets/linux/deb/ubuntu/noble.go
@@ -20,6 +20,7 @@ var (
 		VersionID:          nobleVersionID,
 		ContextRef:         NobleWorkerContextName,
 		DefaultOutputImage: nobleRef,
-		BuilderPackages:    basePackages,
+		BuilderPackages:    builderPackages,
+		BasePackages:       basePackages,
 	}
 )

--- a/test/target_debian_test.go
+++ b/test/target_debian_test.go
@@ -1,27 +1,56 @@
 package test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/targets/linux/deb/debian"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 )
 
 func TestBookworm(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(debian.BookwormDefaultTargetKey, debian.BookwormConfig, withPackageOverride("rust", "rust-all"), withPackageOverride("bazel", "bazel-bootstrap")))
+	testConf := debLinuxTestConfigFor(debian.BookwormDefaultTargetKey, debian.BookwormConfig, withPackageOverride("rust", "rust-all"), withPackageOverride("bazel", "bazel-bootstrap"))
+
+	testLinuxDistro(ctx, t, testConf)
+	testDebianBaseDependencies(t, testConf.Target)
 }
 
 func TestBullseye(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, debLinuxTestConfigFor(
+	testConf := debLinuxTestConfigFor(
 		debian.BullseyeDefaultTargetKey,
 		debian.BullseyeConfig,
 		withPackageOverride("golang", "golang-1.19"),
 		withPackageOverride("rust", "cargo-web"),
 		withPackageOverride("bazel", noPackageAvailable),
-	))
+	)
+
+	testLinuxDistro(ctx, t, testConf)
+	testDebianBaseDependencies(t, testConf.Target)
+}
+
+func testDebianBaseDependencies(t *testing.T, target targetConfig) {
+	ctx := startTestSpan(baseCtx, t)
+	spec := newSimpleSpec()
+	spec.Tests = []*dalec.TestSpec{
+		{
+			Files: map[string]dalec.FileCheckOutput{
+				"/etc/ssl/certs": {
+					Permissions: 0755,
+					IsDir:       true,
+				},
+			},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+		req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(target.Container))
+		solveT(ctx, t, client, req)
+	})
 }


### PR DESCRIPTION
…tainer targets.

For now, the only base package is ca-certificates. This is so certain operations, such as fetching anything at install time over https, will work.

This commit also propagates the error code return in the install-with-constraints script for apt installs, so that if the provided aptitude command fails to resolve the, for example, resolve a package repo, that error will be reported to the Dalec frontend.

(cherry picked from commit 08b3ea62b13265442a03e65dd58f1a2a9f90ba4e)
