### PR TITLE
releases: Only set latest tag when release is the latest one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,20 @@ jobs:
           TRIMMED_REF_NAME="${REF_NAME#v}"
 
           # Creates a comma separated list of tags
-          # - latest
           # - <major>.<minor>
           # - <major>.<minor>.<patch>
-          OUTPUT_TAGS="latest,${TRIMMED_REF_NAME%.*},${TRIMMED_REF_NAME}"
-          
+          OUTPUT_TAGS="${TRIMMED_REF_NAME%.*},${TRIMMED_REF_NAME}"
+
+          # Check if this tag is the latest release by fetching the latest release and comparing the tag to the tag being built.
+          LATEST_TAG="$(gh release view --json tagName -q .tagName)"
+          if [ "$REF_NAME" = "$LATEST_TAG" ]; then
+            OUTPUT_TAGS="latest,${OUTPUT_TAGS}"
+          fi
+
           echo "OUTPUT_TAGS=${OUTPUT_TAGS}" >> "$GITHUB_OUTPUT" && cat "$GITHUB_OUTPUT"
         env:
           REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
 
   build:


### PR DESCRIPTION
Before this change any time the release workflow is run we update the "latest" of the frontend image.
This is fine until we backport a patch to an older release.

To fix this, check if the tag being built is for the latest release.
