### PR TITLE
ci: Set GITHUB_TOKEN perms where recommended

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
       - '.github/workflows/worker-images/**'
       - '.github/workflows/worker-images.yml'
       - '.github/workflows/dependabot.yml'
+      - '.github/workflows/release.yml'
 
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   tagList:
@@ -42,7 +41,11 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         shell: bash
+
   build:
+    permissions:
+      packages: write
+
     needs: tagList
     uses: ./.github/workflows/frontend-image.yml
     with:

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -15,10 +15,11 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   retag:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/worker-images.yml
+++ b/.github/workflows/worker-images.yml
@@ -51,7 +51,6 @@ jobs:
 
   build-worker-images:
     permissions:
-      contents: read
       packages: write
     needs: load-matrix
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This mostly just wants to make sure that read permissions are set the root and write permissions just on the job that needs it.

