### PR TITLE
Fix some small typos

### DIFF
--- a/targets/linux/deb/distro/distro.go
+++ b/targets/linux/deb/distro/distro.go
@@ -36,7 +36,7 @@ type Config struct {
 	DefaultOutputImage string
 
 	// ExtraRepos is used by distributions that want to enable extra repositories
-	// that are not inthe base worker config.
+	// that are not in the base worker config.
 	// A prime example of this is adding Debian backports on debian distributions.
 	ExtraRepos []dalec.PackageRepositoryConfig
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -3087,7 +3087,7 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 					Name: "Test that tests fail the build",
 					Files: map[string]dalec.FileCheckOutput{
 						"/usr/share/test-file": {},
-						// Make sure dir permissions are chcked correctly.
+						// Make sure dir permissions are checked correctly.
 						"/usr/share": {IsDir: true, Permissions: 0o755},
 					},
 				},
@@ -3328,7 +3328,7 @@ func testDisableStrip(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
 			// This should make `strip` fail.
 			//
 			// Note: The test is specifically using ppc64le as GOARCH
-			// because it seems alma/rockylinux do not error ons trip except for ppc64le.
+			// because it seems alma/rockylinux do not error on strip except for ppc64le.
 			// Even this is a stretch as that does not even work as expected at version < v9.
 			{
 				Command: `cd src; if [ "${TARGETARCH}" = "ppc64le" ]; then export GOARCH=amd64; else export GOARCH=ppc64le; fi; go build -o ../bad-executable main.go`,

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -28,7 +28,7 @@ DALEC includes a number of built-in targets that you can either use in your spec
 
 When specifying a "target" to `docker build --target=<target>` DALEC treats
 `<target>` as a route (much like an HTTP path) and each of the above mentioned
-targets have subroutes you can specfiy as well, e.g. `jammy/deb` to have DALEC
+targets have subroutes you can specify as well, e.g. `jammy/deb` to have DALEC
 build and output just the deb package. What subroutes are available depend on
 the underlying target implementation.
 


### PR DESCRIPTION
Fixing some small typos found while going through the website + with `codespell`.

If you like, we can add GHA for codespell to proactively check for typos on PRs.