### PR TITLE
Fix incorrect format for deb version constraints

### DIFF
--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -88,7 +88,7 @@ func AppendConstraints(deps map[string]dalec.PackageConstraints) []string {
 			}
 		}
 
-		out[i] = strings.Join(versionConstraints, " | ")
+		out[i] = strings.Join(versionConstraints, ", ")
 	}
 
 	return out

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -37,7 +37,7 @@ func TestAppendConstraints(t *testing.T) {
 			deps: map[string]dalec.PackageConstraints{
 				"packageA": {Version: []string{">= 1.0", "<< 2.0"}},
 			},
-			want: []string{"packageA (<< 2.0) | packageA (>= 1.0)"},
+			want: []string{"packageA (<< 2.0), packageA (>= 1.0)"},
 		},
 		{
 			name: "single dependency with architecture constraints",
@@ -51,7 +51,7 @@ func TestAppendConstraints(t *testing.T) {
 			deps: map[string]dalec.PackageConstraints{
 				"packageA": {Version: []string{">= 1.0", "<< 2.0"}, Arch: []string{"amd64", "arm64"}},
 			},
-			want: []string{"packageA (<< 2.0) [amd64 arm64] | packageA (>= 1.0) [amd64 arm64]"},
+			want: []string{"packageA (<< 2.0) [amd64 arm64], packageA (>= 1.0) [amd64 arm64]"},
 		},
 		{
 			name: "multiple dependencies with constraints",


### PR DESCRIPTION
The format it was using is the or operator `|` that says either of these constraints satisfies the dependency.
We need these to be be and-ed, which is done like any other package with a `,`.
