### PR TITLE
source: http: make sure we set a source path for mounts

### DIFF
--- a/source_http.go
+++ b/source_http.go
@@ -75,6 +75,10 @@ func (src *SourceHTTP) IsDir() bool {
 }
 
 func (src *SourceHTTP) toMount(opts fetchOptions) (llb.State, []llb.MountOption) {
+	if isRoot(opts.Rename) {
+		opts.Rename = internalMountSourceName
+	}
+
 	st := src.toState(opts)
 	// This is always a file, so to make sure we always mount a file instead of
 	// a directory we need to add a mount opt pointing at the file name.


### PR DESCRIPTION
In the sources refactor we neglected to set a source path when mounting http sources, as such they end up getting mounted as directories instead of files.

Fixes #750 