### PR TITLE
Add copyright notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ Any use of third-party trademarks or logos are subject to those third-party's po
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10703/badge)](https://www.bestpractices.dev/projects/10703)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/project-dalec/dalec/badge)](https://scorecard.dev/viewer/?uri=github.com/project-dalec/dalec)
+
+Copyright Contributors to Dalec, established as Dalec a Series of LF Projects, LLC.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -69,7 +69,8 @@ const config: Config = {
     footer: {
       style: 'dark',
       links: [],
-      copyright: `Copyright © ${new Date().getFullYear()} Azure Container Upstream.`,
+      copyright: `Copyright Dalec a Series of LF Projects, LLC
+      For website terms of use, trademark policy and other project policies please see lfprojects.org/policies/.`
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
Added copyright notice for contributors to Dalec for cncf onboarding
using as reference https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md

Closes #797 