### PR TITLE
test/signing_test.go: don't access nil panic when test is interrupted

### DIFF
--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -97,7 +97,7 @@ func linuxSigningTests(ctx context.Context, testConfig testLinuxConfig) func(*te
 
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -175,7 +175,7 @@ signer:
 
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -262,7 +262,7 @@ signer:
 `)))
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -291,7 +291,7 @@ signer:
 			spec := newSigningSpec()
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -320,7 +320,7 @@ signer:
 
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -358,7 +358,7 @@ signer:
 
 			var found bool
 			handleStatus := func(status *client.SolveStatus) {
-				if found {
+				if found || status == nil {
 					return
 				}
 				for _, w := range status.Warnings {
@@ -498,7 +498,7 @@ signer:
 
 		var found bool
 		handleStatus := func(status *client.SolveStatus) {
-			if found {
+			if found || status == nil {
 				return
 			}
 			for _, w := range status.Warnings {


### PR DESCRIPTION
As test will panic. I am not sure this is correct solution though. We might want to throw an error here instead.

Example panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xfc2680]

goroutine 901 [running]:
github.com/project-dalec/dalec/test.testLinuxDistro.linuxSigningTests.func42.13.1(0xc0005b6788?)
        github.com/project-dalec/dalec/test/signing_test.go:364 +0x20
github.com/project-dalec/dalec/test/testenv.(*BuildxEnv).RunTest.func1()
        github.com/project-dalec/dalec/test/testenv/buildx.go:356 +0x103
created by github.com/project-dalec/dalec/test/testenv.(*BuildxEnv).RunTest in goroutine 864
        github.com/project-dalec/dalec/test/testenv/buildx.go:349 +0x235
FAIL    github.com/project-dalec/dalec/test     6.794s
make: *** [Makefile:53: test-integration] Error 1

```