### PR TITLE
refresh metadata!

### DIFF
--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -153,9 +153,8 @@ func dnfCommand(cfg *dnfInstallConfig, releaseVer string, exe string, dnfSubCmd 
 	clearMetadata := `
 $cmd clean metadata
 `
-
 	if !cfg.refreshMetadata {
-		clearMetadata = "\necho 'Skipping metadata refresh'\n"
+		clearMetadata = ""
 	}
 
 	cacheDir := "/var/cache/" + exe


### PR DESCRIPTION
**What this PR does / why we need it**:

When installing from local repos, dalec will rebuild the repo every time, but keep the metadata cache across runs. This means that on subsequent builds, digests don't match.