### PR TITLE
dependabot: Update all deps at the same time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,16 @@ updates:
     directory: /website
     schedule:
       interval: weekly
+    groups:
+      website-gomod-all:
+        patterns:
+        - "*"
 
   - package-ecosystem: npm
     directory: /website
     schedule:
       interval: weekly
+    groups:
+      website-npm-all:
+        patterns:
+        - "*"


### PR DESCRIPTION
Reduces the number of PR's and also fixes certain cases where dependencies *need* to be bumped at the same time.
