### PR TITLE
website: Add algolia domain verification

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -1,4 +1,5 @@
 ALGOLIA_APP_ID=QB3RJK7I77
 ALGOLIA_INDEX_NAME=projectdalec
+ALGOLIA_SITE_VERIFICATION=1C1CBEF56CCCC1B2
 # Provide the search-only Algolia API key. Leave unset to disable local search.
 ALGOLIA_API_KEY=

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,11 +5,24 @@ import type * as Preset from '@docusaurus/preset-classic';
 const algoliaAppId = process.env.ALGOLIA_APP_ID ?? 'QB3RJK7I77';
 const algoliaApiKey = process.env.ALGOLIA_API_KEY;
 const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME ?? 'projectdalec';
+const algoliaSiteVerification = process.env.ALGOLIA_SITE_VERIFICATION ?? '1C1CBEF56CCCC1B2';
 
 const config: Config = {
   title: 'Dalec',
   tagline: 'Exterminate!',
   favicon: 'img/favicon.ico',
+
+  headTags: algoliaSiteVerification
+    ? [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'algolia-site-verification',
+        content: algoliaSiteVerification,
+      }
+    },
+  ]
+  : undefined,
 
   // Set the production url of your site here
   url: 'https://project-dalec.github.io',


### PR DESCRIPTION
algolia needs us to verify that we own the content at the domain and one way to do this is adding a meta header.
