### PR TITLE
Set tags correctly for release workflow

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -15,7 +15,7 @@ on:
       tag:
         description: 'Tag to publish'
         required: true
-        default: 'latest'
+        default: 'type=raw,value=latest'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,18 +33,23 @@ jobs:
           # Remove leading "v" from tag name
           TRIMMED_REF_NAME="${REF_NAME#v}"
 
-          # Creates a comma separated list of tags
-          # - <major>.<minor>
-          # - <major>.<minor>.<patch>
-          OUTPUT_TAGS="${TRIMMED_REF_NAME%.*},${TRIMMED_REF_NAME}"
+          OUTPUT_TAGS=(
+            "type=raw,value=${TRIMMED_REF_NAME%.*}"
+            "type=raw,value=${TRIMMED_REF_NAME}"
+          )
 
           # Check if this tag is the latest release by fetching the latest release and comparing the tag to the tag being built.
           LATEST_TAG="$(gh release view --json tagName -q .tagName)"
           if [ "$REF_NAME" = "$LATEST_TAG" ]; then
-            OUTPUT_TAGS="latest,${OUTPUT_TAGS}"
+            OUTPUT_TAGS=("type=raw,value=latest" "${OUTPUT_TAGS[@]}")
           fi
 
-          echo "OUTPUT_TAGS=${OUTPUT_TAGS}" >> "$GITHUB_OUTPUT" && cat "$GITHUB_OUTPUT"
+          {
+            echo "OUTPUT_TAGS<<EOF"
+            printf '%s\n' "${OUTPUT_TAGS[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
         env:
           REF_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/worker-images.yml
+++ b/.github/workflows/worker-images.yml
@@ -182,7 +182,7 @@ jobs:
           fi
           
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-          echo "image-name=ghcr.io/${BASE_REPO}" >> $GITHUB_OUTPUT      
+          echo "image-name=ghcr.io/${BASE_REPO}" >> $GITHUB_OUTPUT
       - name: Attest build provenance
         if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch' }}
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.0.0


### PR DESCRIPTION
We switched from manually executing `docker buildx bake` to using the docker metadata and build-push action.
These don't support the format we were using and only the first tag was published.
