### PR TITLE
Document the exact file where targets need to be registered

### DIFF
--- a/website/docs/developers.md
+++ b/website/docs/developers.md
@@ -256,7 +256,7 @@ go test -race ./...
 
 1. Create a new target directory under `targets/`
 2. Implement the target interface
-3. Register the target in `targets/register.go`
+3. Register the target in `targets/plugin/init.go`
 4. Add integration tests in `test/target_<name>_test.go`
 5. Run `make verify` and `make test-integration SUITE=<YourTarget>`
 6. Update documentation


### PR DESCRIPTION
**What this PR does / why we need it**:
When reviewing a recent [PR](https://github.com/project-dalec/dalec/pull/867#pullrequestreview-3500655602) I had to reference the [documentation for adding new targets](https://github.com/project-dalec/dalec/pull/867#pullrequestreview-3500655602) to verify that everything was added correctly.

I found that the docs weren't too clear on the exact file in which a target should be added. It references `targets/register.go` as a place to add the target but I think it'd be more accurate and helpful to point to where we would actually add it which is `targets/plugin/init.go`. I'd prefer the contributor to have to do a little less work to find that file, so this PR adds that change to the website docs.
