### PR TITLE
Add go 1.24 to retags

### DIFF
--- a/.github/workflows/retag/images.yml
+++ b/.github/workflows/retag/images.yml
@@ -4,6 +4,9 @@
 - source: "golang:1.23"
   dest: mirror/dockerhub/library/golang:1.23
 
+- source: "golang:1.24"
+  dest: mirror/dockerhub/library/golang:1.24
+
 - source: "registry:latest"
   dest: mirror/dockerhub/library/registry:latest
 
@@ -66,3 +69,6 @@
 
 - source: "mcr.microsoft.com/oss/go/microsoft/golang:1.23"
   dest: mirror/mcr/oss/go/microsoft/golang:1.23
+
+- source: "mcr.microsoft.com/oss/go/microsoft/golang:1.24"
+  dest: mirror/mcr/oss/go/microsoft/golang:1.24


### PR DESCRIPTION
This is so we can upgrade to go1.24
Fixes the issue in #735