### PR TITLE
Don't consider licenses as doc files.

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -190,9 +190,6 @@ func (a Artifacts) HasDocs() bool {
 	if len(a.Docs) > 0 {
 		return true
 	}
-	if len(a.Licenses) > 0 {
-		return true
-	}
 	if len(a.Manpages) > 0 {
 		return true
 	}


### PR DESCRIPTION
This doesn't change what package managers will do with the licenses (ie omit them from the install process) but it does make sure that we don't consider a license file as a doc which would make it so all packages have a doc (or at least all packages we build).


Addresses https://github.com/Azure/dalec/pull/692/files/7b54d4a9d9396104f749ab03b36c92caf1e43e0e#diff-5980dac7473b3afee451e0b927cf5c7449e94ff4e034d8f46888338886c9c146
