### PR TITLE
include date in copyright

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -69,7 +69,7 @@ const config: Config = {
     footer: {
       style: 'dark',
       links: [],
-      copyright: `Copyright Dalec a Series of LF Projects, LLC
+      copyright: `Copyright © ${new Date().getFullYear()} Dalec, a Series of LF Projects, LLC.
       For website terms of use, trademark policy and other project policies please see lfprojects.org/policies/.`
     },
     prism: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This was removed in recent [PR](https://github.com/project-dalec/dalec/pull/816). I think we should still include date in the copyright.
