### PR TITLE
[0.16] dnf: remove "--refresh" from install command

### DIFF
--- a/targets/linux/rpm/almalinux/v8.go
+++ b/targets/linux/rpm/almalinux/v8.go
@@ -21,6 +21,11 @@ var ConfigV8 = &distro.Config{
 
 	CacheName: dnfCacheNameV8,
 	CacheDir:  "/var/cache/dnf",
+	// Alma's repo configs do not include the $basearch variable in the mirrorlist URL
+	// This means that the cache key that dnf computes for /var/cache/dnf/<repoid>-<hash>
+	// is the same across x86_64 and aarch64, which leads to incorrect repo metadata
+	// when compiling for a non-native architecture.
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "8",
 	BuilderPackages:    builderPackages,

--- a/targets/linux/rpm/almalinux/v9.go
+++ b/targets/linux/rpm/almalinux/v9.go
@@ -21,6 +21,11 @@ var ConfigV9 = &distro.Config{
 
 	CacheName: dnfCacheNameV9,
 	CacheDir:  "/var/cache/dnf",
+	// Alma's repo configs do not include the $basearch variable in the mirrorlist URL
+	// This means that the cache key that dnf computes for /var/cache/dnf/<repoid>-<hash>
+	// is the same across x86_64 and aarch64, which leads to incorrect repo metadata
+	// when compiling for a non-native architecture.
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "9",
 	BuilderPackages:    builderPackages,

--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -69,10 +69,10 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, w
 	}
 
 	rootfs = worker.Run(
+		dalec.WithConstraints(opts...), // Make sure constraints (and platform specifically) are applied before install is set
 		cfg.Install(pkgs, installOpts...),
 		llb.AddMount(rpmMountDir, rpmDir, llb.SourcePath("/RPMS")),
 		llb.AddMount(baseMountPath, basePkgs, llb.SourcePath("/RPMS")),
-		dalec.WithConstraints(opts...),
 	).AddMount(workPath, rootfs)
 
 	if post := spec.GetImagePost(targetKey); post != nil && len(post.Symlinks) > 0 {

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -147,7 +147,7 @@ func TdnfInstall(cfg *dnfInstallConfig, releaseVer string, pkgs []string) llb.Ru
 	cmdFlags := dnfInstallFlags(cfg)
 	// tdnf makecache is needed to ensure that the package metadata is up to date if extra repo
 	// config files have been mounted
-	cmdArgs := fmt.Sprintf("set -ex; tdnf makecache -y; tdnf install -y --refresh --setopt=varsdir=/etc/dnf/vars --releasever=%s %s %s", releaseVer, cmdFlags, strings.Join(pkgs, " "))
+	cmdArgs := fmt.Sprintf("tdnf install -y --setopt=varsdir=/etc/dnf/vars --releasever=%s %s %s", releaseVer, cmdFlags, strings.Join(pkgs, " "))
 
 	var runOpts []llb.RunOption
 
@@ -176,7 +176,7 @@ func DnfInstall(cfg *dnfInstallConfig, releaseVer string, pkgs []string) llb.Run
 	cmdFlags := dnfInstallFlags(cfg)
 	// tdnf makecache is needed to ensure that the package metadata is up to date if extra repo
 	// config files have been mounted
-	cmdArgs := fmt.Sprintf("set -ex; dnf makecache -y; dnf install -y --refresh --releasever=%s --setopt=varsdir=/etc/dnf/vars %s %s", releaseVer, cmdFlags, strings.Join(pkgs, " "))
+	cmdArgs := fmt.Sprintf("dnf install -y --releasever=%s --setopt=varsdir=/etc/dnf/vars %s %s", releaseVer, cmdFlags, strings.Join(pkgs, " "))
 
 	var runOpts []llb.RunOption
 

--- a/test/createrepo.go
+++ b/test/createrepo.go
@@ -22,6 +22,7 @@ baseurl=file://` + repoPath + `
 gpgcheck=0
 priority=0
 enabled=1
+metadata_expire=0
 `)
 
 			pg := dalec.ProgressGroup("Install local repo for test")

--- a/test/createrepo.go
+++ b/test/createrepo.go
@@ -1,18 +1,24 @@
 package test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+
 	"github.com/Azure/dalec"
 	"github.com/Azure/dalec/targets/linux/rpm/distro"
 	"github.com/moby/buildkit/client/llb"
 )
 
-func createYumRepo(installer *distro.Config) func(rpms llb.State, opts ...llb.StateOption) llb.StateOption {
-	return func(rpms llb.State, opts ...llb.StateOption) llb.StateOption {
+func createYumRepo(installer *distro.Config) func(rpms llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
+	return func(rpms llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
 		return func(in llb.State) llb.State {
+			suffixBytes := sha256.Sum256([]byte(repoPath))
+			suffix := hex.EncodeToString(suffixBytes[:])[:8]
 			localRepo := []byte(`
-[Local]
+[Local-` + suffix + `]
 name=Local Repository
-baseurl=file:///opt/repo
+baseurl=file://` + repoPath + `
 gpgcheck=0
 priority=0
 enabled=1
@@ -21,15 +27,15 @@ enabled=1
 			pg := dalec.ProgressGroup("Install local repo for test")
 			withRepos := in.
 				Run(installer.Install([]string{"createrepo"}), pg).
-				File(llb.Mkdir("/opt/repo/RPMS", 0o755, llb.WithParents(true)), pg).
-				File(llb.Mkdir("/opt/repo/SRPMS", 0o755), pg).
-				File(llb.Mkfile("/etc/yum.repos.d/local.repo", 0o644, localRepo), pg).
+				File(llb.Mkdir(filepath.Join(repoPath, "RPMS"), 0o755, llb.WithParents(true)), pg).
+				File(llb.Mkdir(filepath.Join(repoPath, "SRPMS"), 0o755), pg).
+				File(llb.Mkfile("/etc/yum.repos.d/local-"+suffix+".repo", 0o644, localRepo), pg).
 				Run(
 					llb.AddMount("/tmp/st", rpms, llb.Readonly),
-					dalec.ShArgs("cp /tmp/st/RPMS/$(uname -m)/* /opt/repo/RPMS/ && cp /tmp/st/SRPMS/* /opt/repo/SRPMS"),
+					dalec.ShArgsf("cp /tmp/st/RPMS/$(uname -m)/* %s/RPMS/ && cp /tmp/st/SRPMS/* %s/SRPMS", repoPath, repoPath),
 					pg,
 				).
-				Run(dalec.ShArgs("createrepo --compatibility /opt/repo"), pg).
+				Run(dalec.ShArgs("createrepo --compatibility "+repoPath), pg).
 				Root()
 
 			for _, opt := range opts {

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -38,12 +38,12 @@ type workerConfig struct {
 	// CreateRepo takes in a state which is the output of the sign target,
 	// as well as optional state options for additional configuration.
 	// the output [llb.StateOption] should install the repo into the worker image.
-	CreateRepo func(llb.State, ...llb.StateOption) llb.StateOption
-	SignRepo   func(llb.State) llb.StateOption
+	CreateRepo func(st llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption
+	SignRepo   func(st llb.State, repoPath string) llb.StateOption
 	// ContextName is the name of the worker context that the build target will use
 	// to see if a custom worker is provided in a context
 	ContextName    string
-	TestRepoConfig func(string) map[string]dalec.Source
+	TestRepoConfig func(keyPath, repoPath string) map[string]dalec.Source
 	Platform       *ocispecs.Platform
 }
 
@@ -1962,7 +1962,8 @@ func testCustomLinuxWorker(ctx context.Context, t *testing.T, targetCfg targetCo
 		// Add the base package + repo to the worker
 		// This should make it so when dalec installs build deps it can use the package
 		// we built above.
-		worker = worker.With(workerCfg.CreateRepo(pkg))
+		repoPath := filepath.Join("/opt/repo", createRepoSuffix())
+		worker = worker.With(workerCfg.CreateRepo(pkg, repoPath))
 
 		// Now build again with our custom worker
 		// Note, we are solving the main spec, not depSpec here.
@@ -2083,7 +2084,8 @@ func testPinnedBuildDeps(ctx context.Context, t *testing.T, cfg testLinuxConfig)
 			pkg := reqToState(ctx, client, sr, t)
 			pkgs = append(pkgs, pkg)
 		}
-		return w.With(cfg.Worker.CreateRepo(llb.Merge(pkgs)))
+		repoPath := filepath.Join("/opt/repo", createRepoSuffix())
+		return w.With(cfg.Worker.CreateRepo(llb.Merge(pkgs), repoPath))
 	}
 
 	for _, tt := range tests {

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -29,6 +29,7 @@ repo_gpgcheck=1
 priority=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/%s
+metadata_expire=0
 	`, suffix, repoPath, keyPath),
 				},
 			},

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -13,19 +15,21 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var azlinuxTestRepoConfig = func(keyPath string) map[string]dalec.Source {
+var azlinuxTestRepoConfig = func(keyPath, repoPath string) map[string]dalec.Source {
+	suffixBytes := sha256.Sum256([]byte(repoPath))
+	suffix := hex.EncodeToString(suffixBytes[:])[:8]
 	return map[string]dalec.Source{
 		"local.repo": {
 			Inline: &dalec.SourceInline{
 				File: &dalec.SourceInlineFile{
-					Contents: fmt.Sprintf(`[Local]
+					Contents: fmt.Sprintf(`[Local-%s]
 name=Local Repository
-baseurl=file:///opt/repo
+baseurl=file://%s
 repo_gpgcheck=1
 priority=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/%s
-	`, keyPath),
+	`, suffix, repoPath, keyPath),
 				},
 			},
 		},
@@ -164,7 +168,7 @@ func azlinuxListSignFiles(ver string) func(*dalec.Spec, ocispecs.Platform) []str
 	}
 }
 
-func signRepoAzLinux(gpgKey llb.State) llb.StateOption {
+func signRepoAzLinux(gpgKey llb.State, repoPath string) llb.StateOption {
 	// key should be a state that has a public key under /public.key
 	return func(in llb.State) llb.State {
 		return in.Run(
@@ -174,7 +178,7 @@ func signRepoAzLinux(gpgKey llb.State) llb.StateOption {
 			Run(
 				dalec.ShArgs(`ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2) && \
 					gpg --list-keys --keyid-format LONG && \
-					gpg --detach-sign --default-key "$ID" --armor --yes /opt/repo/repodata/repomd.xml`),
+					gpg --detach-sign --default-key "$ID" --armor --yes `+repoPath+`/repodata/repomd.xml`),
 				llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
 			).Root()
 	}

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -64,22 +64,22 @@ func debLinuxTestConfigFor(targetKey string, cfg *distro.Config, opts ...func(*t
 	return tlc
 }
 
-func ubuntuCreateRepo(cfg *distro.Config) func(pkg llb.State, opts ...llb.StateOption) llb.StateOption {
-	return func(pkg llb.State, opts ...llb.StateOption) llb.StateOption {
+func ubuntuCreateRepo(cfg *distro.Config) func(pkg llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
+	return func(pkg llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
 		repoFile := []byte(`
-deb [trusted=yes] copy:/opt/repo/ /
+deb [trusted=yes] copy:` + repoPath + `/ /
 `)
 		return func(in llb.State) llb.State {
 			withRepo := in.Run(
 				dalec.ShArgs("apt-get update && apt-get install -y apt-utils gnupg2"),
 				dalec.WithMountedAptCache(cfg.AptCachePrefix),
-			).File(llb.Copy(pkg, "/", "/opt/repo")).
+			).File(llb.Copy(pkg, "/", repoPath, dalec.WithCreateDestPath())).
 				Run(
-					llb.Dir("/opt/repo"),
+					llb.Dir(repoPath),
 					dalec.ShArgs("apt-ftparchive packages . > Packages"),
 				).
 				Run(
-					llb.Dir("/opt/repo"),
+					llb.Dir(repoPath),
 					dalec.ShArgs("apt-ftparchive release . > Release"),
 				).Root()
 
@@ -93,7 +93,7 @@ deb [trusted=yes] copy:/opt/repo/ /
 	}
 }
 
-func signRepoUbuntu(gpgKey llb.State) llb.StateOption {
+func signRepoUbuntu(gpgKey llb.State, repoPath string) llb.StateOption {
 	// key should be a state that has a public key under /public.key
 	return func(in llb.State) llb.State {
 		// assuming in is the state that has the repo files under / including
@@ -105,20 +105,20 @@ func signRepoUbuntu(gpgKey llb.State) llb.StateOption {
 			Run(
 				dalec.ShArgs(`ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2) && \
 					gpg --list-keys --keyid-format LONG && \
-					gpg --default-key $ID -abs -o /opt/repo/Release.gpg /opt/repo/Release && \
-					gpg --default-key "$ID" --clearsign -o /opt/repo/InRelease /opt/repo/Release`),
+					gpg --default-key $ID -abs -o `+repoPath+`/Release.gpg `+repoPath+`/Release && \
+					gpg --default-key "$ID" --clearsign -o `+repoPath+`/InRelease `+repoPath+`/Release`),
 				llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
 				dalec.ProgressGroup("signing repo"),
 			).Root()
 	}
 }
 
-func ubuntuTestRepoConfig(name string) map[string]dalec.Source {
+func ubuntuTestRepoConfig(name, repoPath string) map[string]dalec.Source {
 	return map[string]dalec.Source{
 		"local.list": {
 			Inline: &dalec.SourceInline{
 				File: &dalec.SourceInlineFile{
-					Contents: fmt.Sprintf(`deb [signed-by=/usr/share/keyrings/%s] copy:/opt/repo/ /`, name),
+					Contents: fmt.Sprintf(`deb [signed-by=/usr/share/keyrings/%s] copy:`+repoPath+`/ /`, name),
 				},
 			},
 		},

--- a/website/docs/repositories.md
+++ b/website/docs/repositories.md
@@ -63,3 +63,8 @@ import MsftAzlCNRepo from './examples/repos/msft-azl-cloud-native.yml.md'
 <summary>Microsoft Azure Linux cloud-native repository (DNF)</summary>
 <MsftAzlCNRepo />
 </details>
+
+
+::: note
+For yum repos backed by the local filesystem, you may want to set `metadata_expire=0` in the repo config to avoid caching issues.
+:::


### PR DESCRIPTION
Since we just ran a `makecache` (which is neccessary or else dependency pinning tests will fail depending on test ordering, which also means real builds would have a problem) we don't need to hit the repo again to refresh the metadata.


(cherry picked from commit 4bbb3d19de74ef6843f79406c4ed40117e28175b)
