### PR TITLE
refactor: Remove a bunch of error returns

### DIFF
--- a/frontend/build.go
+++ b/frontend/build.go
@@ -8,13 +8,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/project-dalec/dalec"
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/project-dalec/dalec"
 )
 
 type LoadConfig struct {

--- a/frontend/debug/handle_cargohome.go
+++ b/frontend/debug/handle_cargohome.go
@@ -3,11 +3,11 @@ package debug
 import (
 	"context"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 )
 
 const keyCargohomeWorker = "context:cargohome-worker"
@@ -33,10 +33,7 @@ func Cargohome(ctx context.Context, client gwclient.Client) (*gwclient.Result, e
 				Run(llb.Shlex("cargo --version")).Root()
 		}
 
-		st, err := spec.CargohomeDeps(sOpt, worker, dalec.Platform(platform))
-		if err != nil {
-			return nil, nil, err
-		}
+		st := spec.CargohomeDeps(sOpt, worker, dalec.Platform(platform))
 
 		def, err := st.Marshal(ctx)
 		if err != nil {

--- a/frontend/debug/handle_gomod.go
+++ b/frontend/debug/handle_gomod.go
@@ -6,11 +6,11 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 )
 
 const keyGomodWorker = "gomod-worker"
@@ -37,10 +37,7 @@ func Gomods(ctx context.Context, client gwclient.Client) (*gwclient.Result, erro
 		}
 		worker = worker.With(addedHosts(client))
 
-		st, err := spec.GomodDeps(sOpt, worker, dalec.Platform(platform))
-		if err != nil {
-			return nil, nil, err
-		}
+		st := spec.GomodDeps(sOpt, worker, dalec.Platform(platform))
 
 		def, err := st.Marshal(ctx)
 		if err != nil {

--- a/frontend/debug/handle_pip.go
+++ b/frontend/debug/handle_pip.go
@@ -3,11 +3,11 @@ package debug
 import (
 	"context"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 )
 
 const keyPipWorker = "context:pip-worker"
@@ -37,10 +37,7 @@ func Pip(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) 
 				Run(llb.Shlex("python3 -m pip --version")).Root()
 		}
 
-		pipDeps, err := spec.PipDeps(sOpt, worker, dalec.Platform(platform))
-		if err != nil {
-			return nil, nil, err
-		}
+		pipDeps := spec.PipDeps(sOpt, worker, dalec.Platform(platform))
 
 		var st llb.State
 		if pipDeps == nil {

--- a/frontend/debug/handle_sources.go
+++ b/frontend/debug/handle_sources.go
@@ -3,11 +3,11 @@ package debug
 import (
 	"context"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 )
 
 // Sources is a handler that outputs all the sources.
@@ -18,10 +18,7 @@ func Sources(ctx context.Context, client gwclient.Client) (*gwclient.Result, err
 			return nil, nil, err
 		}
 
-		sources, err := dalec.Sources(spec, sOpt)
-		if err != nil {
-			return nil, nil, err
-		}
+		sources := dalec.Sources(spec, sOpt)
 
 		def, err := dalec.MergeAtPath(llb.Scratch(), dalec.SortedMapValues(sources), "/").Marshal(ctx)
 		if err != nil {
@@ -64,11 +61,7 @@ func PatchedSources(ctx context.Context, client gwclient.Client) (*gwclient.Resu
 		}
 
 		pc := dalec.Platform(platform)
-		sources, err := dalec.Sources(spec, sOpt, pc)
-		if err != nil {
-			return nil, nil, err
-		}
-
+		sources := dalec.Sources(spec, sOpt, pc)
 		sources = dalec.PatchSources(worker, spec, sources, pc)
 
 		def, err := dalec.MergeAtPath(llb.Scratch(), dalec.SortedMapValues(sources), "/").Marshal(ctx)

--- a/generator_cargohome.go
+++ b/generator_cargohome.go
@@ -70,23 +70,20 @@ func (s *Spec) cargohomeSources() map[string]Source {
 // CargohomeDeps returns an [llb.State] containing all the Cargo dependencies for the spec
 // for any sources that have a cargohome generator specified.
 // If there are no sources with a cargohome generator, this will return a nil state.
-func (s *Spec) CargohomeDeps(sOpt SourceOpts, worker llb.State, opts ...llb.ConstraintsOpt) (*llb.State, error) {
+func (s *Spec) CargohomeDeps(sOpt SourceOpts, worker llb.State, opts ...llb.ConstraintsOpt) *llb.State {
 	sources := s.cargohomeSources()
 	if len(sources) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	deps := llb.Scratch()
 
 	// Get the patched sources for the Cargo projects
 	// This is needed in case a patch includes changes to Cargo.toml or Cargo.lock
-	patched, err := s.getPatchedSources(sOpt, worker, func(name string) bool {
+	patched := s.getPatchedSources(sOpt, worker, func(name string) bool {
 		_, ok := sources[name]
 		return ok
 	}, opts...)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get patched sources")
-	}
 
 	sorted := SortMapKeys(patched)
 
@@ -104,7 +101,7 @@ func (s *Spec) CargohomeDeps(sOpt SourceOpts, worker llb.State, opts ...llb.Cons
 		})
 	}
 
-	return &deps, nil
+	return &deps
 }
 
 func (gen *GeneratorCargohome) UnmarshalYAML(ctx context.Context, node ast.Node) error {

--- a/generator_nodemodules.go
+++ b/generator_nodemodules.go
@@ -80,20 +80,17 @@ func (s *Spec) nodeModSources() map[string]Source {
 // for any sources that have a node module generator specified.
 // If there are no sources with a node module generator, this will return nil.
 // The returned states have node_modules installed for each relevant source, using sources as input.
-func (s *Spec) NodeModDeps(sOpt SourceOpts, worker llb.State, opts ...llb.ConstraintsOpt) (map[string]llb.State, error) {
+func (s *Spec) NodeModDeps(sOpt SourceOpts, worker llb.State, opts ...llb.ConstraintsOpt) map[string]llb.State {
 	sources := s.nodeModSources()
 	if len(sources) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Get the patched sources for the node modules
-	patched, err := s.getPatchedSources(sOpt, worker, func(name string) bool {
+	patched := s.getPatchedSources(sOpt, worker, func(name string) bool {
 		_, ok := sources[name]
 		return ok
 	}, opts...)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get patched sources")
-	}
 
 	result := make(map[string]llb.State)
 	sorted := SortMapKeys(patched)
@@ -109,7 +106,7 @@ func (s *Spec) NodeModDeps(sOpt SourceOpts, worker llb.State, opts ...llb.Constr
 		}
 		result[key] = merged
 	}
-	return result, nil
+	return result
 }
 
 func (gen *GeneratorNodeMod) UnmarshalYAML(ctx context.Context, node ast.Node) error {

--- a/source_test.go
+++ b/source_test.go
@@ -240,10 +240,7 @@ exit 0
 		},
 	}
 
-	st, err := spec.GomodDeps(sOpt, llb.Scratch())
-	if err != nil {
-		t.Fatalf("gomod generator failed: %s", err)
-	}
+	st := spec.GomodDeps(sOpt, llb.Scratch())
 	if st == nil {
 		t.Fatal("gomod generator succeeded but return value was nil")
 	}

--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -5,10 +5,9 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/packaging/linux/deb"
-	"github.com/moby/buildkit/client/llb"
-	"github.com/pkg/errors"
 )
 
 // AptInstall returns an [llb.RunOption] that uses apt to install the provided
@@ -148,15 +147,9 @@ func (d *Config) InstallBuildDeps(ctx context.Context, sOpt dalec.SourceOpts, sp
 		}
 
 		opts := append(opts, dalec.ProgressGroup("Install build dependencies"))
-		debRoot, err := deb.Debroot(ctx, sOpt, depsSpec, in, llb.Scratch(), targetKey, "", d.VersionID, deb.SourcePkgConfig{}, opts...)
-		if err != nil {
-			return dalec.ErrorState(in, err)
-		}
+		debRoot := deb.Debroot(ctx, sOpt, depsSpec, in, llb.Scratch(), targetKey, "", d.VersionID, deb.SourcePkgConfig{}, opts...)
 
-		pkg, err := deb.BuildDebBinaryOnly(in, depsSpec, debRoot, "", opts...)
-		if err != nil {
-			return dalec.ErrorState(in, errors.Wrap(err, "error creating intermediate package for installing build dependencies"))
-		}
+		pkg := deb.BuildDebBinaryOnly(in, depsSpec, debRoot, "", opts...)
 
 		repos := dalec.GetExtraRepos(d.ExtraRepos, "build")
 		repos = append(repos, spec.GetBuildRepos(targetKey)...)

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/packaging/linux/rpm"
-	"github.com/moby/buildkit/client/llb"
 )
 
 var dnfRepoPlatform = dalec.RepoPlatformConfig{
@@ -230,10 +230,7 @@ func (cfg *Config) WithDeps(sOpt dalec.SourceOpts, targetKey, pkgName string, de
 			},
 		}
 
-		rpmSpec, err := rpm.ToSpecLLB(spec, in, targetKey, "", opts...)
-		if err != nil {
-			return dalec.ErrorState(in, err)
-		}
+		rpmSpec := rpm.RPMSpec(spec, in, targetKey, "", opts...)
 
 		specPath := filepath.Join("SPECS", spec.Name, spec.Name+".spec")
 		cacheInfo := rpm.CacheInfo{TargetKey: targetKey, Caches: spec.Build.Caches}

--- a/targets/windows/handle_container.go
+++ b/targets/windows/handle_container.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
@@ -18,6 +16,8 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -132,15 +132,9 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 		}
 
 		pg := dalec.ProgressGroup("Build windows container: " + spec.Name)
-		worker, err := distroConfig.Worker(sOpt, pg)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+		worker := distroConfig.Worker(sOpt, pg)
 
-		bin, err := buildBinaries(ctx, spec, worker, client, sOpt, targetKey)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to build binary %w", err)
-		}
+		bin := buildBinaries(ctx, spec, worker, client, sOpt, targetKey)
 
 		bi := bases[idx]
 

--- a/targets/windows/handler.go
+++ b/targets/windows/handler.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
-	"github.com/project-dalec/dalec/targets/linux/deb/distro"
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	bktargets "github.com/moby/buildkit/frontend/subrequests/targets"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
+	"github.com/project-dalec/dalec/targets/linux/deb/distro"
 )
 
 const (
@@ -76,11 +76,7 @@ func handleWorker(ctx context.Context, client gwclient.Client) (*gwclient.Result
 			return nil, nil, err
 		}
 
-		st, err := distroConfig.Worker(sOpt)
-		if err != nil {
-			return nil, nil, err
-		}
-
+		st := distroConfig.Worker(sOpt)
 		def, err := st.Marshal(ctx)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
This defers the error return until we are marshalling the state to send to buildkit.
It makes the code much simpler to reason and interact with since we don't need to `if err != nil { return err }` constantly throughout the stack.

This is preparing for some other refactors in the codebase to handle #843 and others