### PR TITLE
ci: Don't run workflow for changes to dependabot workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ on:
       - 'cmd/worker-image-matrix/**'
       - '.github/workflows/worker-images/**'
       - '.github/workflows/worker-images.yml'
+      - '.github/workflows/dependabot.yml'
 
   push:
     branches:


### PR DESCRIPTION
This is just a waste of resources since the dependabot config is not checked by the ci workflow.

