### PR TITLE
tests: actually test binaries for dwarf symbols

### DIFF
--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -3,8 +3,8 @@ package test
 import (
 	"testing"
 
-	"github.com/project-dalec/dalec/targets/linux/rpm/almalinux"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec/targets/linux/rpm/almalinux"
 )
 
 func TestAlmalinux9(t *testing.T) {
@@ -90,7 +90,6 @@ func TestAlmalinux8(t *testing.T) {
 			ID:        "almalinux",
 			VersionID: "8",
 		},
-		SkipStripTest: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -3,8 +3,8 @@ package test
 import (
 	"testing"
 
-	"github.com/project-dalec/dalec/targets/linux/rpm/rockylinux"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec/targets/linux/rpm/rockylinux"
 )
 
 func TestRockylinux9(t *testing.T) {
@@ -90,7 +90,6 @@ func TestRockylinux8(t *testing.T) {
 			ID:        "rocky",
 			VersionID: "8",
 		},
-		SkipStripTest: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},


### PR DESCRIPTION
This makes the test more robust and actually check that the files are stripped or not rather than depending on `strip` to exit non-zero.

Almalnux9 has recently started failing on this test on main.

Fixes #863 