### PR TITLE
fix:fix "Date" type's marshalling

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -146,7 +146,7 @@ func (d Date) Compare(other Date) int {
 }
 
 func (d Date) MarshalYAML() ([]byte, error) {
-	return yaml.Marshal(d.String())
+	return yaml.Marshal(d.Format(time.DateOnly))
 }
 
 func (d *Date) UnmarshalYAML(dt []byte) error {
@@ -163,7 +163,7 @@ func (d *Date) UnmarshalYAML(dt []byte) error {
 }
 
 func (d Date) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
+	return json.Marshal(d.Format(time.DateOnly))
 }
 
 func (d *Date) UnmarshalJSON(dt []byte) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Marshalling just does marshals the t.String() date rather than using time.Format(time.DateOnly).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #855

**Special notes for your reviewer**:
