### PR TITLE
distro: Use internal worker

### DIFF
--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -21,8 +21,10 @@ func (d *Config) Validate(spec *dalec.Spec) error {
 	return nil
 }
 
-func (d *Config) BuildPkg(ctx context.Context, client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.State {
+func (d *Config) BuildPkg(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.State {
 	opts = append(opts, dalec.ProgressGroup("Build deb package"))
+
+	worker := d.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 
 	versionID := d.VersionID
 	if versionID == "" {
@@ -170,7 +172,7 @@ func addPaths(paths []string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	}
 }
 
-func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, _ llb.State, spec *dalec.Spec, sOpt dalec.SourceOpts, ctr llb.State, targetKey string, opts ...llb.ConstraintsOpt) (gwclient.Reference, error) {
+func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, ctr llb.State, targetKey string, opts ...llb.ConstraintsOpt) (gwclient.Reference, error) {
 	def, err := ctr.Marshal(ctx, opts...)
 	if err != nil {
 		return nil, err
@@ -238,7 +240,8 @@ func (cfg *Config) HandleSourcePkg(ctx context.Context, client gwclient.Client) 
 	})
 }
 
-func (c *Config) ExtractPkg(ctx context.Context, client gwclient.Client, worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, debSt llb.State, opts ...llb.ConstraintsOpt) llb.State {
+func (c *Config) ExtractPkg(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, debSt llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	worker := c.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 	depDebs := llb.Scratch()
 	deps := spec.GetPackageDeps(targetKey).GetSysext()
 	if len(deps) > 0 {

--- a/targets/linux/deb/distro/worker.go
+++ b/targets/linux/deb/distro/worker.go
@@ -82,7 +82,8 @@ func (cfg *Config) Worker(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb
 		).Root()
 }
 
-func (cfg *Config) SysextWorker(worker llb.State, opts ...llb.ConstraintsOpt) llb.State {
+func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb.State {
+	worker := cfg.Worker(sOpts, opts...)
 	return worker.Run(
 		dalec.WithConstraints(opts...),
 		AptInstall([]string{"erofs-utils"}, opts...),

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -255,12 +255,14 @@ func (cfg *Config) WithDeps(sOpt dalec.SourceOpts, targetKey, pkgName string, de
 	}
 }
 
-func (cfg *Config) DownloadDeps(worker llb.State, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, constraints dalec.PackageDependencyList, opts ...llb.ConstraintsOpt) llb.State {
+func (cfg *Config) DownloadDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, constraints dalec.PackageDependencyList, opts ...llb.ConstraintsOpt) llb.State {
 	if constraints == nil {
 		return llb.Scratch()
 	}
 
 	opts = append(opts, dalec.ProgressGroup("Downloading dependencies"))
+
+	worker := cfg.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 
 	worker = worker.Run(
 		dalec.WithConstraints(opts...),

--- a/targets/linux/rpm/distro/worker.go
+++ b/targets/linux/rpm/distro/worker.go
@@ -77,7 +77,8 @@ func (cfg *Config) Worker(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb
 		).Root()
 }
 
-func (cfg *Config) SysextWorker(worker llb.State, opts ...llb.ConstraintsOpt) llb.State {
+func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb.State {
+	worker := cfg.Worker(sOpts, opts...)
 	return worker.Run(
 		dalec.WithConstraints(opts...),
 		cfg.Install([]string{"erofs-utils"}),

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/go-archive/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 	"github.com/project-dalec/dalec/frontend/pkg/bkfs"
 	"golang.org/x/exp/maps"
 	"gotest.tools/v3/assert"
@@ -44,7 +45,7 @@ type workerConfig struct {
 	ContextName    string
 	TestRepoConfig func(keyPath, repoPath string) map[string]dalec.Source
 	Platform       *ocispecs.Platform
-	SysextWorker   func(worker llb.State, opts ...llb.ConstraintsOpt) llb.State
+	SysextWorker   func(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb.State
 }
 
 type targetConfig struct {
@@ -1126,7 +1127,10 @@ echo "$BAR" > bar.txt
 			}
 
 			sr = newSolveRequest(withBuildTarget(testConfig.Target.Worker), withSpec(ctx, t, nil))
-			worker := testConfig.Worker.SysextWorker(reqToState(ctx, gwc, sr, t))
+
+			sOpt, err := frontend.SourceOptFromClient(ctx, gwc, &cfg.Platform)
+			assert.NilError(t, err)
+			worker := testConfig.Worker.SysextWorker(sOpt)
 
 			pc := dalec.Platform(&cfg.Platform)
 			var opts []llb.ConstraintsOpt


### PR DESCRIPTION
Instead of passing around a worker, distro implementations should use their own implementation of `Worker()`.

This simplifies the interface slightly and should make it simpler/more clear as to how distributions can implement optimizations for cross builds.

