### PR TITLE
rpm: Fix issue where ignore-cache is not respected

### DIFF
--- a/targets/linux/deb/distro/container.go
+++ b/targets/linux/deb/distro/container.go
@@ -57,7 +57,7 @@ func (c *Config) BuildContainer(ctx context.Context, client gwclient.Client, wor
 			},
 		}
 
-		basePkg, err := c.BuildPkg(ctx, client, worker, sOpt, basePkgSpec, targetKey)
+		basePkg, err := c.BuildPkg(ctx, client, worker, sOpt, basePkgSpec, targetKey, opts...)
 		if err != nil {
 			return llb.Scratch(), err
 		}

--- a/targets/linux/rpm/distro/worker.go
+++ b/targets/linux/rpm/distro/worker.go
@@ -22,7 +22,7 @@ func (cfg *Config) HandleWorker(ctx context.Context, client gwclient.Client) (*g
 		}
 
 		pc := dalec.Platform(platform)
-		st, err := cfg.Worker(sOpt, pc)
+		st, err := cfg.Worker(sOpt, pc, frontend.IgnoreCache(client))
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Makes sure `--no-cache` and `--no-cache-filter` is respected for rpm-based targets.