### PR TITLE
tests: Add option to inline the build output to the test log

### DIFF
--- a/test/main_test.go
+++ b/test/main_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 		externalTestHost = "https://github.com"
 	}
 	flag.StringVar(&externalTestHost, "external-test-host", externalTestHost, "http server to use for validating network access")
+	flag.BoolVar(&testenv.InlineBuildOutput, "inline-build-output", testenv.InlineBuildOutput, "Stream the test's build output as it happens instead of waiting until the end. Note: parallel tests will interleave output.")
 
 	flag.Parse()
 


### PR DESCRIPTION
When integration running tests (go test ./test), normally the test runner will only output build logs (ie, logs from the buildkit solve(s) executed by a given test) at the end of a test.
With this change you can now provide a flag, `--inline-build-output`, which will make build output output directly to the test log (by line) instead of defering the output until the end of the test.

As noted in the flag description, when running multiple tests (which are generally run with t.Parallel) the build outputs for multiple tests may be interleaved, hence why this is disabled by default.
