### PR TITLE
Explicitly set contents: read on build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
 
   build:
     permissions:
+      contents: read
       packages: write
 
     needs: tagList


### PR DESCRIPTION
This was dropped before because step security said we should (or we did it wrong...) but this makes the pipeline invalid.

