### PR TITLE
snyk: (try to) ignore go-* vulnerabilties

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,6 @@
 version: v1.25.0
 ignore:
   go-.*:
-    - reason: "Go runtime CVEs not applicable; go.mod version sets the minimum verison, not the version in use"
+    - reason: "Go runtime CVEs not applicable; go.mod version sets the minimum version, not the version in use"
       expires: 2099-01-01T00:00:00Z
 


### PR DESCRIPTION
Snyk is looking at the go directive in the go.mod and assumes we are vulnerable to any/all CVE's in that version.

This is not how the go directive should be used.
We don't build with go1.24.0, and projects consuming dalec are not required to use go1.24.0 either.
This is just a bunch of false positives.

We could bump to go directive, but this is a waste of time and actively harmful to downstreams.

This is a "try to" because the snyk CLI doesn't seem to report these issues (or at least I haven't seen an incantation to make it happen) and it *looks* like this may be something snyk is injecting outside of the actual scan.
This change may or may not work.