### PR TITLE
Add missing quote to fix worker-images.yml workflow

### DIFF
--- a/.github/workflows/worker-images.yml
+++ b/.github/workflows/worker-images.yml
@@ -100,7 +100,7 @@ jobs:
         name: Setup (merged)
         run: |
           set -ex -o pipefail
-          EXTRA_FLAGS=--set worker.cache-to=type=gha,scope=main.${{matrix.target}},mode=max --set worker.cache-from=type=gha,scope=${MAIN_CACHE_SCOPE}"
+          EXTRA_FLAGS="--set worker.cache-to=type=gha,scope=main.${{matrix.target}},mode=max --set worker.cache-from=type=gha,scope=${MAIN_CACHE_SCOPE}"
           echo "EXTRA_FLAGS=${EXTRA_FLAGS}" >> $GITHUB_ENV
       - name: Setup QEMU
         run: docker run --rm --privileged tonistiigi/binfmt:latest --install all


### PR DESCRIPTION
**What this PR does / why we need it**:
The images workflow is failing in the `Setup (merged)` section due to an omitted quote, this fixes it! 
