### PR TITLE
Move spec tests into the LLB graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,9 +492,7 @@ jobs:
           docker buildx bake test
       - name: Build go-md2man example in docs
         run: |
-          version=$(cat docs/examples/go-md2man.yml | yq .version)
-          docker build -t go-md2man:$version -f docs/examples/go-md2man.yml --target=azlinux3/rpm --output=_output .
-          docker build -t go-md2man:$version -f docs/examples/go-md2man.yml --target=azlinux3 .
+          docker buildx bake examples
       - name: dump logs
         if: failure()
         id: dump-logs
@@ -516,7 +514,6 @@ jobs:
           name: e2e-dockerd-logs-diffmerge=${{ matrix.disable_diff_merge }}
           path: ${{ steps.dump-logs.outputs.DOCKERD_LOG_PATH }}
           retention-days: 1
-
   coverage-report:
     runs-on: ubuntu-22.04
     needs:

--- a/cmd/frontend/git_credential_helper.go
+++ b/cmd/frontend/git_credential_helper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -11,9 +12,18 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/project-dalec/dalec/internal/commands"
+	"github.com/project-dalec/dalec/internal/plugins"
 )
 
+func init() {
+	commands.RegisterPlugin(credHelperSubcmd, plugins.CmdHandlerFunc(credentialHelperCmd))
+}
+
 const (
+	credHelperSubcmd = "credential-helper"
+
 	keyProtocol          = "protocol"
 	keyHost              = "host"
 	keyPath              = "path"
@@ -72,7 +82,7 @@ type credConfig struct {
 	kind string
 }
 
-func gomodMain(args []string) {
+func credentialHelperCmd(ctx context.Context, args []string) {
 	var cfg credConfig
 	fs := flag.NewFlagSet(credHelperSubcmd, flag.ExitOnError)
 	fs.Func("kind", "the kind of secret to retrieve (token or header)", readKind(&cfg.kind))

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -1,25 +1,28 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/containerd/plugin"
 	"github.com/moby/buildkit/frontend/gateway/grpcclient"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/project-dalec/dalec/frontend"
 	"github.com/project-dalec/dalec/internal/frontendapi"
-	"github.com/project-dalec/dalec/internal/testrunner"
+	"github.com/project-dalec/dalec/internal/plugins"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/grpclog"
+
+	_ "github.com/project-dalec/dalec/internal/commands"
 )
 
 const (
 	Package = "github.com/project-dalec/dalec/cmd/frontend"
-
-	credHelperSubcmd = "credential-helper"
 )
 
 func init() {
@@ -28,43 +31,62 @@ func init() {
 }
 
 func main() {
-	fs := flag.CommandLine
-	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, `usage: %s [subcommand [args...]]`, os.Args[0])
-	}
+	flags := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ExitOnError)
 
-	if err := fs.Parse(os.Args); err != nil {
+	if err := flags.Parse(os.Args[1:]); err != nil {
 		bklog.L.WithError(err).Fatal("error parsing frontend args")
 		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
-
 	}
 
-	subCmd := fs.Arg(1)
-
-	// NOTE: for subcommands we take args[2:]
-	// skip args[0] (the executable) and args[1] (the subcommand)
-
-	// each "sub-main" function handles its own exit
-	switch subCmd {
-	case credHelperSubcmd:
-		args := flag.Args()[2:]
-		gomodMain(args)
-	case testrunner.StepRunnerCmdName:
-		args := flag.Args()[2:]
-		testrunner.StepCmd(args)
-	case testrunner.CheckFilesCmdName:
-		args := flag.Args()[2:]
-		testrunner.CheckFilesCmd(args)
-	case frontend.TestErrorCmdName:
-		args := flag.Args()[2:]
-		frontend.TestErrorCmd(args)
-	default:
-		dalecMain()
+	ctx := appcontext.Context()
+	if flags.NArg() == 0 {
+		dalecMain(ctx)
+		return
 	}
+
+	h, err := lookupCmd(ctx, flags.Arg(0))
+	if err != nil {
+		bklog.L.WithError(err).Fatal("error handling command")
+		os.Exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
+	}
+
+	if h == nil {
+		fmt.Fprintln(os.Stderr, "unknown subcommand:", flags.Arg(0))
+		fmt.Fprintln(os.Stderr, "full args:", flags.Args())
+		fmt.Fprintln(os.Stderr, "If you see this message this is probably a bug in dalec.")
+		os.Exit(64) // 64 is EX_USAGE, meaning command line usage error
+	}
+
+	h.HandleCmd(ctx, flags.Args()[1:])
 }
 
-func dalecMain() {
-	ctx := appcontext.Context()
+func lookupCmd(ctx context.Context, cmd string) (plugins.CmdHandler, error) {
+	set := plugin.NewPluginSet()
+	filter := func(r *plugins.Registration) bool {
+		return r.Type != plugins.TypeCmd || r.ID != cmd
+	}
+
+	for _, r := range plugins.Graph(filter) {
+		cfg := plugin.NewContext(ctx, set, nil)
+
+		p := r.Init(cfg)
+
+		v, err := p.Instance()
+		if plugin.IsSkipPlugin(err) {
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		return v.(plugins.CmdHandler), nil
+	}
+
+	return nil, nil
+}
+
+func dalecMain(ctx context.Context) {
 	mux, err := frontendapi.NewBuildRouter(ctx)
 	if err != nil {
 		bklog.L.WithError(err).Fatal("error creating frontend router")

--- a/frontend/build.go
+++ b/frontend/build.go
@@ -54,7 +54,7 @@ func LoadSpec(ctx context.Context, client *dockerui.Client, platform *ocispecs.P
 		o(&cfg)
 	}
 
-	src, err := client.ReadEntrypoint(ctx, "Dockerfile")
+	src, err := client.ReadEntrypoint(ctx, "dalec")
 	if err != nil {
 		return nil, fmt.Errorf("could not read spec file: %w", err)
 	}
@@ -218,26 +218,26 @@ func (c *clientWithPlatform) BuildOpts() gwclient.BuildOpts {
 	return opts
 }
 
-func GetCurrentFrontend(client gwclient.Client) (llb.State, error) {
+func GetCurrentFrontend(client gwclient.Client) llb.State {
+	return *getCurrentFrontend(client)
+}
+
+func getCurrentFrontend(client gwclient.Client) *llb.State {
 	f, err := client.(frontendClient).CurrentFrontend()
 	if err != nil {
-		return llb.Scratch(), err
+		panic(err)
 	}
 
 	if f == nil {
-		return llb.Scratch(), fmt.Errorf("nil frontend state returned")
+		panic("nil frontend state returned -- this should never happen")
 	}
 
-	return *f, nil
+	return f
 }
 
 func withCredHelper(c gwclient.Client) func() (llb.RunOption, error) {
 	return func() (llb.RunOption, error) {
-		f, err := GetCurrentFrontend(c)
-		if err != nil {
-			return nil, err
-		}
-
+		f := GetCurrentFrontend(c)
 		return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
 			llb.AddMount("/usr/local/bin/frontend", f, llb.SourcePath("/frontend")).SetRunOption(ei)
 		}), nil

--- a/frontend/request.go
+++ b/frontend/request.go
@@ -203,7 +203,7 @@ func MaybeSign(ctx context.Context, client gwclient.Client, st llb.State, spec *
 		Warnf(ctx, client, st, "Spec signing config overwritten by config at path %q in build-context %q", cfgPath, configCtxName)
 	}
 
-	cfg, err := getSigningConfigFromContext(ctx, client, cfgPath, configCtxName, sOpt)
+	cfg, err := getSigningConfigFromContext(ctx, client, cfgPath, configCtxName, sOpt, opts...)
 	if err != nil {
 		return dalec.ErrorState(llb.Scratch(), err)
 	}

--- a/frontend/test_runner.go
+++ b/frontend/test_runner.go
@@ -2,54 +2,39 @@ package frontend
 
 import (
 	"context"
-	stderrors "errors"
-	"fmt"
-	"io"
-	"io/fs"
-	"os"
-	"path"
-	"path/filepath"
 	"strconv"
-	"strings"
-	"sync"
 
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/moby/buildkit/identity"
-	"github.com/moby/buildkit/solver/errdefs"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend/pkg/bkfs"
 	"github.com/project-dalec/dalec/internal/testrunner"
 )
 
-const (
-	testErrorsOutputFile = ".errors.txt"
-	testOutputPath       = "/tmp/dalec/internal/test/step/output"
-)
+const IgnoreCacheTestsKey = "dalec.tests"
 
-var errorsOutputFullPath = filepath.Join(testOutputPath, testErrorsOutputFile)
-
-// RunTests runs the tests defined in the spec against the given the input state.
-// The result of this is either the provided `finalState` or a state that errors when executed with the errors produced by the tests.
-// The input state should be a runnable container with all dependencies already installed.
-func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, finalState llb.State, target string, platform *ocispecs.Platform) llb.StateOption {
+// RunTests runs the tests defined in the spec against the given target container.
+func RunTests(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, withTestDeps llb.StateOption, target string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	return func(in llb.State) llb.State {
-		const (
-			buildArgPrefix = "build-arg:"
-			skipTestsKey   = "DALEC_SKIP_TESTS"
-		)
-		if skipVar := client.BuildOpts().Opts[buildArgPrefix+skipTestsKey]; skipVar != "" {
+		if skipVar := client.BuildOpts().Opts["build-arg:"+"DALEC_SKIP_TESTS"]; skipVar != "" {
 			skip, err := strconv.ParseBool(skipVar)
 			if err != nil {
-				err = errors.Wrapf(err, "could not parse %s=%s", skipTestsKey, skipVar)
-				return dalec.ErrorState(finalState, err)
+				return dalec.ErrorState(in, errors.Wrapf(err, "could not parse build-arg %s", "DALEC_SKIP_TESTS"))
 			}
 			if skip {
-				Warnf(ctx, client, llb.Scratch(), "Tests skipped due to build-arg %s=%s", skipTestsKey, skipVar)
-				return finalState
+				Warn(ctx, client, llb.Scratch(), "Tests skipped due to build-arg DALEC_SKIP_TESTS="+skipVar)
+				return in
 			}
+		}
+
+		dc, err := dockerui.NewClient(client)
+		if err != nil {
+			return dalec.ErrorState(in, errors.Wrap(err, "failed to create docker client for test runner"))
+		}
+
+		if dc.IsNoCache(IgnoreCacheTestsKey) {
+			opts = append(opts, llb.IgnoreCache)
 		}
 
 		tests := spec.Tests
@@ -60,267 +45,22 @@ func RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, fin
 		}
 
 		if len(tests) == 0 {
-			return finalState
-		}
-
-		if !evalState(ctx, client, in) {
 			return in
 		}
 
-		sOpt, err := SourceOptFromClient(ctx, client, platform)
-		if err != nil {
-			return dalec.ErrorState(finalState, err)
+		vOpts := []testrunner.ValidationOpt{
+			testrunner.WithConstraints(opts...),
+			TestWithClientFrontend(client),
 		}
 
-		frontendSt, err := GetCurrentFrontend(client)
-		if err != nil {
-			// This should never happen and indicates a bug in our implementation.
-			// Nothing a user can do about it, so panic.
-			panic(err)
-		}
-
-		var group errGroup
-
-		for _, test := range tests {
-			pg := llb.ProgressGroup(identity.NewID(), "Test: "+path.Join(target, test.Name), false)
-
-			result := in.With(runTest(frontendSt, sOpt, test, pg))
-
-			group.Go(func() (retErr error) {
-				defer func() {
-					if r := recover(); r != nil {
-						trace := getPanicStack()
-						retErr = errors.Errorf("panic running test %q: %v\n%s", test.Name, r, trace)
-					}
-				}()
-
-				return checkTestResult(ctx, client, test, result, platform)
-			})
-		}
-
-		err = group.Wait()
-		if err == nil {
-			return finalState
-		}
-
-		return in.With(withTestError(err, frontendSt))
+		runTests := testrunner.WithTests(target, sOpt, withTestDeps, tests, vOpts...)
+		return in.With(runTests)
 	}
 }
 
-func checkTestResult(ctx context.Context, client gwclient.Client, test *dalec.TestSpec, result llb.State, platform *ocispecs.Platform) error {
-	// Make sure we force evaluation here otherwise errors won't surface until
-	// later, e.g. when we try to read the output file.
-	resultFS, err := bkfs.EvalFromState(ctx, &result, client, dalec.Platform(platform))
-	if err != nil {
-		err = testrunner.FilterStepError(err)
-		return errors.Wrapf(err, "%q", test.Name)
+func TestWithClientFrontend(client gwclient.Client) testrunner.ValidationOpt {
+	return func(vi *testrunner.ValidationInfo) {
+		st := getCurrentFrontend(client)
+		vi.Frontend = st
 	}
-
-	p := strings.TrimPrefix(errorsOutputFullPath, "/")
-	f, err := resultFS.Open(p)
-	if err != nil {
-		if !stderrors.Is(err, fs.ErrNotExist) {
-			return errors.Wrapf(err, "failed to read test result for %q", test.Name)
-		}
-		// No errors file means no errors.
-		return nil
-	}
-	defer f.Close()
-
-	var errs []error
-	for r, err := range testrunner.DecodeResults(f) {
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return errors.Wrapf(err, "failed to decode test result for %q", test.Name)
-		}
-
-		for _, checkErr := range r.Checks {
-			var src *errdefs.Source
-			if r.StepIndex != nil {
-				idx := *r.StepIndex
-				step := test.Steps[idx]
-				err := errors.Wrapf(checkErr, "step %d", idx)
-				err = errors.Wrapf(err, "%q", test.Name)
-				switch r.Filename {
-				case "stdout":
-					src = step.Stdout.GetErrSource(checkErr)
-				case "stderr":
-					src = step.Stderr.GetErrSource(checkErr)
-				default:
-					return errors.Wrapf(err, "unknown output stream name for step command check, if you see this it is a bug and should be reported: stream %q", r.Filename)
-				}
-
-				err = wrapWithSource(err, src)
-				errs = append(errs, err)
-				continue
-			}
-
-			var err error = checkErr
-			f, ok := test.Files[r.Filename]
-			if ok {
-				src := f.GetErrSource(checkErr)
-				err = errors.Wrap(err, r.Filename)
-				err = errors.Wrapf(err, "%q", test.Name)
-				err = wrapWithSource(err, src)
-				errs = append(errs, err)
-				continue
-			}
-			errs = append(errs, errors.Wrapf(err, "unknown file %q in test %q, if you see this it is a bug and should be reported", r.Filename, test.Name))
-		}
-	}
-
-	return stderrors.Join(errs...)
-}
-
-func runTest(frontend llb.State, sOpt dalec.SourceOpts, test *dalec.TestSpec, opts ...llb.ConstraintsOpt) llb.StateOption {
-	return func(in llb.State) llb.State {
-		base := in
-
-		errorsOutputFullPath := filepath.Join(testOutputPath, testErrorsOutputFile)
-
-		for k, v := range test.Env {
-			base = base.AddEnv(k, v)
-		}
-
-		var rOpts []llb.RunOption
-		rOpts = append(rOpts, dalec.WithConstraints(opts...))
-
-		for _, sm := range test.Mounts {
-			rOpts = append(rOpts, sm.ToRunOption(sOpt, dalec.WithConstraints(opts...)))
-		}
-
-		result := base
-		result = result.File(llb.Mkdir(testOutputPath, 0o755, llb.WithParents(true)), opts...)
-
-		for i, step := range test.Steps {
-			rOpts := append(rOpts, testrunner.WithTestStep(frontend, &step, i, errorsOutputFullPath))
-			rOpts = append(rOpts, step.GetSourceLocation(result))
-			result = result.Run(rOpts...).Root()
-		}
-
-		if len(test.Files) > 0 {
-			rOpts := append(rOpts, testrunner.WithFileChecks(frontend, test, errorsOutputFullPath))
-
-			rOpts = append(rOpts, llb.WithCustomNamef("Execute file checks for test: %s", test.Name))
-			result = result.Run(rOpts...).Root()
-		}
-
-		return result
-	}
-}
-
-func withTestError(err error, frontendSt llb.State) llb.StateOption {
-	return func(in llb.State) llb.State {
-		// Write the error(s) to a file then run a command which will:
-		// 1. cat the errors to stderr
-		// 2. exit non-zero to trigger a build failure.
-		const (
-			frontendP = "/tmp/internal/dalec/frontend"
-			errorsP   = "/tmp/internal/dalec/test/output/errors.txt"
-		)
-		errorsSt := llb.Scratch().File(
-			llb.Mkfile(filepath.Base(errorsP), 0o644, []byte(err.Error())),
-		)
-
-		return in.Run(
-			llb.WithCustomName("Report test errors"),
-			llb.AddMount(frontendP, frontendSt, llb.Readonly, llb.SourcePath("/frontend")),
-			llb.AddMount(errorsP, errorsSt, llb.Readonly, llb.SourcePath("/errors.txt")),
-			llb.Args([]string{frontendP, TestErrorCmdName, errorsP}),
-			dalec.RunOptFunc(func(ei *llb.ExecInfo) {
-				// Add the source maps for each error
-				c := ei.Constraints
-
-				for _, src := range errdefs.Sources(err) {
-					if src.Info == nil {
-						continue
-					}
-					sm := llb.NewSourceMap(&in, src.Info.Filename, src.Info.Language, src.Info.Data)
-					sm.Location(src.Ranges).SetConstraintsOption(&c)
-				}
-
-				ei.Constraints = c
-			}),
-		).Root()
-	}
-}
-
-func wrapWithSource(err error, src *errdefs.Source) error {
-	if src == nil {
-		return err
-	}
-
-	err = errors.Wrapf(err, "%s:%d", src.Info.Filename, src.Ranges[0].Start.Line)
-	return errdefs.WithSource(err, src)
-}
-
-type errGroup struct {
-	group sync.WaitGroup
-	mu    sync.Mutex
-	errs  []error
-}
-
-func (g *errGroup) Go(f func() error) {
-	g.group.Add(1)
-
-	go func() {
-		defer g.group.Done()
-		err := f()
-		g.mu.Lock()
-		g.errs = append(g.errs, err)
-		g.mu.Unlock()
-	}()
-}
-
-func (g *errGroup) Wait() error {
-	g.group.Wait()
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	err := stderrors.Join(g.errs...)
-
-	g.errs = g.errs[:0]
-	return err
-}
-
-const TestErrorCmdName = "test-error-cmd"
-
-// TestErrorCmd is a helper command that reads an error message from a file and
-// writes it to stderr before exiting with a non-zero code.
-// It is used by RunTests to report test failures.
-func TestErrorCmd(args []string) {
-	if len(args) != 1 {
-		fmt.Fprintln(os.Stderr, "requires exactly one argument: path to error file")
-		os.Exit(2)
-	}
-	p := args[0]
-	f, err := os.Open(p)
-	if err != nil {
-		panic(err)
-	}
-
-	defer f.Close()
-
-	_, err = io.Copy(os.Stderr, f)
-	if err != nil {
-		panic(err)
-	}
-
-	os.Exit(1)
-}
-
-func evalState(ctx context.Context, client gwclient.Client, st llb.State) bool {
-	def, err := st.Marshal(ctx)
-	if err != nil {
-		return false
-	}
-
-	_, err = client.Solve(ctx, gwclient.SolveRequest{
-		Definition: def.ToPB(),
-		Evaluate:   true,
-	})
-
-	return err == nil
 }

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -1,0 +1,13 @@
+package commands
+
+import "github.com/project-dalec/dalec/internal/plugins"
+
+func RegisterPlugin(name string, h plugins.CmdHandler) {
+	plugins.Register(&plugins.Registration{
+		ID:   name,
+		Type: plugins.TypeCmd,
+		InitFn: func(*plugins.InitContext) (any, error) {
+			return h, nil
+		},
+	})
+}

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -10,6 +10,7 @@ const (
 	// TypeBuildTarget is a plugin type for build targets.
 	// The returned plugin must implement the BuildHandler interface
 	TypeBuildTarget = "build-target"
+	TypeCmd         = "cmd"
 )
 
 type BuildHandler interface {
@@ -20,4 +21,14 @@ type BuildHandlerFunc func(ctx context.Context, client client.Client) (*client.R
 
 func (f BuildHandlerFunc) HandleBuild(ctx context.Context, client client.Client) (*client.Result, error) {
 	return f(ctx, client)
+}
+
+type CmdHandler interface {
+	HandleCmd(ctx context.Context, args []string)
+}
+
+type CmdHandlerFunc func(ctx context.Context, args []string)
+
+func (f CmdHandlerFunc) HandleCmd(ctx context.Context, args []string) {
+	f(ctx, args)
 }

--- a/internal/test/llb.go
+++ b/internal/test/llb.go
@@ -28,7 +28,7 @@ func LLBOpsFromState(ctx context.Context, state llb.State) ([]LLBOp, error) {
 			return nil, fmt.Errorf("parsing op: %w", err)
 		}
 		dgst := digest.FromBytes(dt)
-		ent := LLBOp{Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}
+		ent := LLBOp{Digest: dgst, Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}
 
 		ops = append(ops, ent)
 	}
@@ -56,6 +56,7 @@ func LLBOpsToJSON(ops []LLBOp) (string, error) {
 
 // LLBOp represents a single LLB operation along with its metadata.
 type LLBOp struct {
+	Digest     digest.Digest
 	Op         *pb.Op
 	OpMetadata *pb.OpMetadata
 }

--- a/internal/testrunner/exit.go
+++ b/internal/testrunner/exit.go
@@ -1,0 +1,6 @@
+package testrunner
+
+import "os"
+
+// exit is overridden in tests to prevent os.Exit from terminating the test process.
+var exit = os.Exit

--- a/internal/testrunner/file_contains.go
+++ b/internal/testrunner/file_contains.go
@@ -1,0 +1,79 @@
+package testrunner
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileContains = checkFileContainsCommand("check-file-contains")
+
+type checkFileContainsCommand string
+
+func (c checkFileContainsCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) []llb.StateOption {
+	if len(checker.Contains) == 0 {
+		return nil
+	}
+
+	outs := make([]llb.StateOption, 0, len(checker.Contains))
+	for i := range checker.Contains {
+		outs = append(outs, c.validate(p, checker, i, opts...))
+	}
+	return outs
+}
+
+func (c checkFileContainsCommand) validate(p string, checker *dalec.CheckOutput, index int, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		args := []string{
+			string(c),
+			p,
+			checker.Contains[index],
+		}
+		opts := append(opts, c.location(in, checker, index))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileContainsCommand) Kind() string {
+	return dalec.CheckOutputContainsKind
+}
+
+func (c checkFileContainsCommand) location(st llb.State, checker *dalec.CheckOutput, index int) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), index))
+	}
+}
+
+func (c checkFileContainsCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <contains-string>")
+		exit(1)
+	}
+
+	p := args[0]
+	f, err := mmapFile(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error opening file:", err)
+		exit(2)
+	}
+	defer f.Close()
+
+	expect := args[1]
+	dt := f.Bytes()
+	if bytes.Contains(dt, []byte(expect)) {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     filterPath(p),
+		Kind:     c.Kind(),
+		Expected: expect,
+		Actual:   previewString(dt),
+	}
+
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_contains_test.go
+++ b/internal/testrunner/file_contains_test.go
@@ -1,0 +1,60 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileContainsCommand(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "log.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("hello world"), 0o600))
+
+	t.Run("contains", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileContains.Cmd, file, "world")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("missing substring", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileContains.Cmd, file, "mars")
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"mars\""))
+	})
+
+	t.Run("invalid args", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileContains.Cmd, file)
+		assert.Check(t, cmp.Equal(code, 1))
+		assert.Check(t, cmp.Contains(stderr, "expected 2 arguments"))
+	})
+}
+
+func TestCheckFileContainsWithCheckLLB(t *testing.T) {
+	checker := checkOutputFromYAML(t, "contains:\n  - alpha\n  - beta\n")
+	stateOpts := checkFileContains.WithCheck("/tmp/output", checker, withTestFrontend())
+	assert.Check(t, cmp.Len(stateOpts, len(checker.Contains)))
+
+	for i, opt := range stateOpts {
+		def := definitionFromStateOption(t, opt)
+		exec := singleExecOp(t, def)
+		expect := []string{
+			frontendMountPath,
+			testRunnerCmdName,
+			string(checkFileContains),
+			"/tmp/output",
+			checker.Contains[i],
+		}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+		requireMountDest(t, exec.GetMounts(), frontendMountPath)
+		requireMountDest(t, exec.GetMounts(), internalStateMountPath)
+	}
+}
+
+func TestCheckFileContainsWithCheckLLBSkip(t *testing.T) {
+	opts := checkFileContains.WithCheck("/tmp/output", checkOutputFromYAML(t, "{}"), withTestFrontend())
+	assert.Check(t, opts == nil)
+}

--- a/internal/testrunner/file_empty.go
+++ b/internal/testrunner/file_empty.go
@@ -1,0 +1,75 @@
+package testrunner
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileEmpty = checkFileEmptyCommand("check-file-empty")
+
+type checkFileEmptyCommand string
+
+func (c checkFileEmptyCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if !checker.Empty {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			p,
+		}
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileEmptyCommand) Kind() string {
+	return dalec.CheckOutputEmptyKind
+}
+
+func (c checkFileEmptyCommand) location(st llb.State, checker *dalec.CheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileEmptyCommand) Cmd(args []string) {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "expected 1 argument: <file-path>")
+		exit(1)
+	}
+
+	p := args[0]
+	stat, err := os.Stat(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+
+	if stat.Size() == 0 {
+		return
+	}
+
+	var actual string
+
+	f, err := mmapFile(p)
+	if err != nil {
+		actual = fmt.Sprintf("<could not read file contents: %v>", err)
+	} else {
+		actual = previewString(f.Bytes())
+	}
+	defer f.Close()
+
+	err = &dalec.CheckOutputError{
+		Path:   filterPath(p),
+		Kind:   c.Kind(),
+		Actual: actual,
+	}
+
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_empty_test.go
+++ b/internal/testrunner/file_empty_test.go
@@ -1,0 +1,43 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileEmptyCommand(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.txt")
+	assert.NilError(t, os.WriteFile(empty, nil, 0o600))
+	full := filepath.Join(dir, "full.txt")
+	assert.NilError(t, os.WriteFile(full, []byte("data"), 0o600))
+
+	t.Run("empty file", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEmpty.Cmd, empty)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEmpty.Cmd, full)
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "got \"data\""))
+	})
+}
+
+func TestCheckFileEmptyWithCheckLLB(t *testing.T) {
+	t.Run("empty true", func(t *testing.T) {
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileEmpty.WithCheck("/tmp/out", checkOutputFromYAML(t, "empty: true\n"), withTestFrontend())))
+		expect := []string{frontendMountPath, testRunnerCmdName, string(checkFileEmpty), "/tmp/out"}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("skip when empty false", func(t *testing.T) {
+		execs := execsFromDefinition(t, definitionFromStateOption(t, checkFileEmpty.WithCheck("/tmp/out", checkOutputFromYAML(t, "{}"), withTestFrontend())))
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+}

--- a/internal/testrunner/file_endswith.go
+++ b/internal/testrunner/file_endswith.go
@@ -1,0 +1,70 @@
+package testrunner
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileEndsWith checkFileEndsWithCommand = "check-file-endswith"
+
+type checkFileEndsWithCommand string
+
+func (c checkFileEndsWithCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.EndsWith == "" {
+			return in
+		}
+		args := []string{
+			string(c),
+			p,
+			checker.EndsWith,
+		}
+
+		opts := append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileEndsWithCommand) Kind() string {
+	return dalec.CheckOutputEndsWithKind
+}
+
+func (c checkFileEndsWithCommand) location(st llb.State, checker *dalec.CheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileEndsWithCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <ends-with-string>")
+		exit(1)
+	}
+
+	p := args[0]
+	f, err := mmapFile(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+	defer f.Close()
+
+	dt := f.Bytes()
+	endsWith := args[1]
+	if bytes.HasSuffix(dt, []byte(endsWith)) {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     filterPath(p),
+		Kind:     c.Kind(),
+		Expected: endsWith,
+		Actual:   previewString(dt),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_endswith_test.go
+++ b/internal/testrunner/file_endswith_test.go
@@ -1,0 +1,41 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileEndsWithCommand(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "log.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("some data trailer"), 0o600))
+
+	t.Run("matches suffix", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEndsWith.Cmd, file, "trailer")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("suffix mismatch", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEndsWith.Cmd, file, "wrong")
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"wrong\""))
+	})
+}
+
+func TestCheckFileEndsWithWithCheckLLB(t *testing.T) {
+	t.Run("runs when suffix provided", func(t *testing.T) {
+		checker := checkOutputFromYAML(t, "ends_with: done\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileEndsWith.WithCheck("/tmp/out", checker, withTestFrontend())))
+		expect := []string{frontendMountPath, testRunnerCmdName, string(checkFileEndsWith), "/tmp/out", "done"}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("skip when suffix empty", func(t *testing.T) {
+		execs := execsFromDefinition(t, definitionFromStateOption(t, checkFileEndsWith.WithCheck("/tmp/out", checkOutputFromYAML(t, "{}"), withTestFrontend())))
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+}

--- a/internal/testrunner/file_equals.go
+++ b/internal/testrunner/file_equals.go
@@ -1,0 +1,71 @@
+package testrunner
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileEquals = checkFileEqualsCommand("check-file-equals")
+
+type checkFileEqualsCommand string
+
+func (c checkFileEqualsCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.Equals == "" {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			p,
+			checker.Equals,
+		}
+
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileEqualsCommand) Kind() string {
+	return dalec.CheckOutputEqualsKind
+}
+
+func (c checkFileEqualsCommand) location(st llb.State, checker *dalec.CheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileEqualsCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <file-equals-content>")
+		exit(1)
+	}
+
+	p := args[0]
+	f, err := mmapFile(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+	defer f.Close()
+
+	dt := f.Bytes()
+	equals := args[1]
+	if bytes.Equal(dt, []byte(equals)) {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     filterPath(p),
+		Kind:     c.Kind(),
+		Expected: equals,
+		Actual:   previewString(dt),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_equals_test.go
+++ b/internal/testrunner/file_equals_test.go
@@ -1,0 +1,42 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileEqualsCommand(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "config.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("exact-value"), 0o600))
+
+	t.Run("exact match", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEquals.Cmd, file, "exact-value")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileEquals.Cmd, file, "other")
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"other\""))
+	})
+}
+
+func TestCheckFileEqualsWithCheckLLB(t *testing.T) {
+	t.Run("executes when equals set", func(t *testing.T) {
+		checker := checkOutputFromYAML(t, "equals: data\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileEquals.WithCheck("/tmp/file", checker, withTestFrontend())))
+		expect := []string{frontendMountPath, testRunnerCmdName, string(checkFileEquals), "/tmp/file", "data"}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("skip when equals empty", func(t *testing.T) {
+		checker := checkOutputFromYAML(t, "{}")
+		execs := execsFromDefinition(t, definitionFromStateOption(t, checkFileEquals.WithCheck("/tmp/file", checker, withTestFrontend())))
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+}

--- a/internal/testrunner/file_exists.go
+++ b/internal/testrunner/file_exists.go
@@ -1,0 +1,112 @@
+package testrunner
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const (
+	checkFileNotExists = checkFileNotExistsCommand("check-file-not-exists")
+
+	noFollowFlagName = "no-follow-symlinks"
+)
+
+type checkFileNotExistsCommand string
+
+func (c checkFileNotExistsCommand) WithCheck(p string, checker *dalec.FileCheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if !checker.NotExist {
+			// This check is only for non-existence.
+			// If the file is expected to exist, skip this check.
+			return in
+		}
+
+		args := []string{
+			string(c),
+			"--" + noFollowFlagName + "=" + strconv.FormatBool(checker.NoFollow),
+			p,
+		}
+
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileNotExistsCommand) Kind() string {
+	return dalec.CheckFileNotExistsKind
+}
+
+func (c checkFileNotExistsCommand) location(st llb.State, checker *dalec.FileCheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileNotExistsCommand) newNotExistsError(p string, shouldExist, doesExist bool) error {
+	return &dalec.CheckOutputError{
+		Kind:     c.Kind(),
+		Path:     p,
+		Expected: "exists=" + strconv.FormatBool(shouldExist),
+		Actual:   "exists=" + strconv.FormatBool(doesExist),
+	}
+}
+
+func (c checkFileNotExistsCommand) Cmd(args []string) {
+	flags := flag.NewFlagSet(string(c), flag.ExitOnError)
+	noFollowFl := flags.Bool(noFollowFlagName, false, "do not follow symlinks")
+	flags.Parse(args) //nolint:errcheck // errors are handled by ExitOnError
+
+	if flags.NArg() != 1 {
+		flags.Usage()
+		exit(1)
+	}
+
+	p := flags.Arg(0)
+
+	_, err := fileInfo(p, *noFollowFl)
+	notExist := os.IsNotExist(err)
+
+	if err != nil && !notExist {
+		fmt.Fprintln(os.Stderr, "error checking file existence:", err)
+		exit(2)
+	}
+
+	if notExist {
+		return
+	}
+
+	err = c.newNotExistsError(p, false, true)
+	fmt.Fprintln(os.Stderr, err)
+	exit(2)
+}
+
+func fileInfo(p string, noFollow bool) (fs.FileInfo, error) {
+	if noFollow {
+		return os.Lstat(p)
+	}
+	return os.Stat(p)
+}
+
+func mustFileInfo(p string, noFollow bool) fs.FileInfo {
+	info, err := fileInfo(p, noFollow)
+	if err == nil {
+		return info
+	}
+
+	if os.IsNotExist(err) {
+		err = checkFileNotExists.newNotExistsError(p, true, false)
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+
+	fmt.Fprintln(os.Stderr, "error checking file info:", err)
+	exit(2)
+	// unreachable
+	return info
+}

--- a/internal/testrunner/file_exists_test.go
+++ b/internal/testrunner/file_exists_test.go
@@ -1,0 +1,87 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileExistsCommand(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("ok"), 0o600))
+	missing := filepath.Join(dir, "missing.txt")
+
+	t.Run("file exists", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileNotExists.Cmd, file)
+		assert.Assert(t, cmp.Equal(code, 2))
+
+		err := checkFileNotExists.newNotExistsError(file, false, true)
+		assert.Check(t, cmp.Contains(stderr, err.Error()))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileNotExists.Cmd, missing)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("expect not exists", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileNotExists.Cmd, missing)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, stderr == "")
+	})
+
+	t.Run("no follow symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target.txt")
+		symlink := filepath.Join(dir, "symlink.txt")
+
+		// Create a dangling symlink at <dir>/symlink.txt
+		// which points to a non-existent file <dir>/target.txt
+		if err := os.Symlink(target, symlink); err != nil {
+			t.Skip("skipping symlink test, could not create symlink:", err)
+		}
+
+		// The target does not exist, so should exit 0
+		code, _ := runCommand(t, checkFileNotExists.Cmd, symlink)
+		assert.Check(t, cmp.Equal(code, 0))
+
+		// the symlink itself does exist, which is what we are checking here.
+		// This should exit non-zero since "symlink" exists and we are not following the symlink.
+		code, stderr := runCommand(t, checkFileNotExists.Cmd, "--no-follow-symlinks=true", symlink)
+		assert.Check(t, cmp.Equal(code, 2))
+		err := checkFileNotExists.newNotExistsError(symlink, false, true)
+		assert.Check(t, cmp.Contains(stderr, err.Error()))
+	})
+}
+
+func TestCheckFileExistsWithCheckLLB(t *testing.T) {
+	t.Run("default flags", func(t *testing.T) {
+		opts := []ValidationOpt{withTestFrontend()}
+
+		checker := &dalec.FileCheckOutput{}
+		opt := checkFileNotExists.WithCheck("/var/log/app.log", checker, opts...)
+		def := definitionFromStateOption(t, opt)
+		execs := execsFromDefinition(t, def)
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+
+	t.Run("not exist and no follow", func(t *testing.T) {
+		checker := &dalec.FileCheckOutput{
+			NotExist: true,
+			NoFollow: true,
+		}
+		opt := checkFileNotExists.WithCheck("/tmp/link", checker, withTestFrontend())
+		args := singleExecOp(t, definitionFromStateOption(t, opt)).GetMeta().GetArgs()
+		assert.Assert(t, cmp.Len(args, 5))
+
+		actual := args[2:]
+		expect := []string{string(checkFileNotExists), "--" + noFollowFlagName + "=true", "/tmp/link"}
+		assert.Check(t, cmp.DeepEqual(expect, actual))
+	})
+}

--- a/internal/testrunner/file_isdir.go
+++ b/internal/testrunner/file_isdir.go
@@ -1,0 +1,78 @@
+package testrunner
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const (
+	checkFileIsDir = checkFileIsDirCommand("check-file-isdir")
+)
+
+type checkFileIsDirCommand string
+
+func (c checkFileIsDirCommand) WithCheck(p string, checker *dalec.FileCheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.NotExist {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			"--not=" + strconv.FormatBool(!checker.IsDir),
+			"--" + noFollowFlagName + "=" + strconv.FormatBool(checker.NoFollow),
+			p,
+		}
+
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileIsDirCommand) Kind() string {
+	return dalec.CheckFileIsDirKind
+}
+
+func (c checkFileIsDirCommand) location(st llb.State, checker *dalec.FileCheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileIsDirCommand) Cmd(args []string) {
+	flags := flag.NewFlagSet(string(c), flag.ExitOnError)
+	notFl := flags.Bool("not", false, "invert the is_dir check")
+	noFollowFl := flags.Bool(noFollowFlagName, false, "do not follow symlinks")
+	flags.Parse(args) //nolint:errcheck // already handled by ExitOnError
+
+	if flags.NArg() != 1 {
+		flags.Usage()
+		fmt.Fprintln(os.Stderr, "error: exactly one path argument is required")
+		fmt.Fprintln(os.Stderr, "args:", args)
+		exit(1)
+	}
+
+	p := flags.Arg(0)
+	fi := mustFileInfo(p, *noFollowFl)
+
+	expectDir := !*notFl
+	actual := fi.IsDir()
+
+	if actual == expectDir {
+		return
+	}
+
+	err := &dalec.CheckOutputError{
+		Kind:     c.Kind(),
+		Path:     p,
+		Expected: "is_dir=" + strconv.FormatBool(expectDir),
+		Actual:   "is_dir=" + strconv.FormatBool(actual),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(2)
+}

--- a/internal/testrunner/file_isdir_test.go
+++ b/internal/testrunner/file_isdir_test.go
@@ -1,0 +1,81 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileIsDirCommand(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("data"), 0o600))
+
+	t.Run("is directory", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileIsDir.Cmd, dir)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("not directory", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileIsDir.Cmd, file)
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"is_dir=true\""))
+	})
+
+	t.Run("symlink respects follow flag", func(t *testing.T) {
+		dir := t.TempDir()
+		expectDir := filepath.Join(dir, "dir")
+		assert.NilError(t, os.Mkdir(expectDir, 0o755))
+		link := filepath.Join(dir, "link")
+		if err := os.Symlink(expectDir, link); err != nil {
+			t.Skip("symlinks unsupported:", err)
+		}
+
+		code, stderr := runCommand(t, checkFileIsDir.Cmd, link)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+
+		code, stderr = runCommand(t, checkFileIsDir.Cmd, "--"+noFollowFlagName+"=true", link)
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"is_dir=true\""))
+	})
+}
+
+func TestCheckFileIsDirWithCheckLLB(t *testing.T) {
+	t.Run("is dir true", func(t *testing.T) {
+		checker := fileCheckFromYAML(t, "is_dir: true\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileIsDir.WithCheck("/data", checker, withTestFrontend())))
+		expect := []string{
+			frontendMountPath,
+			testRunnerCmdName,
+			string(checkFileIsDir),
+			"--not=false",
+			"--" + noFollowFlagName + "=false",
+			"/data",
+		}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("not dir expectation by default", func(t *testing.T) {
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileIsDir.WithCheck("/file", fileCheckFromYAML(t, "{}"), withTestFrontend())))
+		expect := []string{
+			frontendMountPath,
+			testRunnerCmdName,
+			string(checkFileIsDir),
+			"--not=true",
+			"--" + noFollowFlagName + "=false",
+			"/file",
+		}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("no follow flag", func(t *testing.T) {
+		checker := fileCheckFromYAML(t, "is_dir: true\nno_follow: true\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileIsDir.WithCheck("/data", checker, withTestFrontend())))
+		assert.Check(t, cmp.DeepEqual(exec.GetMeta().GetArgs()[3:6], []string{"--not=false", "--" + noFollowFlagName + "=true", "/data"}))
+	})
+}

--- a/internal/testrunner/file_link_target.go
+++ b/internal/testrunner/file_link_target.go
@@ -1,0 +1,68 @@
+package testrunner
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileLinkTarget = checkFileLinkTargetCommand("check-link-target")
+
+type checkFileLinkTargetCommand string
+
+func (c checkFileLinkTargetCommand) WithCheck(p string, checker *dalec.FileCheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.LinkTarget == "" {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			p,
+			checker.LinkTarget,
+		}
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileLinkTargetCommand) location(st llb.State, checker *dalec.FileCheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileLinkTargetCommand) Kind() string {
+	return dalec.CheckFileLinkTargetPathKind
+}
+
+func (c checkFileLinkTargetCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <link-target>")
+		exit(1)
+	}
+
+	p := args[0]
+	expected := args[1]
+
+	actual, err := os.Readlink(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+
+	if expected == actual {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Kind:     c.Kind(),
+		Path:     p,
+		Expected: expected,
+		Actual:   actual,
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(2)
+}

--- a/internal/testrunner/file_link_target_test.go
+++ b/internal/testrunner/file_link_target_test.go
@@ -1,0 +1,60 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileLinkTargetCommand(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	assert.NilError(t, os.WriteFile(target, []byte("data"), 0o600))
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	t.Run("matches target", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileLinkTarget.Cmd, link, target)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("unexpected target", func(t *testing.T) {
+		const want = "other"
+		code, stderr := runCommand(t, checkFileLinkTarget.Cmd, link, want)
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "expected: \""+want+"\""))
+		assert.Check(t, cmp.Contains(stderr, "got \""+target+"\""))
+	})
+
+	t.Run("invalid args", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileLinkTarget.Cmd, link)
+		assert.Check(t, cmp.Equal(code, 1))
+		assert.Check(t, cmp.Contains(stderr, "expected 2 arguments"))
+	})
+}
+
+func TestCheckFileLinkTargetWithCheckLLB(t *testing.T) {
+	t.Run("runs when link target set", func(t *testing.T) {
+		checker := fileCheckFromYAML(t, "link_target: /usr/bin/tool\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFileLinkTarget.WithCheck("/tmp/link", checker, withTestFrontend())))
+		expect := []string{
+			frontendMountPath,
+			testRunnerCmdName,
+			string(checkFileLinkTarget),
+			"/tmp/link",
+			"/usr/bin/tool",
+		}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("skip when link target empty", func(t *testing.T) {
+		execs := execsFromDefinition(t, definitionFromStateOption(t, checkFileLinkTarget.WithCheck("/tmp/link", fileCheckFromYAML(t, "{}"), withTestFrontend())))
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+}

--- a/internal/testrunner/file_matches.go
+++ b/internal/testrunner/file_matches.go
@@ -1,0 +1,87 @@
+package testrunner
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileMatches = checkFileMatchesCommand("check-file-matches")
+
+type checkFileMatchesCommand string
+
+func (c checkFileMatchesCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) []llb.StateOption {
+	if len(checker.Matches) == 0 {
+		return nil
+	}
+
+	outs := make([]llb.StateOption, 0, len(checker.Matches))
+	for i := range checker.Matches {
+		outs = append(outs, c.validate(p, checker, i, opts...))
+	}
+
+	return outs
+}
+
+func (c checkFileMatchesCommand) validate(p string, checker *dalec.CheckOutput, index int, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		args := []string{
+			string(c),
+			p,
+			checker.Matches[index],
+		}
+
+		opts := append(opts, c.location(in, checker, index))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileMatchesCommand) Kind() string {
+	return dalec.CheckOutputMatchesKind
+}
+
+func (c checkFileMatchesCommand) location(st llb.State, checker *dalec.CheckOutput, index int) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), index))
+	}
+}
+
+func (c checkFileMatchesCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <regexp pattern>")
+		fmt.Fprintln(os.Stderr, "args:", args)
+		exit(1)
+	}
+
+	pattern := args[1]
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error compiling regex pattern", pattern, err)
+		exit(2)
+	}
+
+	p := args[0]
+	f, err := mmapFile(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error opening file:", err)
+		exit(2)
+	}
+	defer f.Close()
+
+	dt := f.Bytes()
+	if re.Match(dt) {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     filterPath(p),
+		Kind:     dalec.CheckOutputMatchesKind,
+		Expected: pattern,
+		Actual:   previewString(dt),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_matches_test.go
+++ b/internal/testrunner/file_matches_test.go
@@ -1,0 +1,52 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileMatchesCommand(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "log.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("value=42"), 0o600))
+
+	t.Run("regex matches", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileMatches.Cmd, file, `value=\d+`)
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("regex mismatch", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileMatches.Cmd, file, `value=\d{3}`)
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"value=\\\\d{3}\""))
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileMatches.Cmd, file, `*invalid`)
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "error compiling regex pattern"))
+	})
+}
+
+func TestCheckFileMatchesWithCheckLLB(t *testing.T) {
+	checker := checkOutputFromYAML(t, "matches:\n  - foo\n  - bar\n")
+	stateOpts := checkFileMatches.WithCheck("/tmp/log", checker, withTestFrontend())
+	assert.Check(t, cmp.Len(stateOpts, 2))
+
+	for i, opt := range stateOpts {
+		exec := singleExecOp(t, definitionFromStateOption(t, opt))
+		expect := []string{frontendMountPath, testRunnerCmdName, string(checkFileMatches), "/tmp/log", checker.Matches[i]}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+		requireMountDest(t, exec.GetMounts(), frontendMountPath)
+		requireMountDest(t, exec.GetMounts(), internalStateMountPath)
+	}
+}
+
+func TestCheckFileMatchesWithCheckSkip(t *testing.T) {
+	opts := checkFileMatches.WithCheck("/tmp/log", checkOutputFromYAML(t, "{}"), withTestFrontend())
+	assert.Check(t, opts == nil)
+}

--- a/internal/testrunner/file_perms.go
+++ b/internal/testrunner/file_perms.go
@@ -1,0 +1,81 @@
+package testrunner
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFilePerms = checkFilePermsCommand("check-file-perms")
+
+type checkFilePermsCommand string
+
+func (c checkFilePermsCommand) WithCheck(p string, checker *dalec.FileCheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.Permissions == 0 {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			"--" + noFollowFlagName + "=" + strconv.FormatBool(checker.NoFollow),
+			p,
+			fmt.Sprintf("%o", checker.Permissions.Perm()),
+		}
+
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFilePermsCommand) Kind() string {
+	return dalec.CheckFilePermissionsKind
+}
+
+func (c checkFilePermsCommand) location(st llb.State, checker *dalec.FileCheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFilePermsCommand) Cmd(args []string) {
+	flags := flag.NewFlagSet(string(c), flag.ExitOnError)
+	noFollowFl := flags.Bool(noFollowFlagName, false, "do not follow symlinks")
+	flags.Parse(args) //nolint:errcheck // errors are handled by ExitOnError
+
+	if flags.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <permissions in octal>")
+		fmt.Fprintln(os.Stderr, "args:", args)
+		exit(1)
+		return
+	}
+
+	p := flags.Arg(0)
+	perms, err := strconv.ParseUint(flags.Arg(1), 8, 32)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error parsing perms:", err)
+		exit(1)
+	}
+
+	fi := mustFileInfo(p, *noFollowFl)
+	expected := fs.FileMode(perms)
+	actual := fi.Mode().Perm()
+
+	if actual == expected {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     p,
+		Kind:     c.Kind(),
+		Expected: expected.String(),
+		Actual:   actual.String(),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(2)
+}

--- a/internal/testrunner/file_perms_test.go
+++ b/internal/testrunner/file_perms_test.go
@@ -1,0 +1,77 @@
+package testrunner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFilePermsCommand(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "script.sh")
+	assert.NilError(t, os.WriteFile(file, []byte("#!/bin/true"), 0o700))
+	assert.NilError(t, os.Chmod(file, 0o764))
+
+	t.Run("expected perms", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFilePerms.Cmd, file, "764")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("wrong perms", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFilePerms.Cmd, file, "644")
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"-rw-r--r--\""))
+	})
+
+	t.Run("symlink respects follow flag", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		assert.NilError(t, os.WriteFile(target, []byte("data"), 0o600))
+		link := filepath.Join(dir, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skip("symlinks unsupported:", err)
+		}
+
+		code, stderr := runCommand(t, checkFilePerms.Cmd, link, "600")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+
+		code, stderr = runCommand(t, checkFilePerms.Cmd, "--"+noFollowFlagName+"=true", link, "600")
+		assert.Check(t, cmp.Equal(code, 2))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"-rw-------\""))
+		gotSymlinkMode := strings.Contains(stderr, "got \"Lrwxrwxrwx\"") || strings.Contains(stderr, "got \"-rwxrwxrwx\"")
+		assert.Check(t, gotSymlinkMode, "stderr did not report symlink mode: %s", stderr)
+	})
+}
+
+func TestCheckFilePermsWithCheckLLB(t *testing.T) {
+	t.Run("runs when permissions set", func(t *testing.T) {
+		checker := fileCheckFromYAML(t, "permissions: 0o754\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFilePerms.WithCheck("/bin/tool", checker, withTestFrontend())))
+		expect := []string{
+			frontendMountPath,
+			testRunnerCmdName,
+			string(checkFilePerms),
+			"--" + noFollowFlagName + "=false",
+			"/bin/tool",
+			fmt.Sprintf("%o", checker.Permissions.Perm()),
+		}
+		assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+	})
+
+	t.Run("no follow flag", func(t *testing.T) {
+		checker := fileCheckFromYAML(t, "permissions: 0o644\nno_follow: true\n")
+		exec := singleExecOp(t, definitionFromStateOption(t, checkFilePerms.WithCheck("/bin/tool", checker, withTestFrontend())))
+		assert.Check(t, cmp.DeepEqual(exec.GetMeta().GetArgs()[3:6], []string{"--" + noFollowFlagName + "=true", "/bin/tool", fmt.Sprintf("%o", checker.Permissions.Perm())}))
+	})
+
+	t.Run("skip when permissions unset", func(t *testing.T) {
+		execs := execsFromDefinition(t, definitionFromStateOption(t, checkFilePerms.WithCheck("/bin/tool", fileCheckFromYAML(t, "{}"), withTestFrontend())))
+		assert.Check(t, cmp.Len(execs, 0))
+	})
+}

--- a/internal/testrunner/file_startswith.go
+++ b/internal/testrunner/file_startswith.go
@@ -1,0 +1,70 @@
+package testrunner
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+const checkFileStartsWith = checkFileStartsWithCommand("check-file-starts-with")
+
+type checkFileStartsWithCommand string
+
+func (c checkFileStartsWithCommand) WithCheck(p string, checker *dalec.CheckOutput, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if checker.StartsWith == "" {
+			return in
+		}
+
+		args := []string{
+			string(c),
+			p,
+			checker.StartsWith,
+		}
+		opts = append(opts, c.location(in, checker))
+		return in.With(doValidate(args, opts...))
+	}
+}
+
+func (c checkFileStartsWithCommand) Kind() string {
+	return dalec.CheckOutputStartsWithKind
+}
+
+func (c checkFileStartsWithCommand) location(st llb.State, checker *dalec.CheckOutput) ValidationOpt {
+	return func(info *ValidationInfo) {
+		info.Constraints = append(info.Constraints, checker.GetSourceLocation(st, c.Kind(), 0))
+	}
+}
+
+func (c checkFileStartsWithCommand) Cmd(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "expected 2 arguments: <file-path> <starts-with-string>")
+		exit(1)
+	}
+
+	p := args[0]
+	f, err := mmapFile(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(2)
+	}
+	defer f.Close()
+
+	dt := f.Bytes()
+	startsWith := args[1]
+	if bytes.HasPrefix(dt, []byte(startsWith)) {
+		return
+	}
+
+	err = &dalec.CheckOutputError{
+		Path:     filterPath(p),
+		Kind:     c.Kind(),
+		Expected: startsWith,
+		Actual:   previewString(dt),
+	}
+	fmt.Fprintln(os.Stderr, err)
+	exit(3)
+}

--- a/internal/testrunner/file_startswith_test.go
+++ b/internal/testrunner/file_startswith_test.go
@@ -1,0 +1,34 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckFileStartsWithCommand(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "log.txt")
+	assert.NilError(t, os.WriteFile(file, []byte("prefix-data"), 0o600))
+
+	t.Run("matches prefix", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileStartsWith.Cmd, file, "prefix")
+		assert.Check(t, cmp.Equal(code, 0))
+		assert.Check(t, cmp.Equal(stderr, ""))
+	})
+
+	t.Run("prefix mismatch", func(t *testing.T) {
+		code, stderr := runCommand(t, checkFileStartsWith.Cmd, file, "wrong")
+		assert.Check(t, cmp.Equal(code, 3))
+		assert.Check(t, cmp.Contains(stderr, "expected: \"wrong\""))
+	})
+}
+
+func TestCheckFileStartsWithWithCheckLLB(t *testing.T) {
+	checker := checkOutputFromYAML(t, "starts_with: hello\n")
+	exec := singleExecOp(t, definitionFromStateOption(t, checkFileStartsWith.WithCheck("/tmp/out", checker, withTestFrontend())))
+	expect := []string{frontendMountPath, testRunnerCmdName, string(checkFileStartsWith), "/tmp/out", "hello"}
+	assert.Check(t, cmp.DeepEqual(expect, exec.GetMeta().GetArgs()))
+}

--- a/internal/testrunner/files.go
+++ b/internal/testrunner/files.go
@@ -1,205 +1,30 @@
 package testrunner
 
 import (
-	"encoding/json"
-	"flag"
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/moby/buildkit/client/llb"
-	"github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
 )
 
-const CheckFilesCmdName = "test-checkfiles"
-
-// CheckFilesCmd is the entrypoint for the file checking subcommand.
-// It reads the file checks from the provided file path (first argument)
-// and executes them, writing output to os.Stdout and os.Stderr.
-//
-// This should only be called from inside a container where the test is meant to run.
-func CheckFilesCmd(args []string) {
-	var files map[string]dalec.FileCheckOutput
-
-	flags := flag.NewFlagSet(CheckFilesCmdName, flag.ExitOnError)
-
-	var outputPath string
-	flags.StringVar(&outputPath, "output", "", "Path to write test results to")
-
-	if err := flags.Parse(args); err != nil {
-		fmt.Fprintln(os.Stderr, "error parsing flags:", err)
-		os.Exit(1)
+func withFileChecks(test *dalec.TestSpec, opts ...ValidationOpt) llb.StateOption {
+	if len(test.Files) == 0 {
+		return dalec.NoopStateOption
 	}
 
-	if outputPath == "" {
-		fmt.Fprintln(os.Stderr, "error: output path is required")
-		os.Exit(1)
+	outs := make([]llb.StateOption, 0, len(test.Files))
+	for file, check := range test.Files {
+		outs = append(outs, withFileCheck(file, &check, opts...)...)
 	}
-
-	dt, err := os.ReadFile(flags.Arg(0))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error reading file checks:", err)
-		os.Exit(1)
-	}
-
-	if err := json.Unmarshal(dt, &files); err != nil {
-		fmt.Fprintln(os.Stderr, "error unmarshalling file checks:", err)
-		os.Exit(1)
-	}
-
-	results := checkFiles(files)
-	if len(results) == 0 {
-		return
-	}
-
-	dt, err = json.Marshal(results)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error marshaling results:", err)
-		os.Exit(2)
-	}
-
-	if err := writeFileAppend(outputPath, dt, 0o600); err != nil {
-		fmt.Fprintln(os.Stderr, "error writing results:", err)
-		os.Exit(2)
-	}
+	return mergeStateOptions(outs, opts...)
 }
 
-func writeFileAppend(path string, data []byte, mode os.FileMode) error {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, mode)
-	if err != nil {
-		return errors.Wrapf(err, "opening file %s", path)
-	}
-	defer f.Close()
-	if _, err := f.Write(data); err != nil {
-		return errors.Wrapf(err, "writing file %s", path)
-	}
-	return nil
-}
+func withFileCheck(file string, check *dalec.FileCheckOutput, opts ...ValidationOpt) []llb.StateOption {
+	var outs []llb.StateOption
 
-type FileCheckErrResult struct {
-	Filename  string
-	StepIndex *int
-	Checks    []*dalec.CheckOutputError
-}
+	outs = append(outs, checkFileNotExists.WithCheck(file, check, opts...))
+	outs = append(outs, checkFileIsDir.WithCheck(file, check, opts...))
+	outs = append(outs, checkFilePerms.WithCheck(file, check, opts...))
+	outs = append(outs, checkFileLinkTarget.WithCheck(file, check, opts...))
+	outs = append(outs, withCheckOutput(file, &check.CheckOutput, opts...)...)
 
-func checkFiles(files map[string]dalec.FileCheckOutput) []FileCheckErrResult {
-	var results []FileCheckErrResult
-	for path, check := range files {
-		if err := checkFile(path, check); err != nil {
-			results = append(results, FileCheckErrResult{Filename: path, Checks: getFileCheckErrs(err)})
-		}
-	}
-	return results
-}
-
-func checkFile(p string, check dalec.FileCheckOutput) error {
-	var (
-		stat os.FileInfo
-		err  error
-	)
-
-	if check.NoFollow {
-		stat, err = os.Lstat(p)
-	} else {
-		stat, err = os.Stat(p)
-	}
-
-	if err != nil {
-		if os.IsNotExist(err) {
-			if check.NotExist {
-				return nil
-			}
-
-			return &dalec.CheckOutputError{
-				Kind:     dalec.CheckFileNotExistsKind,
-				Path:     p,
-				Expected: "exists=true",
-				Actual:   "exists=false",
-			}
-		}
-		return errors.Wrapf(err, "checking file %s", p)
-	}
-
-	var target string
-	if check.LinkTarget != "" {
-		target, err = os.Readlink(p)
-		if err != nil {
-			return errors.Wrapf(err, "reading symlink %s", p)
-		}
-	}
-
-	if check.NotExist {
-		return &dalec.CheckOutputError{
-			Kind:     dalec.CheckFileNotExistsKind,
-			Path:     p,
-			Expected: "exists=false",
-			Actual:   "exists=true",
-		}
-	}
-
-	var v string
-	if !stat.IsDir() && !check.IsEmpty() {
-		f, err := os.Open(p)
-		if err != nil {
-			return errors.Wrapf(err, "opening file %s", p)
-		}
-		defer f.Close()
-		dt, err := io.ReadAll(f)
-		if err != nil {
-			return errors.Wrapf(err, "reading file %s", p)
-		}
-		v = string(dt)
-	}
-
-	if err := check.Check(v, stat.Mode(), stat.IsDir(), p, target); err != nil {
-		return err
-	}
-	return nil
-}
-
-// WithFileChecks returns an llb.RunOption that checks the files specified in the test spec.
-func WithFileChecks(frontend llb.State, test *dalec.TestSpec, outputPath string) llb.RunOption {
-	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
-		llb.WithCustomNamef("Check files for test %q", test.Name).SetRunOption(ei)
-
-		dt, err := json.Marshal(test.Files)
-		if err != nil {
-			ei.State = dalec.ErrorState(ei.State, fmt.Errorf("failed to marshal file checks for test %q: %w", test.Name, err))
-			llb.Args([]string{"false"}).SetRunOption(ei)
-			return
-		}
-
-		const checkFilesPath = "/tmp/dalec/internal/frontend/test/check_files"
-		llb.AddMount(checkFilesPath, frontend, llb.SourcePath("/frontend")).SetRunOption(ei)
-		st := llb.Scratch().File(llb.Mkfile("files.json", 0o600, dt))
-
-		const fileChecksPath = "/tmp/dalec/internal/frontend/test/files.json"
-		llb.AddMount(fileChecksPath, st, llb.SourcePath("files.json")).SetRunOption(ei)
-		llb.Args([]string{checkFilesPath, CheckFilesCmdName, "--output", outputPath, fileChecksPath, test.Name}).SetRunOption(ei)
-	})
-}
-
-func getFileCheckErrs(err error) []*dalec.CheckOutputError {
-	if wrapped, ok := err.(interface{ Unwrap() []error }); ok {
-		var errs []*dalec.CheckOutputError
-		for _, e := range wrapped.Unwrap() {
-			errs = append(errs, getFileCheckErrs(e)...)
-		}
-		return errs
-	}
-
-	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
-		return getFileCheckErrs(wrapped.Unwrap())
-	}
-
-	var ce *dalec.CheckOutputError
-	ok := errors.As(err, &ce)
-	if !ok {
-		ce = &dalec.CheckOutputError{
-			Kind:   "unknown",
-			Actual: err.Error(),
-		}
-	}
-	return []*dalec.CheckOutputError{ce}
+	return outs
 }

--- a/internal/testrunner/llb_test_helpers_test.go
+++ b/internal/testrunner/llb_test_helpers_test.go
@@ -1,0 +1,91 @@
+package testrunner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/gogo/protobuf/proto"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+const (
+	frontendMountPath      = "/tmp/internal/dalec/testrunner/frontend"
+	internalStateMountPath = "/tmp/internal/dalec/testrunner/__internal_state"
+)
+
+func withTestFrontend() ValidationOpt {
+	frontend := llb.Scratch().File(llb.Mkfile("frontend", 0o600, []byte("binary")))
+	return func(vi *ValidationInfo) {
+		st := frontend
+		vi.Frontend = &st
+	}
+}
+
+func definitionFromStateOption(t *testing.T, opt llb.StateOption) *llb.Definition {
+	t.Helper()
+	if opt == nil {
+		t.Fatalf("state option must not be nil")
+	}
+	state := llb.Scratch().With(opt)
+	def, err := state.Marshal(context.Background())
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	return def
+}
+
+func checkOutputFromYAML(t *testing.T, body string) *dalec.CheckOutput {
+	t.Helper()
+	var out dalec.CheckOutput
+	if err := yaml.UnmarshalContext(context.Background(), []byte(body), &out); err != nil {
+		t.Fatalf("unmarshal check output: %v", err)
+	}
+	return &out
+}
+
+func fileCheckFromYAML(t *testing.T, body string) *dalec.FileCheckOutput {
+	t.Helper()
+	var out dalec.FileCheckOutput
+	if err := yaml.UnmarshalContext(context.Background(), []byte(body), &out); err != nil {
+		t.Fatalf("unmarshal file check output: %v", err)
+	}
+	return &out
+}
+
+func singleExecOp(t *testing.T, def *llb.Definition) *pb.ExecOp {
+	t.Helper()
+	execs := execsFromDefinition(t, def)
+	if len(execs) != 1 {
+		t.Fatalf("expected 1 exec op, got %d", len(execs))
+	}
+	return execs[0]
+}
+
+func execsFromDefinition(t *testing.T, def *llb.Definition) []*pb.ExecOp {
+	t.Helper()
+	pbDef := def.ToPB()
+	execs := make([]*pb.ExecOp, 0, len(pbDef.Def))
+	for _, dt := range pbDef.Def {
+		var op pb.Op
+		err := proto.Unmarshal(dt, &op)
+		assert.NilError(t, err)
+		if exec := op.GetExec(); exec != nil {
+			execs = append(execs, exec)
+		}
+	}
+	return execs
+}
+
+func requireMountDest(t *testing.T, mounts []*pb.Mount, dest string) {
+	t.Helper()
+	for _, m := range mounts {
+		if m.GetDest() == dest {
+			return
+		}
+	}
+	t.Fatalf("expected mount with dest %q, got %v", dest, mounts)
+}

--- a/internal/testrunner/mmap_stub.go
+++ b/internal/testrunner/mmap_stub.go
@@ -1,0 +1,37 @@
+//go:build !unix
+
+package testrunner
+
+import (
+	"io"
+	"os"
+)
+
+// mmapBuffer is a simple file-backed buffer used on non-Unix systems.
+type mmapBuffer struct {
+	f  *os.File
+	dt []byte
+}
+
+func (mf *mmapBuffer) Close() {
+	_ = mf.f.Close()
+}
+
+func mmapFile(path string) (*mmapBuffer, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	dt, err := io.ReadAll(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	return &mmapBuffer{f: f, dt: dt}, nil
+}
+
+func (mf *mmapBuffer) Bytes() []byte {
+	return mf.dt
+}

--- a/internal/testrunner/mmap_unix.go
+++ b/internal/testrunner/mmap_unix.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package testrunner
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// mmapBuffer represents a memory-mapped file on Unix systems.
+type mmapBuffer struct {
+	f  *os.File
+	dt []byte
+}
+
+func (mf *mmapBuffer) Close() {
+	if mf.dt != nil {
+		munmap(mf.dt)
+	}
+	_ = mf.f.Close()
+}
+
+func mmapFile(path string) (*mmapBuffer, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	mf := &mmapBuffer{f: f}
+	size := stat.Size()
+	if size == 0 {
+		mf.dt = []byte{}
+		return mf, nil
+	}
+
+	dt, err := mmap(mf.f.Fd(), size)
+	if err != nil {
+		_ = mf.f.Close()
+		return nil, err
+	}
+
+	mf.dt = dt
+	return mf, nil
+}
+
+func (mf *mmapBuffer) Bytes() []byte {
+	return mf.dt
+}
+
+func mmap(fd uintptr, size int64) ([]byte, error) {
+	for {
+		dt, err := unix.Mmap(int(fd), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+		if err == unix.EINTR {
+			continue
+		}
+		return dt, err
+	}
+}
+
+func munmap(dt []byte) {
+	for {
+		err := unix.Munmap(dt)
+		if err == unix.EINTR {
+			continue
+		}
+		// Any other error is ignored since there is nothing we can do about it.
+		return
+	}
+}

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -1,0 +1,271 @@
+package testrunner
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/internal/commands"
+	"github.com/project-dalec/dalec/internal/plugins"
+)
+
+func init() {
+	var runner Runner
+	commands.RegisterPlugin(testRunnerCmdName, plugins.CmdHandlerFunc(runner.Cmd))
+}
+
+const testRunnerCmdName = "test-runner"
+
+type Runner struct{}
+
+func (tr *Runner) Cmd(ctx context.Context, args []string) {
+	flags := flag.NewFlagSet(testRunnerCmdName, flag.ExitOnError)
+	flags.Parse(args) //nolint:errcheck // errors are handled by ExitOnError
+
+	if flags.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "no test-runner command provided")
+		exit(1)
+	}
+
+	cmd := flags.Arg(0)
+	args = flags.Args()[1:]
+	switch cmd {
+	case string(checkFilePerms):
+		checkFilePerms.Cmd(args)
+	case string(checkFileNotExists):
+		checkFileNotExists.Cmd(args)
+	case string(checkFileContains):
+		checkFileContains.Cmd(args)
+	case string(checkFileEmpty):
+		checkFileEmpty.Cmd(args)
+	case string(checkFileStartsWith):
+		checkFileStartsWith.Cmd(args)
+	case string(checkFileEndsWith):
+		checkFileEndsWith.Cmd(args)
+	case string(checkFileMatches):
+		checkFileMatches.Cmd(args)
+	case string(checkFileEquals):
+		checkFileEquals.Cmd(args)
+	case string(checkFileIsDir):
+		checkFileIsDir.Cmd(args)
+	case string(checkFileLinkTarget):
+		checkFileLinkTarget.Cmd(args)
+	case string(stepRunner):
+		stepRunner.Cmd(ctx, args)
+	case string(trueCmd):
+		trueCmd.Cmd(args)
+	default:
+		fmt.Fprintln(os.Stderr, testRunnerCmdName+":", "Unknown command:", cmd)
+		exit(70) // 70 is EX_SOFTWARE, meaning internal software error occurred
+	}
+}
+
+func doValidate(args []string, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		const (
+			internalStatePath = "/tmp/internal/dalec/testrunner/__internal_state"
+		)
+
+		return in.Run(
+			testRunner(args, opts...),
+			llb.ReadonlyRootFS(),
+			llb.WithCustomName(strings.Join(args, " ")),
+		).AddMount(internalStatePath, in)
+	}
+}
+
+func testRunner(args []string, opts ...ValidationOpt) llb.RunOption {
+	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+		const p = "/tmp/internal/dalec/testrunner/frontend"
+
+		args = append([]string{p, testRunnerCmdName}, args...)
+		llb.Args(args).SetRunOption(ei)
+
+		info := validationOpts(opts...)
+		llb.AddMount(p, *info.Frontend, llb.Readonly, llb.SourcePath("/frontend")).SetRunOption(ei)
+		info.SetRunOption(ei)
+	})
+}
+
+type ValidationOpt func(*ValidationInfo)
+
+type ValidationInfo struct {
+	Frontend    *llb.State
+	Constraints []llb.ConstraintsOpt
+	ExtraOpts   []llb.RunOption
+}
+
+func validationOptsFromTest(t *dalec.TestSpec, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) ValidationOpt {
+	return func(i *ValidationInfo) {
+		for k, v := range t.Env {
+			i.ExtraOpts = append(i.ExtraOpts, llb.AddEnv(k, v))
+		}
+
+		for _, mnt := range t.Mounts {
+			i.ExtraOpts = append(i.ExtraOpts, mnt.ToRunOption(sOpt, dalec.WithConstraints(opts...)))
+		}
+	}
+}
+
+func ValidateWithMount(sOpt dalec.SourceOpts, mnt dalec.SourceMount, opts ...llb.ConstraintsOpt) ValidationOpt {
+	return func(i *ValidationInfo) {
+		i.ExtraOpts = append(i.ExtraOpts, mnt.ToRunOption(sOpt, dalec.WithConstraints(opts...)))
+	}
+}
+
+func (i *ValidationInfo) SetRunOption(ei *llb.ExecInfo) {
+	c := ei.Constraints
+	i.SetConstraintsOption(&c)
+	ei.Constraints = c
+
+	for _, opt := range i.ExtraOpts {
+		opt.SetRunOption(ei)
+	}
+}
+
+func (i *ValidationInfo) SetConstraintsOption(c *llb.Constraints) {
+	for _, opt := range i.Constraints {
+		opt.SetConstraintsOption(c)
+	}
+}
+
+func WithConstraints(opts ...llb.ConstraintsOpt) ValidationOpt {
+	return func(vi *ValidationInfo) {
+		vi.Constraints = append(vi.Constraints, opts...)
+	}
+}
+
+func validationOpts(opts ...ValidationOpt) ValidationInfo {
+	var i ValidationInfo
+	for _, o := range opts {
+		o(&i)
+	}
+
+	if i.Frontend == nil {
+		panic("missing frontend state in validation opt")
+	}
+
+	return i
+}
+
+func asConstraints(opts ...ValidationOpt) llb.ConstraintsOpt {
+	return dalec.ConstraintsOptFunc(func(c *llb.Constraints) {
+		vi := validationOpts(opts...)
+		vi.SetConstraintsOption(c)
+	})
+}
+
+// mergeStateOptions merges multiple llb.StateOptions into a single llb.StateOption.
+//
+// Each option is applied independently to the same input state.
+// Conceptually:
+//
+//  1. Start from origState
+//  2. For each option:
+//     - create a temporary branch: diff(origState, stateN)
+//  3. Merge all resulting branches back together
+//
+// No option sees the effects of any other option.
+//
+// Example:
+//
+//	         input
+//	           |
+//	   +-------+-------+
+//	   |       |       |
+//	apply    apply   apply
+//	 opt1     opt2    opt3
+//	   |       |       |
+//	 diff1  diff2  diff3
+//	   |       |       |
+//	   +-------+-------+
+//	           |
+//	merge(input, diff1, diff2, diff3)
+//	           |
+//	         output
+//
+// All intermediate states (state1, state2, state3) are direct descendants
+// of origState.
+//
+// If you expect options to apply sequentially
+// (origState -> state1 -> state2 -> state3),
+// This is NOT the function you want.
+func mergeStateOptions(stateOpts []llb.StateOption, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if len(stateOpts) == 0 {
+			return in
+		}
+
+		if len(stateOpts) == 1 {
+			// Avoid diff/merge overhead for single state option
+			return in.With(stateOpts[0])
+		}
+
+		states := make([]llb.State, 0, len(opts))
+		states = append(states, in)
+		for _, o := range stateOpts {
+			states = append(states, in.With(o))
+		}
+
+		return dalec.MergeAtPath(in, states, "/", asConstraints(opts...))
+	}
+}
+
+func filterPath(p string) string {
+	if strings.HasPrefix(p, "/tmp/internal/dalec") {
+		return filepath.Base(p)
+	}
+	return p
+}
+
+// WithFinalState returns a state option which takes as input a potentially modified
+// state and returns the original unmodified state.
+// This makes sure that any changes made during test steps are discarded but makes sure
+// there is a dependency on the intermediate state so buildkit will execute it.
+//
+// NOTE: This is a hack to work around the fact that buildkit does not currently
+// have a proper way to express "run this for validation only".
+func WithFinalState(st llb.State, opts ...ValidationOpt) llb.StateOption {
+	return trueCmd.WithOutput(st, opts...)
+}
+
+func withCheckOutput(filename string, checker *dalec.CheckOutput, opts ...ValidationOpt) []llb.StateOption {
+	if checker.IsEmpty() {
+		return nil
+	}
+
+	var outs []llb.StateOption
+
+	outs = append(outs, checkFileEmpty.WithCheck(filename, checker, opts...))
+	outs = append(outs, checkFileEquals.WithCheck(filename, checker, opts...))
+	outs = append(outs, checkFileContains.WithCheck(filename, checker, opts...)...)
+	outs = append(outs, checkFileMatches.WithCheck(filename, checker, opts...)...)
+	outs = append(outs, checkFileStartsWith.WithCheck(filename, checker, opts...))
+	outs = append(outs, checkFileEndsWith.WithCheck(filename, checker, opts...))
+
+	return outs
+}
+
+func previewString(dt []byte) string {
+	if bytes.Contains(dt, []byte{'\x00'}) {
+		// Don't try to print binary data.
+		// The null byte check is a simple heuristic for binary data.
+		// It's not perfect, but good enough for our use case.
+		return "<binary data>"
+	}
+
+	// dt could be large (especially since these are all mmaped files that get passed in).
+	// we don't want to pass this through entirely.
+	const maxPreview = 1024
+	if len(dt) > maxPreview {
+		return string(dt[:maxPreview]) + "<...truncated to 1024 bytes out of " + strconv.Itoa(len(dt)) + " bytes>"
+	}
+	return string(dt)
+}

--- a/internal/testrunner/step.go
+++ b/internal/testrunner/step.go
@@ -1,137 +1,142 @@
 package testrunner
 
 import (
-	"bytes"
 	"context"
+	_ "crypto/sha256"
 	"encoding/json"
-	"flag"
+	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"os"
 	"os/exec"
-	"strconv"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/shlex"
 	"github.com/moby/buildkit/client/llb"
-	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
-	"github.com/moby/buildkit/util/appcontext"
-	"github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
 )
 
 const (
-	StepRunnerCmdName = "test-steprunner"
-	testRunnerPath    = "/tmp/dalec/internal/frontend/test-runner"
-	testStepPath      = "/tmp/dalec/internal/frontend/test/step.json"
+	trueCmd    = noopCommand("true")
+	stepRunner = stepRunnerCommand("step-runner")
 )
 
-// StepCmd is the entrypoint for the test step runner subcommand.
-// It reads the test step from the provided file path (first argument)
-// and executes it, writing output to os.Stdout and os.Stderr.
-//
-// This should only be called from inside a container where the test is meant to run.
-func StepCmd(args []string) {
-	ctx := appcontext.Context()
+type noopCommand string
 
-	flags := flag.NewFlagSet(StepRunnerCmdName, flag.ExitOnError)
-	var outputPath string
-	flags.StringVar(&outputPath, "output", "", "Path to write test results to")
+func (c noopCommand) Cmd(args []string) {}
 
-	var stepIndex int
-	flags.IntVar(&stepIndex, "step-index", -1, "Index of the step being run")
+// WithOutput runs a no-op command that produces the provided output state.
+// This is useful for creating a dependency between the StateOption's input
+// state and the provided output state.
+func (c noopCommand) WithOutput(out llb.State, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		const outputPath = "/tmp/internal/dalec/testrunner/__internal_output__"
+		args := []string{string(c)}
 
-	if err := flags.Parse(args); err != nil {
-		fmt.Fprintln(os.Stderr, "error parsing flags:", err)
-		os.Exit(1)
+		// Ideally we would use llb.Readonly here.
+		// However, buildkit optmizes out the case since the returned state
+		// cannot be modified by the run.
+		// The run ends up not executing.
+		return in.Run(
+			testRunner(args, opts...),
+			llb.ReadonlyRootFS(),
+		).AddMount(outputPath, out)
+	}
+}
+
+type stepRunnerCommand string
+
+func (c stepRunnerCommand) stepJSONPath() string {
+	const p = "/tmp/internal/dalec/testrunner/step/step.json"
+	return p
+}
+
+func (c stepRunnerCommand) outputPath() string {
+	const p = "/tmp/internal/dalec/testrunner/step/output"
+	return p
+}
+
+func (c stepRunnerCommand) Run(test *dalec.TestSpec, sOpt dalec.SourceOpts, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		out := in
+
+		// Steps run sequentially, each step depending on the previous one.
+		for _, step := range test.Steps {
+			out = out.With(c.withTestStep(step, opts...))
+		}
+
+		return out
+	}
+}
+
+func (c stepRunnerCommand) withTestStep(step dalec.TestStep, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		dt, err := json.Marshal(step)
+		if err != nil {
+			return dalec.ErrorState(in, fmt.Errorf("could not marshal test step %q: %w", step.Command, err))
+		}
+
+		st := llb.Scratch().File(llb.Mkfile("step.json", 0o600, dt), asConstraints(opts...))
+
+		args := []string{
+			string(c),
+		}
+
+		out := in.Run(
+			llb.AddMount(c.stepJSONPath(), st, llb.SourcePath("step.json")),
+			testRunner(args, opts...),
+			step.GetSourceLocation(in),
+			llb.WithCustomName(step.Command),
+		).Root()
+
+		// Do any stdout/stderr checks
+		var stateOpts []llb.StateOption
+
+		stateOpts = append(stateOpts, withCheckOutput(filepath.Join(c.outputPath(), "stdout"), &step.Stdout, opts...)...)
+		stateOpts = append(stateOpts, withCheckOutput(filepath.Join(c.outputPath(), "stderr"), &step.Stderr, opts...)...)
+
+		return out.With(mergeStateOptions(stateOpts, opts...))
+	}
+}
+
+func (c stepRunnerCommand) Cmd(ctx context.Context, args []string) {
+	if len(args) != 0 {
+		fmt.Fprintln(os.Stderr, "usage: "+string(c))
+		exit(1)
 	}
 
-	if stepIndex < 0 {
-		fmt.Fprintln(os.Stderr, "--step-index is required")
-		os.Exit(1)
-	}
-
-	dt, err := os.ReadFile(flags.Arg(0))
+	dt, err := os.ReadFile(c.stepJSONPath())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error reading test step:", err)
-		return
+		exit(1)
 	}
 
 	var step dalec.TestStep
 	if err := json.Unmarshal(dt, &step); err != nil {
 		fmt.Fprintln(os.Stderr, "error unmarshalling test step:", err)
-		return
+		exit(1)
 	}
 
-	results, err := runStep(ctx, &step, os.Stdout, os.Stderr, stepIndex)
+	err = c.doStep(ctx, &step, os.Stdout, os.Stderr, c.outputPath())
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
+			exit(exitErr.ExitCode())
 		}
 		fmt.Fprintln(os.Stderr, "error running test step:", err)
-		os.Exit(2)
-	}
-
-	dt, err = json.Marshal(results)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error marshalling results:", err)
-		os.Exit(2)
-	}
-
-	if err := writeFileAppend(outputPath, dt, 0o600); err != nil {
-		fmt.Fprintln(os.Stderr, "error writing test results:", err)
-		os.Exit(2)
+		exit(2)
 	}
 }
 
-// WithRunStep returns an llb.RunOption that executes the provided test step.
-func WithTestStep(frontend llb.State, step *dalec.TestStep, index int, outputPath string) llb.RunOption {
-	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
-		llb.WithCustomName(step.Command).SetRunOption(ei)
-
-		dt, err := json.Marshal(step)
-		if err != nil {
-			ei.State = dalec.ErrorState(ei.State, fmt.Errorf("failed to marshal test step %q: %w", step.Command, err))
-			llb.Args([]string{"false"}).SetRunOption(ei)
-			return
-		}
-
-		for k, v := range step.Env {
-			ei.State = ei.State.AddEnv(k, v)
-		}
-
-		llb.AddMount(testRunnerPath, frontend, llb.SourcePath("/frontend")).SetRunOption(ei)
-
-		st := llb.Scratch().File(llb.Mkfile("step.json", 0o600, dt))
-		llb.AddMount(testStepPath, st, llb.SourcePath("step.json")).SetRunOption(ei)
-		llb.Args([]string{testRunnerPath, StepRunnerCmdName, "--output", outputPath, "--step-index", strconv.Itoa(index), testStepPath}).SetRunOption(ei)
-	})
-}
-
-// FilterStepError removes extraneous/internal context from errors caused by
-// a test step command returning a non-zero exit code.
-func FilterStepError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var exErr *moby_buildkit_v1_frontend.ExitError
-	if !errors.As(err, &exErr) {
-		return err
-	}
-	return &stepCmdError{err: exErr}
-}
-
-// runStep executes the provided test step.
+// doStep executes the provided test step.
 // This should only be called from inside a container where the test is meant to run.
 //
 // Provide the desired stdout and stderr writers to capture output.
-func runStep(ctx context.Context, step *dalec.TestStep, stdout, stderr io.Writer, stepIndex int) ([]FileCheckErrResult, error) {
+func (stepRunnerCommand) doStep(ctx context.Context, step *dalec.TestStep, stdout, stderr io.Writer, outputPath string) error {
 	args, err := shlex.Split(step.Command)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
@@ -142,75 +147,33 @@ func runStep(ctx context.Context, step *dalec.TestStep, stdout, stderr io.Writer
 		cmd.Stdin = strings.NewReader(step.Stdin)
 	}
 
-	type check struct {
-		buf     fmt.Stringer
-		checker dalec.CheckOutput
-		name    string
-	}
-
-	var checks []check
-
 	if !step.Stdout.IsEmpty() {
-		buf := bytes.NewBuffer(nil)
-		var w io.Writer = buf
-		if cmd.Stdout != nil {
-			w = io.MultiWriter(cmd.Stdout, buf)
+		if err := os.MkdirAll(outputPath, 0o700); err != nil {
+			return err
 		}
-		cmd.Stdout = w
-		checks = append(checks, check{buf, step.Stdout, "stdout"})
+		f, err := os.OpenFile(filepath.Join(outputPath, "stdout"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, f)
 	}
 
 	if !step.Stderr.IsEmpty() {
-		buf := bytes.NewBuffer(nil)
-		var w io.Writer = buf
-		if cmd.Stderr != nil {
-			w = io.MultiWriter(cmd.Stderr, buf)
+		if err := os.MkdirAll(outputPath, 0o700); err != nil {
+			return err
 		}
-		cmd.Stderr = w
-		checks = append(checks, check{buf, step.Stderr, "stderr"})
+		f, err := os.OpenFile(filepath.Join(outputPath, "stderr"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, f)
 	}
+
 	if err := cmd.Run(); err != nil {
-		return nil, err
+		return err
 	}
 
-	var results []FileCheckErrResult
-	for _, c := range checks {
-		if err := c.checker.Check(c.buf.String(), c.name); err != nil {
-			results = append(results, FileCheckErrResult{Filename: c.name, StepIndex: &stepIndex, Checks: getFileCheckErrs(err)})
-		}
-	}
-	return results, nil
-}
-
-type stepCmdError struct {
-	err *moby_buildkit_v1_frontend.ExitError
-}
-
-func (s *stepCmdError) Error() string {
-	return fmt.Sprintf("step did not complete successfully: exit code: %d", s.err.ExitCode)
-}
-
-func (s *stepCmdError) Unwrap() error {
-	return s.err
-}
-
-func DecodeResults(r io.Reader) iter.Seq2[*FileCheckErrResult, error] {
-	return func(yield func(*FileCheckErrResult, error) bool) {
-		dec := json.NewDecoder(r)
-		var results []FileCheckErrResult
-
-		for {
-			err := dec.Decode(&results)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			for _, r := range results {
-				if !yield(&r, nil) {
-					return
-				}
-			}
-		}
-	}
+	return nil
 }

--- a/internal/testrunner/test_helpers_test.go
+++ b/internal/testrunner/test_helpers_test.go
@@ -1,0 +1,55 @@
+package testrunner
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+type exitPanic struct {
+	code int
+}
+
+// runCommand executes a command function while capturing its exit code and stderr output.
+// Commands invoke exit() directly, so tests override it to panic with the exit code instead.
+func runCommand(t *testing.T, cmd func([]string), args ...string) (int, string) {
+	t.Helper()
+
+	oldExit := exit
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stderr pipe: %v", err)
+	}
+	exit = func(code int) { panic(exitPanic{code: code}) }
+	os.Stderr = w
+
+	var recovered interface{}
+	func() {
+		defer func() { recovered = recover() }()
+		cmd(args)
+	}()
+
+	if err := w.Close(); err != nil {
+		// Close errors would interfere with the capture and should fail the test.
+		t.Fatalf("closing stderr writer: %v", err)
+	}
+	stderr, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr output: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing stderr reader: %v", err)
+	}
+	os.Stderr = oldStderr
+	exit = oldExit
+
+	if recovered != nil {
+		if ex, ok := recovered.(exitPanic); ok {
+			return ex.code, string(stderr)
+		}
+		panic(recovered)
+	}
+
+	return 0, string(stderr)
+}

--- a/internal/testrunner/tests.go
+++ b/internal/testrunner/tests.go
@@ -1,0 +1,37 @@
+package testrunner
+
+import (
+	"path"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+func WithTests(target string, sOpt dalec.SourceOpts, deps llb.StateOption, tests []*dalec.TestSpec, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		if len(tests) == 0 {
+			return in
+		}
+
+		outs := make([]llb.StateOption, 0, len(tests))
+		for _, test := range tests {
+			outs = append(outs, withTest(target, sOpt, test, opts...))
+		}
+
+		out := in.With(deps).With(mergeStateOptions(outs, opts...))
+		return out.With(WithFinalState(in, opts...))
+	}
+}
+
+func withTest(target string, sOpt dalec.SourceOpts, test *dalec.TestSpec, opts ...ValidationOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
+		opts := append(opts, WithConstraints(dalec.ProgressGroup("Test: "+path.Join(target, test.Name))))
+		opts = append(opts, validationOptsFromTest(test, sOpt))
+
+		runSteps := stepRunner.Run(test, sOpt, opts...)
+		fileChecks := withFileChecks(test, opts...)
+		out := in.With(runSteps).With(fileChecks)
+
+		return out.With(WithFinalState(in, opts...))
+	}
+}

--- a/sourcemap.go
+++ b/sourcemap.go
@@ -120,14 +120,25 @@ func (v *endPosVisitor) Visit(n ast.Node) ast.Visitor {
 
 	setEndChar := func(ns string) {
 		newlines := strings.Count(ns, "\n")
-		v.endLine += newlines - 1
 		if newlines == 0 {
 			v.endChar = pos.Column + len(ns)
 			return
 		}
 
+		// If the string ends with a newline, we want to end at the last character
+		// of the last line with content, not at character 1 of the next line
+		if strings.HasSuffix(ns, "\n") {
+			ns = strings.TrimSuffix(ns, "\n")
+			newlines--
+		}
+
+		v.endLine += newlines
 		last := strings.LastIndex(ns, "\n")
-		if last != -1 {
+		if last == -1 {
+			// Single line (or what's left after trimming trailing newline)
+			v.endChar = pos.Column + len(ns)
+		} else {
+			// Multiple lines - end character is the length of the last line
 			v.endChar = len(ns) - last
 		}
 	}

--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -37,8 +37,7 @@ func (d *Config) BuildPkg(ctx context.Context, client gwclient.Client, sOpt dale
 
 	worker = worker.With(d.InstallBuildDeps(ctx, sOpt, spec, targetKey, append(opts, frontend.IgnoreCache(client))...))
 
-	// Preprocess the spec to generate patches for gomod edits and other generators
-	// This must happen after build deps are installed so Go is available
+	// Preprocess after build deps are installed so generators can use build tools.
 	if err := spec.Preprocess(sOpt, worker, opts...); err != nil {
 		return dalec.ErrorState(worker, err)
 	}
@@ -178,11 +177,12 @@ func addPaths(paths []string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	}
 }
 
-func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, final llb.State, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	return func(in llb.State) llb.State {
-		deps := cfg.InstallTestDeps(sOpt, targetKey, spec, opts...)
-		tests := frontend.RunTests(ctx, client, spec, final, targetKey, sOpt.TargetPlatform)
-		return in.With(deps).With(tests)
+		opts = append(opts, frontend.IgnoreCache(client))
+		withTestDeps := cfg.InstallTestDeps(sOpt, targetKey, spec, opts...)
+		runTests := frontend.RunTests(ctx, client, sOpt, spec, withTestDeps, targetKey, opts...)
+		return in.With(runTests)
 	}
 }
 

--- a/targets/linux/distro_handler.go
+++ b/targets/linux/distro_handler.go
@@ -9,12 +9,12 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/frontend"
-
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec/internal/testrunner"
 )
 
 type DistroConfig interface {
@@ -49,8 +49,7 @@ type DistroConfig interface {
 
 	// RunTests runts the tests specified in a dalec spec against a built container, which may be the target container.
 	// Some distros may need to pass in a separate worker before mounting the target container.
-	RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, ctr llb.State,
-		targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption
+	RunTests(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, target string, opts ...llb.ConstraintsOpt) llb.StateOption
 }
 
 func BuildImageConfig(ctx context.Context, sOpt dalec.SourceOpts, spec *dalec.Spec, platform *ocispecs.Platform, targetKey string) (*dalec.DockerImageSpec, error) {
@@ -117,9 +116,24 @@ func HandleContainer(c DistroConfig) gwclient.BuildFunc {
 			}
 
 			ctr := c.BuildContainer(ctx, client, sOpt, spec, targetKey, pkgSt, opts...)
-			tests := c.RunTests(ctx, client, spec, sOpt, ctr, targetKey, opts...)
+			runTests := c.RunTests(ctx, client, sOpt, spec, targetKey, opts...)
 
-			ref, err := getRef(ctx, client, ctr.With(tests))
+			def, err := ctr.With(runTests).Marshal(ctx, opts...)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			res, err := client.Solve(ctx, gwclient.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				return nil, nil, err
+			}
 
 			return ref, img, err
 		})
@@ -175,11 +189,33 @@ func HandleSysext(c DistroConfig) gwclient.BuildFunc {
 				dalec.WithConstraints(opts...),
 			).AddMount("/output", llb.Scratch())
 
-			ctr := c.BuildContainer(ctx, client, sOpt, spec, targetKey, pkgSt, pc)
-			tests := c.RunTests(ctx, client, spec, sOpt, erofs, targetKey, pc)
+			// The input to the test runner needs to be the output of the container builder.
+			// In order to accomplish this while still outputing the sysext image, we need to
+			// create a dependency chain from tests back to erofs.
+			ctr := c.BuildContainer(ctx, client, sOpt, spec, targetKey, pkgSt, opts...)
+			withTests := c.RunTests(ctx, client, sOpt, spec, targetKey, opts...)
+			withFinalState := testrunner.WithFinalState(erofs, frontend.TestWithClientFrontend(client), testrunner.WithConstraints(opts...))
 
-			ref, err := getRef(ctx, client, ctr.With(tests))
-			return ref, &dalec.DockerImageSpec{Image: ocispecs.Image{Platform: *platform}}, err
+			erofs = ctr.With(withTests).With(withFinalState)
+
+			def, err := erofs.Marshal(ctx, opts...)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			res, err := client.Solve(ctx, gwclient.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				return nil, nil, err
+			}
+
+			return ref, &dalec.DockerImageSpec{Image: ocispecs.Image{Platform: *platform}}, nil
 		})
 	}
 }
@@ -187,7 +223,7 @@ func HandleSysext(c DistroConfig) gwclient.BuildFunc {
 // getPrebuiltPackage retrieves a package based on the target environment.
 // Target-specific packages (e.g., "{targetKey}-pkg") are prioritized over generic packages ("pkg").
 // This ensures compatibility with the build context and optimizes functionality for specific environments.
-// Examples of target keys include "azlinux3", "windowscross", and "bookworm".
+// Examples of target keys include "mariner2", "azlinux3", "windowscross", and "bookworm".
 func getPrebuiltPackage(ctx context.Context, targetKey string, client gwclient.Client, opts []llb.ConstraintsOpt, sOpt dalec.SourceOpts) (llb.State, bool) {
 	var pkgSt llb.State
 
@@ -237,34 +273,41 @@ func HandlePackage(cfg DistroConfig) gwclient.BuildFunc {
 			}
 
 			pc := dalec.Platform(platform)
+			opts := []llb.ConstraintsOpt{pg, pc}
 
-			pkgSt := cfg.BuildPkg(ctx, client, sOpt, spec, targetKey, pg, pc)
+			pkgSt := cfg.BuildPkg(ctx, client, sOpt, spec, targetKey, opts...)
 
-			ctr := cfg.BuildContainer(ctx, client, sOpt, spec, targetKey, pkgSt, pg, pc)
-			tests := cfg.RunTests(ctx, client, spec, sOpt, pkgSt, targetKey, pg, pc)
+			// The input to the test runner needs to be the output of the container builder.
+			// In order to accomplish this while still outputing the package, we need to
+			// create a dependency chain from tests back to pkgSt.
+			ctr := cfg.BuildContainer(ctx, client, sOpt, spec, targetKey, pkgSt, opts...)
+			withTests := cfg.RunTests(ctx, client, sOpt, spec, targetKey, opts...)
+			withFinalState := testrunner.WithFinalState(pkgSt, frontend.TestWithClientFrontend(client), testrunner.WithConstraints(opts...))
 
-			ref, err := getRef(ctx, client, ctr.With(tests))
+			pkgSt = ctr.With(withTests).With(withFinalState)
+
+			def, err := pkgSt.Marshal(ctx, opts...)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error marshalling llb: %w", err)
+			}
+
+			res, err := client.Solve(ctx, gwclient.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				return nil, nil, err
+			}
+
 			if platform == nil {
 				p := platforms.DefaultSpec()
 				platform = &p
 			}
-			return ref, &dalec.DockerImageSpec{Image: ocispecs.Image{Platform: *platform}}, err
+			return ref, &dalec.DockerImageSpec{Image: ocispecs.Image{Platform: *platform}}, nil
 		})
 	}
-}
-
-func getRef(ctx context.Context, client gwclient.Client, st llb.State) (gwclient.Reference, error) {
-	def, err := st.Marshal(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := client.Solve(ctx, gwclient.SolveRequest{
-		Definition: def.ToPB(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return res.SingleRef()
 }

--- a/targets/linux/rpm/distro/pkg.go
+++ b/targets/linux/rpm/distro/pkg.go
@@ -12,7 +12,9 @@ import (
 	"github.com/project-dalec/dalec/targets"
 )
 
-var defaultRepoConfig = &dnfRepoPlatform
+var (
+	defaultRepoConfig = &dnfRepoPlatform
+)
 
 func (c *Config) Validate(spec *dalec.Spec) error {
 	if err := rpm.ValidateSpec(spec); err != nil {
@@ -43,13 +45,12 @@ func needsAutoGocache(spec *dalec.Spec, targetKey string) bool {
 }
 
 func (c *Config) BuildPkg(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.State {
-	opts = append(opts, frontend.IgnoreCache(client), dalec.Platform(sOpt.TargetPlatform))
+	opts = append(opts, frontend.IgnoreCache(client))
 
-	worker := c.Worker(sOpt, opts...)
+	worker := c.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 	worker = worker.With(c.InstallBuildDeps(spec, sOpt, targetKey, opts...))
 
-	// Preprocess the spec to generate patches for gomod edits and other generators
-	// This must happen after build deps are installed so Go is available
+	// Preprocess after build deps are installed so generators can use build tools.
 	if err := spec.Preprocess(sOpt, worker, opts...); err != nil {
 		return dalec.ErrorState(worker, err)
 	}
@@ -68,16 +69,21 @@ func (c *Config) BuildPkg(ctx context.Context, client gwclient.Client, sOpt dale
 	buildOpts := append(opts, spec.Build.Steps.GetSourceLocation(builder), frontend.IgnoreCache(client, targets.IgnoreCacheKeyPkg))
 	st := rpm.Build(br, builder, specPath, cacheInfo, buildOpts...)
 
-	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt, opts...)
+	signed := frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt, opts...)
+
+	// Merge the signed state with the original state
+	// The signed files should overwrite the unsigned ones.
+	st = st.File(llb.Copy(signed, "/", "/"), opts...)
+	return st
 }
 
-// RunTests runs the package tests
+// runTests runs the package tests
 // The returned reference is the solved container state
-func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, spec *dalec.Spec, sOpt dalec.SourceOpts, final llb.State, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
+func (cfg *Config) RunTests(ctx context.Context, client gwclient.Client, sOpt dalec.SourceOpts, spec *dalec.Spec, targetKey string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	return func(in llb.State) llb.State {
-		deps := cfg.InstallTestDeps(sOpt, targetKey, spec, opts...)
-		tests := frontend.RunTests(ctx, client, spec, final, targetKey, sOpt.TargetPlatform)
-		return in.With(deps).With(tests)
+		withTestDeps := cfg.InstallTestDeps(sOpt, targetKey, spec, opts...)
+		runTests := frontend.RunTests(ctx, client, sOpt, spec, withTestDeps, targetKey, opts...)
+		return in.With(runTests)
 	}
 }
 
@@ -101,18 +107,12 @@ func (cfg *Config) InstallTestDeps(sOpt dalec.SourceOpts, targetKey string, spec
 		return dalec.NoopStateOption
 	}
 
-	opts = append(opts, dalec.ProgressGroup("Install test dependencies"))
-
 	return func(in llb.State) llb.State {
 		repos := spec.GetTestRepos(targetKey)
 		repoMounts, keyPaths := cfg.RepoMounts(repos, sOpt, opts...)
-		importRepos := []DnfInstallOpt{
-			DnfAtRoot("/tmp/rootfs"),
-			DnfWithMounts(repoMounts),
-			DnfImportKeys(keyPaths),
-			DnfInstallWithConstraints(opts),
-		}
+		importRepos := []DnfInstallOpt{DnfAtRoot("/tmp/rootfs"), DnfWithMounts(repoMounts), DnfImportKeys(keyPaths)}
 
+		opts = append(opts, dalec.ProgressGroup("Install test dependencies"))
 		worker := cfg.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 		return worker.Run(
 			dalec.WithConstraints(opts...),

--- a/targets/register.go
+++ b/targets/register.go
@@ -9,7 +9,7 @@ func RegisterBuildTarget(name string, build gwclient.BuildFunc) {
 	plugins.Register(&plugins.Registration{
 		ID:   name,
 		Type: plugins.TypeBuildTarget,
-		InitFn: func(*plugins.InitContext) (interface{}, error) {
+		InitFn: func(*plugins.InitContext) (any, error) {
 			return plugins.BuildHandlerFunc(build), nil
 		},
 	})

--- a/test/fixtures/signer/main.go
+++ b/test/fixtures/signer/main.go
@@ -91,8 +91,7 @@ func main() {
 			return nil, errors.Wrap(err, "error marshalling file manifest")
 		}
 
-		pg := dalec.ProgressGroup("Signing Artifacts")
-
+		pg := dalec.ProgressGroup("phony signer output")
 		output := llb.Scratch().
 			File(llb.Mkfile("/target", 0o600, []byte(target)), pg).
 			File(llb.Mkfile("/config.json", 0o600, configBytes), pg).
@@ -111,7 +110,7 @@ func main() {
 				File(llb.Mkfile("/env/"+key, 0o600, []byte(v)), pg)
 		}
 
-		def, err := output.Marshal(ctx)
+		def, err := output.Marshal(ctx, pg)
 		if err != nil {
 			return nil, err
 		}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/containerd/platforms"
@@ -226,15 +227,22 @@ func withBuildArg(k, v string) srOpt {
 	}
 }
 
+// Since withSpec is modifying a spec, this is used
+// to prevent potential data races which, while the data being modified is harmless
+// can still cause memory corruption.
+var withSpecMu sync.Mutex
+
 func withSpec(ctx context.Context, t *testing.T, spec *dalec.Spec) srOpt {
 	return func(cfg *newSolveRequestConfig) {
 		if spec != nil && !cfg.noFillSpecFields {
+			withSpecMu.Lock()
 			if spec.Packager == "" {
 				spec.Packager = "test"
 			}
 			if spec.Website == "" {
 				spec.Website = "https://github.com/project-dalec/dalec"
 			}
+			withSpecMu.Unlock()
 		}
 		specToSolveRequest(ctx, t, spec, cfg.req)
 	}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/frontend"
@@ -294,14 +295,15 @@ func solveT(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient
 	}
 
 	// Running this validation as part of this function allows us to verify most test scenarios.
-	verifyConstraintsPropagation(ctx, t, res)
+	verifyConstraintsPropagation(ctx, t, req, res)
 
 	return res
 }
 
-func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclient.Result) {
+func verifyConstraintsPropagation(ctx context.Context, t *testing.T, req gwclient.SolveRequest, res *gwclient.Result) {
 	t.Helper()
 
+	inputOps := frontendInputOps(t, req)
 	allOps := []test.LLBOp{}
 
 	if err := res.EachRef(func(ref gwclient.Reference) error {
@@ -324,6 +326,13 @@ func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclie
 	badOps := []test.LLBOp{}
 
 	for _, op := range allOps {
+		// Frontend inputs are supplied as already-marshaled definitions. BuildKit
+		// preserves those ops as-is, so Dalec cannot apply constraints to their
+		// internal ops when consuming them as named contexts.
+		if _, ok := inputOps[op.Digest]; ok {
+			continue
+		}
+
 		// - Checking metadata for progress group presence is a good gauge for constraints propagation.
 		// - As far as observed, merge OP does not inherit constraints.
 		// - "llb.customname" property comes from current frontend context Dockerfile, where constraints cannot be applied
@@ -347,6 +356,19 @@ func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclie
 	t.Errorf("Found %d operations without progress group metadata:\n%s", len(badOps), opsJSON)
 }
 
+func frontendInputOps(t *testing.T, req gwclient.SolveRequest) map[digest.Digest]struct{} {
+	t.Helper()
+
+	ops := make(map[digest.Digest]struct{})
+	for _, def := range req.FrontendInputs {
+		for _, dt := range def.Def {
+			ops[digest.FromBytes(dt)] = struct{}{}
+		}
+	}
+
+	return ops
+}
+
 func solveTCh(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient.SolveRequest, rc chan<- *gwclient.Result, ec chan<- error) {
 	t.Helper()
 
@@ -358,7 +380,7 @@ func solveTCh(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclie
 		}
 
 		// Running this validation as part of this function allows us to verify most test scenarios.
-		verifyConstraintsPropagation(ctx, t, res)
+		verifyConstraintsPropagation(ctx, t, req, res)
 
 		rc <- res
 	}()

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,12 +27,9 @@ import (
 	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/go-archive/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/frontend"
 	"github.com/project-dalec/dalec/frontend/pkg/bkfs"
-	"github.com/project-dalec/dalec/internal/test"
-	"github.com/project-dalec/dalec/targets"
 	"github.com/project-dalec/dalec/test/testenv"
 	"golang.org/x/exp/maps"
 	"gotest.tools/v3/assert"
@@ -169,7 +167,7 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-			sr := newSolveRequest(withSpec(ctx, t, &spec), withBuildTarget(testConfig.Target.Package))
+			sr := newSolveRequest(withSpec(ctx, t, &spec), withBuildTarget(testConfig.Target.Container))
 			sr.Evaluate = true
 			_, err := gwc.Solve(ctx, sr)
 			var xErr *moby_buildkit_v1_frontend.ExitError
@@ -203,74 +201,12 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		testTargetArtifactsTakePrecedence(ctx, t, testConfig.Target)
 	})
 
-	t.Run("build_steps", func(t *testing.T) {
+	t.Run("container", func(t *testing.T) {
 		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
 
-		t.Run("multiline_command_works_with_env_vars", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{
-				Build: dalec.ArtifactBuild{
-					Steps: []dalec.BuildStep{
-						{
-							// Test that a multiline command works with env vars
-							Env: map[string]string{
-								"FOO": "foo",
-								"BAR": "bar",
-							},
-							Command: `
-echo "${FOO}_0" > foo0.txt
-echo "${FOO}_1" > foo1.txt
-echo "$BAR" > bar.txt
-`,
-						},
-					},
-				},
-
-				Artifacts: dalec.Artifacts{
-					Binaries: map[string]dalec.ArtifactConfig{
-						// These are files we created in the build step
-						// They aren't really binaries but we want to test that they are created and have the right content
-						"foo0.txt": {},
-						"foo1.txt": {},
-						"bar.txt":  {},
-					},
-				},
-
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Check that multi-line command (from build step) with env vars propagates env vars to whole command",
-						Files: map[string]dalec.FileCheckOutput{
-							"/usr/bin/foo0.txt": {CheckOutput: dalec.CheckOutput{StartsWith: "foo_0\n"}},
-							"/usr/bin/foo1.txt": {CheckOutput: dalec.CheckOutput{StartsWith: "foo_1\n"}},
-							"/usr/bin/bar.txt":  {CheckOutput: dalec.CheckOutput{StartsWith: "bar\n"}},
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Package),
-				)
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-	})
-
-	t.Run("sources", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("patches_are_applied_in_order", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			const src2Patch3File = "patch3"
-			src2Patch3Content := []byte(`
+		const src2Patch3File = "patch3"
+		src2Patch3Content := []byte(`
 diff --git a/file3 b/file3
 new file mode 100700
 index 0000000..5260cb1
@@ -282,7 +218,7 @@ index 0000000..5260cb1
 +echo "Added another new file"
 `)
 
-			src2Patch4Content := []byte(`
+		src2Patch4Content := []byte(`
 diff --git a/file4 b/file4
 new file mode 100700
 index 0000000..5260cb1
@@ -294,7 +230,7 @@ index 0000000..5260cb1
 +echo "Added yet another new file"
 `)
 
-			src2Patch5Content := []byte(`
+		src2Patch5Content := []byte(`
 diff --git a/file5 b/file5
 new file mode 100700
 index 0000000..5260cb1
@@ -306,33 +242,47 @@ index 0000000..5260cb1
 +echo "Added yet again...another new file"
 `)
 
-			const src2Patch4File = "patches/patch4"
-			const src2Patch5File = "patches/patch5"
-			const patchContextName = "patch-context"
+		const src2Patch4File = "patches/patch4"
+		const src2Patch5File = "patches/patch5"
+		const patchContextName = "patch-context"
 
-			opts := dalec.ProgressGroup("test-patch-sources")
+		patchContext := llb.Scratch().
+			File(llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content)).
+			File(llb.Mkdir("patches", 0o755)).
+			File(llb.Mkfile(src2Patch4File, 0o600, src2Patch4Content)).
+			File(llb.Mkfile(src2Patch5File, 0o600, src2Patch5Content))
 
-			patchContext := llb.Scratch().
-				File(llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content), opts).
-				File(llb.Mkdir("patches", 0o755), opts).
-				File(llb.Mkfile(src2Patch4File, 0o600, src2Patch4Content), opts).
-				File(llb.Mkfile(src2Patch5File, 0o600, src2Patch5Content), opts)
-
-			spec := testLinuxSpec(t, dalec.Spec{
-				Sources: map[string]dalec.Source{
-					"src2": {
-						Inline: &dalec.SourceInline{
-							Dir: &dalec.SourceInlineDir{
-								Files: map[string]*dalec.SourceInlineFile{
-									"file1": {Contents: "file1 contents\n"},
-								},
+		spec := dalec.Spec{
+			Name:        "test-container-build",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/project-dalec/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Testing container target",
+			Sources: map[string]dalec.Source{
+				"src1": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/usr/bin/env bash\necho hello world",
+							Permissions: 0o700,
+						},
+					},
+				},
+				"src2": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"file1": {Contents: "file1 contents\n"},
 							},
 						},
 					},
-					"src2-patch1": {
-						Inline: &dalec.SourceInline{
-							File: &dalec.SourceInlineFile{
-								Contents: `
+				},
+				"src2-patch1": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents: `
 diff --git a/file1 b/file1
 index 84d55c5..22b9b11 100644
 --- a/file1
@@ -341,15 +291,15 @@ index 84d55c5..22b9b11 100644
 -file1 contents
 +file1 contents patched
 `,
-							},
 						},
 					},
-					"src2-patch2": {
-						Inline: &dalec.SourceInline{
-							Dir: &dalec.SourceInlineDir{
-								Files: map[string]*dalec.SourceInlineFile{
-									"the-patch": {
-										Contents: `
+				},
+				"src2-patch2": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"the-patch": {
+									Contents: `
 diff --git a/file2 b/file2
 new file mode 100700
 index 0000000..5260cb1
@@ -360,214 +310,155 @@ index 0000000..5260cb1
 +
 +echo "Added a new file"
 `,
-									},
 								},
 							},
 						},
 					},
-					"src2-patch3": {
-						Context: &dalec.SourceContext{
-							Name: patchContextName,
-						},
-					},
-					"src2-patch4": {
-						Context: &dalec.SourceContext{
-							Name: patchContextName,
-						},
-						Includes: []string{src2Patch4File},
-					},
-					"src2-patch5": {
-						Context: &dalec.SourceContext{
-							Name: patchContextName,
-						},
-						Path: src2Patch5File,
+				},
+				"src2-patch3": {
+					Context: &dalec.SourceContext{
+						Name: patchContextName,
 					},
 				},
-				Patches: map[string][]dalec.PatchSpec{
-					"src2": {
-						{Source: "src2-patch1"},
-						{Source: "src2-patch2", Path: "the-patch"},
-						{Source: "src2-patch3", Path: src2Patch3File},
-						{Source: "src2-patch4", Path: src2Patch4File},
-						{Source: "src2-patch5", Path: filepath.Base(src2Patch5File)},
+				"src2-patch4": {
+					Context: &dalec.SourceContext{
+						Name: patchContextName,
 					},
+					Includes: []string{src2Patch4File},
 				},
-
-				Build: dalec.ArtifactBuild{
-					Steps: []dalec.BuildStep{
-						{
-							// file added by patch
-							Command: "ls -lh ./src2/file2",
-						},
-						{
-							// file added by patch
-							Command: "test -f ./src2/file2",
-						},
-						{
-							// file added by patch
-							Command: "test -x ./src2/file2",
-						},
-						{
-							Command: "grep 'Added a new file' ./src2/file2",
-						},
-						{
-							// file added by patch
-							Command: "test -f ./src2/file3",
-						},
-						{
-							// file added by patch
-							Command: "test -x ./src2/file3",
-						},
-						{
-							Command: "grep 'Added another new file' ./src2/file3",
-						},
+				"src2-patch5": {
+					Context: &dalec.SourceContext{
+						Name: patchContextName,
 					},
+					Path: src2Patch5File,
 				},
-
-				Image: &dalec.ImageConfig{
-					Post: &dalec.PostInstall{
-						Symlinks: map[string]dalec.SymlinkTarget{
-							"/usr/bin/src2": {
-								Paths: []string{"/non/existing/dir/src2"},
-								Group: "coffee",
-							},
-						},
-					},
-				},
-
-				Artifacts: dalec.Artifacts{
-					Binaries: map[string]dalec.ArtifactConfig{
-						"src2/file2": {},
-					},
-					Links: []dalec.ArtifactSymlinkConfig{
-						{
-							Source: "/usr/bin/src2/file2",
-							Dest:   "/bin/owned-link2",
-							User:   "need",
-						},
-					},
-					Users: []dalec.AddUserConfig{
-						{
-							Name: "need",
-						},
-					},
-					Groups: []dalec.AddGroupConfig{
-						{
-							Name: "coffee",
-						},
-					},
-				},
-
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Check that the binary artifacts execute and provide the expected output",
-						Steps: []dalec.TestStep{
-							{
-								Command: "/usr/bin/file2",
-								Stdout:  dalec.CheckOutput{Equals: "Added a new file\n"},
-								Stderr:  dalec.CheckOutput{Empty: true},
-							},
-						},
-					},
-					{
-						Name: "Post-install symlinks should be created and have correct ownership",
-						Steps: []dalec.TestStep{
-							{Command: "/bin/bash -exc 'test -L /non/existing/dir/src2'"},
-							{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir/src2)\" = \"/usr/bin/src2\"'"},
-							{Command: "/bin/bash -exc 'NEED_UID=0; COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src2); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-						},
-					},
-					{
-						Name: "Artifact symlinks should have correct ownership",
-						Steps: []dalec.TestStep{
-							{Command: "/bin/bash -exc 'test -L /bin/owned-link2'"},
-							{Command: "/bin/bash -exc 'test \"$(readlink /bin/owned-link2)\" = \"/usr/bin/src2/file2\"'"},
-							{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /bin/owned-link2); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Package),
-					withBuildContext(ctx, t, patchContextName, patchContext),
-				)
-				sr.Evaluate = true
-
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-
-		t.Run("are_available_in_build_steps", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{
-				Sources: map[string]dalec.Source{
-					"src1": {
-						Inline: &dalec.SourceInline{
-							File: &dalec.SourceInlineFile{
-								Contents:    "#!/usr/bin/env bash\necho hello world",
-								Permissions: 0o700,
-							},
-						},
-					},
-				},
-				Build: dalec.ArtifactBuild{
-					Steps: []dalec.BuildStep{
-						// These are "build" steps where we aren't really building things just verifying
-						// that sources are in the right place and have the right permissions and content
-						{
-							// file added by patch
-							Command: "test -f ./src1",
-						},
-						{
-							Command: "test -x ./src1",
-						},
-						{
-							Command: "test ! -d ./src1",
-						},
-						{
-							Command: "./src1 | grep 'hello world'",
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Package),
-				)
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-	})
-
-	t.Run("artifacts", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := startTestSpan(baseCtx, t)
-
-		spec := testLinuxSpec(t, dalec.Spec{
-			Sources: map[string]dalec.Source{
-				"src1": {
+				"src3": {
 					Inline: &dalec.SourceInline{
 						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
+							Contents:    "#!/usr/bin/env bash\necho goodbye",
 							Permissions: 0o700,
 						},
 					},
 				},
 			},
+			Patches: map[string][]dalec.PatchSpec{
+				"src2": {
+					{Source: "src2-patch1"},
+					{Source: "src2-patch2", Path: "the-patch"},
+					{Source: "src2-patch3", Path: src2Patch3File},
+					{Source: "src2-patch4", Path: src2Patch4File},
+					{Source: "src2-patch5", Path: filepath.Base(src2Patch5File)},
+				},
+			},
+
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					"bash":      {},
+					"coreutils": {},
+				},
+			},
+
+			Build: dalec.ArtifactBuild{
+				Steps: []dalec.BuildStep{
+					// These are "build" steps where we aren't really building things just verifying
+					// that sources are in the right place and have the right permissions and content
+					{
+						// file added by patch
+						Command: "test -f ./src1",
+					},
+					{
+						Command: "test -x ./src1",
+					},
+					{
+						Command: "test ! -d ./src1",
+					},
+					{
+						Command: "./src1 | grep 'hello world'",
+					},
+					{
+						// file added by patch
+						Command: "ls -lh ./src2/file2",
+					},
+					{
+						// file added by patch
+						Command: "test -f ./src2/file2",
+					},
+					{
+						// file added by patch
+						Command: "test -x ./src2/file2",
+					},
+					{
+						Command: "grep 'Added a new file' ./src2/file2",
+					},
+					{
+						// file added by patch
+						Command: "test -f ./src2/file3",
+					},
+					{
+						// file added by patch
+						Command: "test -x ./src2/file3",
+					},
+					{
+						Command: "grep 'Added another new file' ./src2/file3",
+					},
+					{
+						// Test that a multiline command works with env vars
+						Env: map[string]string{
+							"FOO": "foo",
+							"BAR": "bar",
+						},
+						Command: `
+echo "${FOO}_0" > foo0.txt
+echo "${FOO}_1" > foo1.txt
+echo "$BAR" > bar.txt
+`,
+					},
+				},
+			},
+
+			Image: &dalec.ImageConfig{
+				Post: &dalec.PostInstall{
+					Symlinks: map[string]dalec.SymlinkTarget{
+						"/usr/bin/src1": {
+							Path: "/src1",
+							User: "need",
+						},
+						"/usr/bin/src2": {
+							Paths: []string{"/non/existing/dir/src2"},
+							Group: "coffee",
+						},
+						"/usr/bin/src3": {
+							Paths: []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"},
+							User:  "need",
+							Group: "coffee",
+						},
+					},
+				},
+			},
+
 			Artifacts: dalec.Artifacts{
 				Binaries: map[string]dalec.ArtifactConfig{
-					"src1": {},
+					"src1":       {},
+					"src2/file2": {},
+					"src3":       {},
+					// These are files we created in the build step
+					// They aren't really binaries but we want to test that they are created and have the right content
+					"foo0.txt": {},
+					"foo1.txt": {},
+					"bar.txt":  {},
 				},
 				Links: []dalec.ArtifactSymlinkConfig{
+					{
+						Source: "/usr/bin/src3",
+						Dest:   "/bin/owned-link",
+						User:   "need",
+						Group:  "coffee",
+					},
+					{
+						Source: "/usr/bin/src2/file2",
+						Dest:   "/bin/owned-link2",
+						User:   "need",
+					},
 					{
 						Source: "/usr/bin/src1",
 						Dest:   "/bin/owned-link3",
@@ -590,7 +481,79 @@ index 0000000..5260cb1
 					},
 				},
 			},
+
 			Tests: []*dalec.TestSpec{
+				{
+					Name: "Verify source mounts work",
+					Mounts: []dalec.SourceMount{
+						{
+							Dest: "/foo",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: "hello world",
+									},
+								},
+							},
+						},
+						{
+							Dest: "/nested/foo",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: "hello world nested",
+									},
+								},
+							},
+						},
+						{
+							Dest: "/dir",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									Dir: &dalec.SourceInlineDir{
+										Files: map[string]*dalec.SourceInlineFile{
+											"foo": {Contents: "hello from dir"},
+										},
+									},
+								},
+							},
+						},
+						{
+							Dest: "/nested/dir",
+							Spec: dalec.Source{
+								Inline: &dalec.SourceInline{
+									Dir: &dalec.SourceInlineDir{
+										Files: map[string]*dalec.SourceInlineFile{
+											"foo": {Contents: "hello from nested dir"},
+										},
+									},
+								},
+							},
+						},
+					},
+					Steps: []dalec.TestStep{
+						{
+							Command: "/bin/sh -c 'cat /foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello world"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /nested/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello world nested"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /dir/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello from dir"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+						{
+							Command: "/bin/sh -c 'cat /nested/dir/foo'",
+							Stdout:  dalec.CheckOutput{Equals: "hello from nested dir"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+					},
+				},
 				{
 					Name: "Check that the binary artifacts execute and provide the expected output",
 					Steps: []dalec.TestStep{
@@ -599,11 +562,72 @@ index 0000000..5260cb1
 							Stdout:  dalec.CheckOutput{Equals: "hello world\n"},
 							Stderr:  dalec.CheckOutput{Empty: true},
 						},
+						{
+							Command: "/usr/bin/file2",
+							Stdout:  dalec.CheckOutput{Equals: "Added a new file\n"},
+							Stderr:  dalec.CheckOutput{Empty: true},
+						},
+					},
+				},
+				{
+					Name: "Check that multi-line command (from build step) with env vars propagates env vars to whole command",
+					Files: map[string]dalec.FileCheckOutput{
+						"/usr/bin/foo0.txt": {CheckOutput: dalec.CheckOutput{StartsWith: "foo_0\n"}},
+						"/usr/bin/foo1.txt": {CheckOutput: dalec.CheckOutput{StartsWith: "foo_1\n"}},
+						"/usr/bin/bar.txt":  {CheckOutput: dalec.CheckOutput{StartsWith: "bar\n"}},
+					},
+				},
+				{
+					Name: "Post-install symlinks should be created and have correct ownership",
+					Files: map[string]dalec.FileCheckOutput{
+						"/src1":                  {},
+						"/non/existing/dir/src3": {},
+					},
+					Steps: []dalec.TestStep{
+						{Command: "/bin/bash -exc 'test -L /src1'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
+						{Command: "/bin/bash -exc 'test -L /non/existing/dir/src2'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir/src2)\" = \"/usr/bin/src2\"'"},
+						{Command: "/bin/bash -exc 'test -L /non/existing/dir/src3'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir/src3)\" = \"/usr/bin/src3\"'"},
+						{Command: "/bin/bash -exc 'test -L /non/existing/dir2/src3'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir2/src3)\" = \"/usr/bin/src3\"'"},
+						{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /src1); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+						{Command: "/bin/bash -exc 'NEED_UID=0; COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src2); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+						{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+						{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir2/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+						{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+						{Command: "/non/existing/dir/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+						{Command: "/non/existing/dir2/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+					},
+				},
+				{
+					Name: "Check /etc/os-release",
+					Files: map[string]dalec.FileCheckOutput{
+						"/etc/os-release": {
+							CheckOutput: dalec.CheckOutput{
+								Matches: []string{
+									// Some distros have quotes around the values
+									// Regex is to match the values with or without quotes
+									// "(?m)" enables multi-line mode so that ^ and $ match the start and end of lines rather than the full document.
+									//
+									// Due to these values getting processed for build args, quotes are stripped unless they are escaped.
+									`(?m)^ID=(\")?` + testConfig.Release.ID + `(\")?`,
+									`(?m)^VERSION_ID=(\")?` + testConfig.Release.VersionID + `(\")?`,
+								},
+							},
+						},
 					},
 				},
 				{
 					Name: "Artifact symlinks should have correct ownership",
 					Steps: []dalec.TestStep{
+						{Command: "/bin/bash -exc 'test -L /bin/owned-link'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /bin/owned-link)\" = \"/usr/bin/src3\"'"},
+						{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /bin/owned-link); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+						{Command: "/bin/bash -exc 'test -L /bin/owned-link2'"},
+						{Command: "/bin/bash -exc 'test \"$(readlink /bin/owned-link2)\" = \"/usr/bin/src2/file2\"'"},
+						{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /bin/owned-link2); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
 						{Command: "/bin/bash -exc 'test -L /bin/owned-link3'"},
 						{Command: "/bin/bash -exc 'test \"$(readlink /bin/owned-link3)\" = \"/usr/bin/src1\"'"},
 						{Command: "/bin/bash -exc 'NEED_UID=0; COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /bin/owned-link3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
@@ -613,651 +637,43 @@ index 0000000..5260cb1
 					},
 				},
 			},
-		})
+		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 			sr := newSolveRequest(
 				withSpec(ctx, t, &spec),
-				withBuildTarget(testConfig.Target.Package),
+				withBuildTarget(testConfig.Target.Container),
+				withBuildContext(ctx, t, patchContextName, patchContext),
 			)
-			solveT(ctx, t, gwc, sr)
-		})
-	})
+			sr.Evaluate = true
 
-	t.Run("tests", func(t *testing.T) {
-		t.Parallel()
+			beforeBuild := time.Now()
+			res := solveT(ctx, t, gwc, sr)
 
-		t.Run("have_access_to_source_mounts", func(t *testing.T) {
-			t.Parallel()
-			ctx := startTestSpan(baseCtx, t)
+			dt, ok := res.Metadata[exptypes.ExporterImageConfigKey]
+			assert.Assert(t, ok, "result metadata should contain an image config: available metadata: %s", strings.Join(maps.Keys(res.Metadata), ", "))
 
-			spec := testLinuxSpec(t, dalec.Spec{
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Verify source mounts work",
-						Mounts: []dalec.SourceMount{
-							{
-								Dest: "/foo",
-								Spec: dalec.Source{
-									Inline: &dalec.SourceInline{
-										File: &dalec.SourceInlineFile{
-											Contents: "hello world",
-										},
-									},
-								},
-							},
-							{
-								Dest: "/nested/foo",
-								Spec: dalec.Source{
-									Inline: &dalec.SourceInline{
-										File: &dalec.SourceInlineFile{
-											Contents: "hello world nested",
-										},
-									},
-								},
-							},
-							{
-								Dest: "/dir",
-								Spec: dalec.Source{
-									Inline: &dalec.SourceInline{
-										Dir: &dalec.SourceInlineDir{
-											Files: map[string]*dalec.SourceInlineFile{
-												"foo": {Contents: "hello from dir"},
-											},
-										},
-									},
-								},
-							},
-							{
-								Dest: "/nested/dir",
-								Spec: dalec.Source{
-									Inline: &dalec.SourceInline{
-										Dir: &dalec.SourceInlineDir{
-											Files: map[string]*dalec.SourceInlineFile{
-												"foo": {Contents: "hello from nested dir"},
-											},
-										},
-									},
-								},
-							},
-						},
-						Steps: []dalec.TestStep{
-							{
-								Command: "/bin/sh -c 'cat /foo'",
-								Stdout:  dalec.CheckOutput{Equals: "hello world"},
-								Stderr:  dalec.CheckOutput{Empty: true},
-							},
-							{
-								Command: "/bin/sh -c 'cat /nested/foo'",
-								Stdout:  dalec.CheckOutput{Equals: "hello world nested"},
-								Stderr:  dalec.CheckOutput{Empty: true},
-							},
-							{
-								Command: "/bin/sh -c 'cat /dir/foo'",
-								Stdout:  dalec.CheckOutput{Equals: "hello from dir"},
-								Stderr:  dalec.CheckOutput{Empty: true},
-							},
-							{
-								Command: "/bin/sh -c 'cat /nested/dir/foo'",
-								Stdout:  dalec.CheckOutput{Equals: "hello from nested dir"},
-								Stderr:  dalec.CheckOutput{Empty: true},
-							},
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Package),
-				)
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-	})
-
-	t.Run("container", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("depsonly", func(t *testing.T) {
-			if testConfig.Target.DepsOnly == "" {
-				t.Skip("depsonly target not defined")
-			}
-
-			t.Parallel()
-			ctx := startTestSpan(ctx, t)
-			testDepsOnly(ctx, t, testConfig)
-		})
-
-		t.Run("creates_post_install_symlinks", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{
-				Sources: map[string]dalec.Source{
-					"src1": {
-						Inline: &dalec.SourceInline{
-							File: &dalec.SourceInlineFile{
-								Contents:    "#!/usr/bin/env bash\necho hello world",
-								Permissions: 0o700,
-							},
-						},
-					},
-					"src3": {
-						Inline: &dalec.SourceInline{
-							File: &dalec.SourceInlineFile{
-								Contents:    "#!/usr/bin/env bash\necho goodbye",
-								Permissions: 0o700,
-							},
-						},
-					},
-				},
-				Artifacts: dalec.Artifacts{
-					Binaries: map[string]dalec.ArtifactConfig{
-						"src1": {},
-						"src3": {},
-					},
-					Users: []dalec.AddUserConfig{
-						{
-							Name: "need",
-						},
-					},
-					Groups: []dalec.AddGroupConfig{
-						{
-							Name: "coffee",
-						},
-					},
-				},
-				Image: &dalec.ImageConfig{
-					Post: &dalec.PostInstall{
-						Symlinks: map[string]dalec.SymlinkTarget{
-							"/usr/bin/src1": {
-								Path: "/src1",
-								User: "need",
-							},
-							"/usr/bin/src3": {
-								Paths: []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"},
-								User:  "need",
-								Group: "coffee",
-							},
-						},
-					},
-				},
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Post-install symlinks should be created and have correct ownership",
-						Files: map[string]dalec.FileCheckOutput{
-							"/src1":                  {},
-							"/non/existing/dir/src3": {},
-						},
-						Steps: []dalec.TestStep{
-							{Command: "/bin/bash -exc 'test -L /src1'"},
-							{Command: "/bin/bash -exc 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
-							{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /src1); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-							{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
-
-							{Command: "/bin/bash -exc 'test -L /non/existing/dir/src3'"},
-							{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir/src3)\" = \"/usr/bin/src3\"'"},
-							{Command: "/bin/bash -exc 'test -L /non/existing/dir2/src3'"},
-							{Command: "/bin/bash -exc 'test \"$(readlink /non/existing/dir2/src3)\" = \"/usr/bin/src3\"'"},
-							{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-							{Command: "/bin/bash -exc 'NEED_UID=$(getent passwd need | cut -d: -f3); COFFEE_GID=$(getent group coffee | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir2/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-							{Command: "/non/existing/dir/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
-							{Command: "/non/existing/dir2/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-				)
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-
-		t.Run("contains_etc_os_release_file", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Check /etc/os-release",
-						Files: map[string]dalec.FileCheckOutput{
-							"/etc/os-release": {
-								CheckOutput: dalec.CheckOutput{
-									Matches: []string{
-										// Some distros have quotes around the values
-										// Regex is to match the values with or without quotes
-										// "(?m)" enables multi-line mode so that ^ and $ match the start and end of lines rather than the full document.
-										//
-										// Due to these values getting processed for build args, quotes are stripped unless they are escaped.
-										`(?m)^ID=(\")?` + testConfig.Release.ID + `(\")?`,
-										`(?m)^VERSION_ID=(\")?` + testConfig.Release.VersionID + `(\")?`,
-									},
-								},
-							},
-						},
-					},
-				},
-			})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-				)
-				solveT(ctx, t, gwc, sr)
-			})
-		})
-
-		t.Run("runs_tests", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
+			var cfg dalec.DockerImageSpec
+			assert.Assert(t, json.Unmarshal(dt, &cfg))
+			assert.Check(t, cfg.Created.After(beforeBuild))
+			assert.Check(t, cfg.Created.Before(time.Now()))
 
 			// Make sure the test framework was actually executed by the build target.
 			// This appends a test case so that is expected to fail and as such cause the build to fail.
-			spec := testLinuxSpec(t, dalec.Spec{
-				Tests: []*dalec.TestSpec{
-					{
-						Name: "Test framework should be executed",
-						Steps: []dalec.TestStep{
-							{Command: "/bin/sh -c 'echo this command should fail; exit 42'"},
-						},
-					},
+			spec.Tests = append(spec.Tests, &dalec.TestSpec{
+				Name: "Test framework should be executed",
+				Steps: []dalec.TestStep{
+					{Command: "/bin/sh -c 'echo this command should fail; exit 42'"},
 				},
 			})
 
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-				)
-				sr.Evaluate = true
-
-				_, err := gwc.Solve(ctx, sr)
-				if err == nil {
-					t.Fatal("Expected test spec to run with error but got none")
-				}
-			})
-		})
-
-		t.Run("has_image_config_available_with_build_time", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-				)
-				sr.Evaluate = true
-
-				beforeBuild := time.Now()
-				res := solveT(ctx, t, gwc, sr)
-
-				dt, ok := res.Metadata[exptypes.ExporterImageConfigKey]
-				assert.Assert(t, ok, "result metadata should contain an image config: available metadata: %s", strings.Join(maps.Keys(res.Metadata), ", "))
-
-				var cfg dalec.DockerImageSpec
-				assert.Assert(t, json.Unmarshal(dt, &cfg))
-				assert.Check(t, cfg.Created.After(beforeBuild))
-				assert.Check(t, cfg.Created.Before(time.Now()))
-			})
-		})
-
-		t.Run("respects_container_cache_key", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-					withIgnoreCache(targets.IgnoreCacheKeyContainer),
-				)
-
-				res := solveT(ctx, t, gwc, sr)
-
-				ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
-				if err != nil {
-					t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
-				}
-
-				cacheIgnored := []test.LLBOp{}
-				execFound := false
-
-				for _, op := range ops {
-					if op.OpMetadata.IgnoreCache {
-						cacheIgnored = append(cacheIgnored, op)
-					}
-
-					e := op.Op.GetExec()
-					pg := op.OpMetadata.ProgressGroup.Name
-					if e == nil || (pg != "Install spec package" && pg != "Install RPMs") {
-						continue
-					}
-
-					execFound = true
-
-					if !op.OpMetadata.IgnoreCache {
-						t.Errorf("Expected install step to have cache ignore enabled")
-					}
-				}
-
-				if !execFound {
-					t.Errorf("No exec ops found in the build")
-				}
-
-				if len(cacheIgnored) > 1 {
-					ops, err := test.LLBOpsToJSON(cacheIgnored)
-					if err != nil {
-						t.Errorf("Error converting ops to JSON: %v", err)
-					}
-
-					t.Errorf("Expected only one operation to have cache ignore enabled, found %d: \n%s", len(cacheIgnored), ops)
-				}
-			})
-		})
-
-		t.Run("respects_ignoring_all_caches", func(t *testing.T) {
-			t.Parallel()
-
-			ctx := startTestSpan(baseCtx, t)
-
-			spec := testLinuxSpec(t, dalec.Spec{})
-
-			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-				sr := newSolveRequest(
-					withSpec(ctx, t, &spec),
-					withBuildTarget(testConfig.Target.Container),
-					withIgnoreCache(),
-				)
-
-				res := solveT(ctx, t, gwc, sr)
-
-				ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
-				if err != nil {
-					t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
-				}
-
-				badOps := []test.LLBOp{}
-
-				for _, op := range ops {
-					if op.OpMetadata.IgnoreCache {
-						continue
-					}
-
-					badOps = append(badOps, op)
-				}
-
-				if len(badOps) != 0 {
-					opsJSON, err := test.LLBOpsToJSON(badOps)
-					if err != nil {
-						t.Fatalf("Unexpected error converting bad ops to JSON: %v", err)
-					}
-
-					t.Fatalf("Unexpected %d operations without cache ignore:\n%s", len(badOps), opsJSON)
-				}
-			})
-		})
-
-		t.Run("when_installing_spec_package", func(t *testing.T) {
-			t.Parallel()
-
-			t.Run("makes_extra_repos_from_spec_available", func(t *testing.T) {
-				t.Parallel()
-
-				ctx := startTestSpan(baseCtx, t)
-
-				// Create repository configurations for different phases
-				// This test verifies that repos configured for "install" are properly processed during container build
-				// and that repos configured for other phases (like "build") don't interfere
-				installRepoConfig := llb.Scratch().File(
-					llb.Mkfile("install-repo.list", 0o644, []byte("# Install phase repository config\n")),
-					dalec.ProgressGroup("Create install repo config"),
-				)
-
-				buildRepoConfig := llb.Scratch().File(
-					llb.Mkfile("build-repo.list", 0o644, []byte("# Unexpected repo\n")),
-					dalec.ProgressGroup("Create build repo config"),
-				)
-
-				spec := testLinuxSpec(t, dalec.Spec{
-					Dependencies: &dalec.PackageDependencies{
-						ExtraRepos: []dalec.PackageRepositoryConfig{
-							{
-								Config: map[string]dalec.Source{
-									"install-repo.list": {
-										Context: &dalec.SourceContext{
-											Name: "install-repo-config",
-										},
-										Path: "install-repo.list",
-									},
-								},
-								Envs: []string{"install"},
-							},
-							{
-								Config: map[string]dalec.Source{
-									"build-repo.list": {
-										Context: &dalec.SourceContext{
-											Name: "build-repo-config",
-										},
-										Path: "build-repo.list",
-									},
-								},
-								Envs: []string{"build"},
-							},
-						},
-					},
-					Build: dalec.ArtifactBuild{
-						Steps: []dalec.BuildStep{
-							{
-								Command: `
-# This is not a debian build, skip this.
-[ ! -d debian ] && exit 0;
-
-# Inject a custom postinst script to inspect the install environment
-[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)
-[ -x debian/postinst ] || chmod +x debian/postinst
-cat >> debian/postinst << 'EOF'
-cat /etc/apt/sources.list.d/*
-grep 'Unexpected repo' /etc/apt/sources.list.d/* && exit 1 || exit 0
-EOF
-`,
-							},
-						},
-					},
-				})
-
-				testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-					sr := newSolveRequest(
-						withSpec(ctx, t, &spec),
-						withBuildTarget(testConfig.Target.Container),
-						withBuildContext(ctx, t, "install-repo-config", installRepoConfig),
-						withBuildContext(ctx, t, "build-repo-config", buildRepoConfig),
-					)
-					solveT(ctx, t, gwc, sr)
-				})
-			})
-
-			t.Run("enables_dpkg_debug", func(t *testing.T) {
-				t.Parallel()
-
-				ctx := startTestSpan(baseCtx, t)
-
-				spec := testLinuxSpec(t, dalec.Spec{
-					Build: dalec.ArtifactBuild{
-						Steps: []dalec.BuildStep{
-							{
-								Command: `
-# This is not a debian build, skip this.
-[ ! -d debian ] && exit 0;
-
-# Inject a custom postinst script to inspect the install environment
-[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)
-[ -x debian/postinst ] || chmod +x debian/postinst
-cat >> debian/postinst << 'EOF'
-grep debug=2 /etc/dpkg/dpkg.cfg.d/99-dalec-debug
-EOF
-`,
-							},
-						},
-					},
-				})
-
-				testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-					sr := newSolveRequest(
-						withSpec(ctx, t, &spec),
-						withBuildTarget(testConfig.Target.Container),
-					)
-
-					solveT(ctx, t, gwc, sr)
-				})
-			})
-
-			t.Run("allows_upgrades", func(t *testing.T) {
-				t.Parallel()
-
-				ctx := startTestSpan(baseCtx, t)
-
-				spec := testLinuxSpec(t, dalec.Spec{
-					Build: dalec.ArtifactBuild{
-						Steps: []dalec.BuildStep{
-							{
-								Command: `
-# This is not a debian build, skip this.
-[ ! -d debian ] && exit 0;
-
-# Inject a custom postinst script to inspect the install environment
-[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)
-[ -x debian/postinst ] || chmod +x debian/postinst
-cat >> debian/postinst << 'EOF'
-if [ "${DALEC_UPGRADE}" != "true" ]; then echo "Expected DALEC_UPGRADE to be \"true\", got \"${DALEC_UPGRADE}\""; exit 1; fi
-EOF
-	`,
-							},
-						},
-					},
-				})
-
-				testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-					sr := newSolveRequest(
-						withSpec(ctx, t, &spec),
-						withBuildTarget(testConfig.Target.Container),
-					)
-
-					solveT(ctx, t, gwc, sr)
-				})
-			})
-
-			t.Run("handles_ubuntu_dpkg_excludes_config", func(t *testing.T) {
-				t.Parallel()
-
-				t.Run("by_masking_when_target_has_docs", func(t *testing.T) {
-					t.Parallel()
-
-					ctx := startTestSpan(baseCtx, t)
-
-					spec := testLinuxSpec(t, dalec.Spec{
-						Sources: map[string]dalec.Source{
-							"foo": {
-								Inline: &dalec.SourceInline{
-									File: &dalec.SourceInlineFile{
-										Contents: "hello world!",
-									},
-								},
-							},
-						},
-						Artifacts: dalec.Artifacts{
-							Docs: map[string]dalec.ArtifactConfig{
-								"foo": {},
-							},
-						},
-						Build: dalec.ArtifactBuild{
-							Steps: []dalec.BuildStep{
-								{
-									Command: `
-# This is not a debian build, skip this.
-[ ! -d debian ] && exit 0;
-
-# Inject a custom postinst script to inspect the install environment
-[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)
-[ -x debian/postinst ] || chmod +x debian/postinst
-cat >> debian/postinst << 'EOF'
-[ -s /etc/dpkg/dpkg.cfg.d/excludes ] && exit 1
-exit 0
-EOF
-	`,
-								},
-							},
-						},
-					})
-
-					testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-						sr := newSolveRequest(
-							withSpec(ctx, t, &spec),
-							withBuildTarget(testConfig.Target.Container),
-						)
-
-						solveT(ctx, t, gwc, sr)
-					})
-				})
-
-				t.Run("by_not_masking_when_target_has_no_docs", func(t *testing.T) {
-					t.Parallel()
-
-					ctx := startTestSpan(baseCtx, t)
-
-					spec := testLinuxSpec(t, dalec.Spec{
-						Build: dalec.ArtifactBuild{
-							Steps: []dalec.BuildStep{
-								{
-									Command: `
-# This is not a debian build, skip this.
-[ ! -d debian ] && exit 0;
-
-# Inject a custom postinst script to inspect the install environment
-[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)
-[ -x debian/postinst ] || chmod +x debian/postinst
-cat >> debian/postinst << 'EOF'
-set -x
-
-# If file does not exist, all good.
-[ ! -f /etc/dpkg/dpkg.cfg.d/excludes ] && exit 0
-
-# if file exists, ensure it is not masked.
-if [ ! -s /etc/dpkg/dpkg.cfg.d/excludes ]; then echo "Unexpected masking found"; exit 1; fi
-EOF
-	`,
-								},
-							},
-						},
-					})
-
-					testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-						sr := newSolveRequest(
-							withSpec(ctx, t, &spec),
-							withBuildTarget(testConfig.Target.Container),
-						)
-
-						solveT(ctx, t, gwc, sr)
-					})
-				})
-			})
+			// update the spec in the solve request
+			withSpec(ctx, t, &spec)(&newSolveRequestConfig{req: &sr})
+
+			_, err := gwc.Solve(ctx, sr)
+			if err == nil {
+				t.Fatal("expected test spec to run with error but got none")
+			}
 		})
 	})
 
@@ -1308,13 +724,11 @@ index 0000000..5260cb1
 		const src2Patch5File = "patches/patch5"
 		const patchContextName = "patch-context"
 
-		opts := dalec.ProgressGroup("test-patch-sources")
-
 		patchContext := llb.Scratch().
-			File(llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content), opts).
-			File(llb.Mkdir("patches", 0o755), opts).
-			File(llb.Mkfile(src2Patch4File, 0o600, src2Patch4Content), opts).
-			File(llb.Mkfile(src2Patch5File, 0o600, src2Patch5Content), opts)
+			File(llb.Mkfile(src2Patch3File, 0o600, src2Patch3Content)).
+			File(llb.Mkdir("patches", 0o755)).
+			File(llb.Mkfile(src2Patch4File, 0o600, src2Patch4Content)).
+			File(llb.Mkfile(src2Patch5File, 0o600, src2Patch5Content))
 
 		spec := dalec.Spec{
 			Name:        "test-sysext-build",
@@ -1746,11 +1160,12 @@ echo "$BAR" > bar.txt
 				t.Fatalf("error marshalling llb: %v", defErr)
 			}
 
-			sr = gwclient.SolveRequest{
+			res, resErr := gwc.Solve(ctx, gwclient.SolveRequest{
 				Definition: def.ToPB(),
+			})
+			if resErr != nil {
+				t.Fatal(resErr)
 			}
-
-			res = solveT(ctx, t, gwc, sr)
 
 			ref, refErr = res.SingleRef()
 			if refErr != nil {
@@ -1845,7 +1260,7 @@ WantedBy=multi-user.target
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 
@@ -1871,7 +1286,7 @@ WantedBy=multi-user.target
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 
@@ -1900,7 +1315,7 @@ WantedBy=multi-user.target
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -2016,7 +1431,7 @@ Environment="FOO_ARGS=--some-foo-args"
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -2073,7 +1488,7 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -2127,755 +1542,7 @@ Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/boot
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace directive", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		spec := &dalec.Spec{
-			Name:        "test-gomod-replace",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod replace directive",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Inline: &dalec.SourceInline{
-						Dir: &dalec.SourceInlineDir{
-							Files: map[string]*dalec.SourceInlineFile{
-								"go.mod": {Contents: "module example.com/test\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n"},
-								"main.go": {Contents: `package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`},
-							},
-						},
-					},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					// Verify go.mod was patched with replace directive and correct version
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/go.mod"},
-					{Command: "grep -F 'github.com/stretchr/testify v1.8.0' ./src/go.mod"},
-					// Build the code - will fail if replace didn't work
-					{Command: "cd ./src && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace directive incompatible version", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		spec := &dalec.Spec{
-			Name:        "test-gomod-replace-incompatible",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod replace directive with in-compatible version",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Inline: &dalec.SourceInline{
-						Dir: &dalec.SourceInlineDir{
-							Files: map[string]*dalec.SourceInlineFile{
-								"go.mod": {Contents: "module example.com/test\n\ngo 1.18\n\nrequire github.com/docker/cli v29.2.1+incompatible\n"},
-								"main.go": {Contents: `package main
-
-import _ "github.com/docker/cli/pkg/kvfile"
-
-func main() {}
-`},
-							},
-						},
-					},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/docker/cli", Update: "github.com/docker/cli@v29.2.1"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "grep -F 'replace github.com/docker/cli => github.com/docker/cli v29.2.1+incompatible' ./src/go.mod"},
-					{Command: "[ -d \"${GOMODCACHE}/github.com/docker/cli@v29.2.1+incompatible\" ]"},
-					{Command: "cd ./src && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod multi-module with paths", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		opts := dalec.ProgressGroup("gomod-multi-module")
-
-		// Create a multi-module repo with two modules
-		contextSt := llb.Scratch().
-			File(llb.Mkdir("/module1", 0755), opts).
-			File(llb.Mkfile("/module1/go.mod", 0644, []byte("module example.com/module1\n\ngo 1.18\n")), opts).
-			File(llb.Mkfile("/module1/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("module1")
-	assert.True(nil, true)
-}
-`)), opts).
-			File(llb.Mkdir("/module2", 0755), opts).
-			File(llb.Mkfile("/module2/go.mod", 0644, []byte("module example.com/module2\n\ngo 1.18\n")), opts).
-			File(llb.Mkfile("/module2/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("module2")
-	assert.True(nil, true)
-}
-`)), opts)
-
-		const contextName = "multi-module-edits"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-multi-module",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod multi-module with paths",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Paths: []string{"module1", "module2"},
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify@v1.7.0", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					// Verify both modules were patched with replace directive
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/module1/go.mod"},
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/module2/go.mod"},
-					{Command: "cd ./src/module1 && go build"},
-					{Command: "cd ./src/module2 && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod with subpath", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		opts := dalec.ProgressGroup("gomod-subpath")
-
-		// Create a context with a subdirectory structure
-		contextSt := llb.Scratch().
-			File(llb.Mkdir("/subdir", 0755), opts).
-			File(llb.Mkfile("/subdir/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n")), opts).
-			File(llb.Mkfile("/subdir/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`)), opts)
-
-		const contextName = "subpath-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-subpath",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod with subpath",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Subpath: "subdir",
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify@v1.7.0", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					// Verify the go.mod in subdir was patched with replace directive
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/subdir/go.mod"},
-					{Command: "cd ./src/subdir && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace with vendor directory", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		pg := dalec.ProgressGroup("Setup test context")
-		contextSt := llb.Scratch().
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n")), pg).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`)), pg).
-			File(llb.Mkdir("/vendor/github.com/stretchr/testify/assert", 0755, llb.WithParents(true)), pg).
-			File(llb.Mkfile("/vendor/modules.txt", 0644, []byte(`# github.com/stretchr/testify v1.9.0
-## explicit; go 1.17
-github.com/stretchr/testify/assert
-`)), pg).
-			File(llb.Mkfile("/vendor/github.com/stretchr/testify/VERSION", 0644, []byte("v1.9.0\n")), pg).
-			File(llb.Mkfile("/vendor/github.com/stretchr/testify/assert/assertions.go", 0644, []byte(`// Package assert - stub for v1.9.0
-package assert
-
-// True stub
-func True(t interface{}, value bool, msgAndArgs ...interface{}) bool {
-	return value
-}
-`)), pg)
-
-		const contextName = "vendor-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-vendor",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod replace with vendor directory",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/go.mod"},
-					{Command: "grep -F 'github.com/stretchr/testify v1.8.0' ./src/go.mod"},
-					{Command: "grep -F 'v1.8.0' ./src/vendor/modules.txt"},
-					{Command: "cd ./src && go build -mod=vendor"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace with go work only", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		pg := dalec.ProgressGroup("Setup test context")
-		contextSt := llb.Scratch().
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n")), pg).
-			File(llb.Mkfile("/go.work", 0644, []byte("go 1.18\n\nuse .\n")), pg).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`)), pg)
-
-		const contextName = "gowork-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-gowork",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod with go.work",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/go.mod"},
-					{Command: "grep -F 'github.com/stretchr/testify v1.8.0' ./src/go.mod"},
-					// Verify go.work was updated to match go.mod version if it was bumped
-					{Command: "cd ./src && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace with go work and vendor", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		pg := dalec.ProgressGroup("Setup test context")
-		contextSt := llb.Scratch().
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n")), pg).
-			File(llb.Mkfile("/go.work", 0644, []byte("go 1.18\n\nuse .\n")), pg).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`)), pg).
-			File(llb.Mkdir("/vendor/github.com/stretchr/testify/assert", 0755, llb.WithParents(true)), pg).
-			File(llb.Mkfile("/vendor/modules.txt", 0644, []byte(`## workspace
-# github.com/stretchr/testify v1.9.0
-## explicit; go 1.17
-github.com/stretchr/testify/assert
-`)), pg).
-			File(llb.Mkfile("/vendor/github.com/stretchr/testify/assert/assertions.go", 0644, []byte(`// Package assert - stub for v1.9.0
-package assert
-
-// True stub
-func True(t interface{}, value bool, msgAndArgs ...interface{}) bool {
-	return value
-}
-`)), pg)
-
-		const contextName = "gowork-vendor-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-gowork-vendor",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod with go.work and vendor",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/go.mod"},
-					{Command: "grep -F 'github.com/stretchr/testify v1.8.0' ./src/go.mod"},
-					// Verify go.work was patched
-					{Command: "test -f ./src/go.work"},
-					// Verify it builds (vendor may or may not be complete depending on Go version)
-					// Go 1.22+ will have full vendor via 'go work vendor'
-					// Go < 1.22 will have partial vendor via 'GOWORK=off go mod vendor'
-					{Command: "cd ./src && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod replace with go work and vendor syncs workspace transitive deps", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		// 'go work vendor' requires Go 1.22+. On older distros the script falls back
-		// to 'GOWORK=off go mod vendor', which does not walk workspace sub-modules.
-		// Skip rather than fail on those targets.
-		skip.If(t, !testConfig.SupportsGomodVersionUpdate,
-			"Test requires Go 1.22+ for 'go work vendor' support")
-
-		// This test specifically covers the case where a replace directive introduces
-		// a transitive dependency that is only reachable through a workspace sub-module,
-		// not the root module. With the correct 'go work vendor' behaviour, the dep
-		// must appear in vendor/. With the broken 'GOWORK=off go mod vendor' fallback
-		// it will be missing, causing a GOPROXY=off build failure.
-		pg := dalec.ProgressGroup("Setup test context")
-		contextSt := llb.Scratch().
-			// Root module — no dependencies at all. This is critical: with GOWORK=off
-			// go mod vendor, the root has nothing to vendor so testify would be absent.
-			// Only 'go work vendor' walks the full workspace and vendors sub-module deps.
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/root\n\ngo 1.18\n")), pg).
-			File(llb.Mkfile("/go.work", 0644, []byte("go 1.18\n\nuse .\nuse ./sub\n")), pg).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-func main() {}
-`)), pg).
-			// Sub-module — requires testify. Only reachable via go.work, not via root go.mod.
-			File(llb.Mkdir("/sub", 0755), pg).
-			File(llb.Mkfile("/sub/go.mod", 0644, []byte(
-				"module example.com/sub\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n",
-			)), pg).
-			File(llb.Mkfile("/sub/sub.go", 0644, []byte(`package sub
-import _ "github.com/stretchr/testify/assert"
-`)), pg).
-			// Minimal vendor dir — just a marker file so gomod-patch.sh knows to run
-			// 'go work vendor'. Contains NO pre-existing testify files, so if testify
-			// appears in vendor after patching it proves 'go work vendor' ran (not
-			// 'GOWORK=off go mod vendor', which would produce an empty vendor for a
-			// root module with no dependencies). Adding files via patch is safe from
-			// the dpkg-source --include-removal issue; only deletions are skipped.
-			File(llb.Mkdir("/vendor", 0755), pg).
-			File(llb.Mkfile("/vendor/modules.txt", 0644, []byte("## workspace\n")), pg)
-
-		const contextName = "gowork-vendor-transitive-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-gowork-vendor-transitive",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing that go work vendor syncs workspace sub-module transitive deps",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										// Bump testify — this is only a dep of the sub-module,
-										// not the root. GOWORK=off go mod vendor would miss it.
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					// testify/assert must be present in the vendor directory.
-					// This is only possible if 'go work vendor' walked the full workspace
-					// graph and included the sub-module's dependencies. If the broken
-					// 'GOWORK=off go mod vendor' fallback ran instead, only the root module's
-					// dependencies would be vendored — and the root module doesn't require
-					// testify, so it would be absent.
-					{Command: "test -d ./src/vendor/github.com/stretchr/testify/assert"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("gomod go work version sync", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		skip.If(t, !testConfig.SupportsGomodVersionUpdate,
-			"Test requires Go 1.21+ for automatic toolchain management")
-
-		// Start with go.mod and go.work both at go 1.18
-		// Verify that go.work stays in sync with go.mod
-		pg := dalec.ProgressGroup("Setup test context")
-		contextSt := llb.Scratch().
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n\nrequire go.etcd.io/etcd/client/v3 v3.5.0\n")), pg).
-			File(llb.Mkfile("/go.work", 0644, []byte("go 1.18\n\nuse .\n")), pg).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	_ "go.etcd.io/etcd/client/v3"
-)
-func main() {
-	fmt.Println("hello")
-}
-`)), pg)
-
-		const contextName = "gowork-version-sync-test"
-		spec := &dalec.Spec{
-			Name:        "test-gomod-gowork-version-sync",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing gomod go.work version synchronization",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										// v3.5.14 requires go 1.21, which will bump go.mod from 1.18 to 1.21
-										{Original: "go.etcd.io/etcd/client/v3", Update: "go.etcd.io/etcd/client/v3@v3.5.14"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "grep -F 'replace go.etcd.io/etcd/client/v3' ./src/go.mod"},
-					{Command: "grep -F 'go.etcd.io/etcd/client/v3 v3.5.14' ./src/go.mod"},
-					// Verify go.work exists
-					{Command: "test -f ./src/go.work"},
-					// Verify the go versions in go.mod and go.work match exactly
-					{Command: "test \"$(grep '^go ' ./src/go.mod | head -1)\" = \"$(grep '^go ' ./src/go.work | head -1)\""},
-					// Verify it builds without version mismatch errors
-					{Command: "cd ./src && go build"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			solveT(ctx, t, client, req)
-		})
-	})
-
-	t.Run("git source with keep git dir and gomod replace", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(baseCtx, t)
-
-		// Verifies that sources with a .git directory work with gomod replace.
-		opts := dalec.ProgressGroup("keepgitdir-gomod-replace")
-
-		contextSt := llb.Scratch().
-			File(llb.Mkfile("/go.mod", 0644, []byte("module example.com/test\n\ngo 1.18\n\nrequire github.com/stretchr/testify v1.9.0\n")), opts).
-			File(llb.Mkfile("/main.go", 0644, []byte(`package main
-import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
-)
-func main() {
-	fmt.Println("hello")
-	assert.True(nil, true)
-}
-`)), opts).
-			File(llb.Mkdir("/.git", 0755), opts).
-			File(llb.Mkfile("/.git/config", 0644, []byte("[core]\nrepositoryformatversion = 0\n")), opts).
-			File(llb.Mkfile("/.git/HEAD", 0644, []byte("ref: refs/heads/main\n")), opts)
-
-		const contextName = "keepgitdir-context"
-		spec := &dalec.Spec{
-			Name:        "test-keepgitdir-gomod-replace",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Testing keepGitDir with gomod replace directive",
-			Sources: map[string]dalec.Source{
-				"src": {
-					Context: &dalec.SourceContext{Name: contextName},
-					Generate: []*dalec.SourceGenerator{
-						{
-							Gomod: &dalec.GeneratorGomod{
-								Edits: &dalec.GomodEdits{
-									Replace: []dalec.GomodReplace{
-										{Original: "github.com/stretchr/testify", Update: "github.com/stretchr/testify@v1.8.0"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Build: map[string]dalec.PackageConstraints{
-					testConfig.GetPackage("golang"): {},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					// Verify go.mod was patched with replace directive
-					{Command: "grep -F 'replace github.com/stretchr/testify' ./src/go.mod"},
-					{Command: "grep -F 'github.com/stretchr/testify v1.8.0' ./src/go.mod"},
-					// Use -buildvcs=false since we have a fake .git directory
-					{Command: "cd ./src && go build -buildvcs=false"},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
-			req.Evaluate = true
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -3004,7 +1671,7 @@ func Value() string {
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -3057,7 +1724,7 @@ func Value() string {
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			solveT(ctx, t, client, req)
 		})
 	})
@@ -3536,7 +2203,7 @@ func Value() string {
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			sr := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			sr := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			sr.Evaluate = true
 			solveT(ctx, t, client, sr)
 		})
@@ -3663,7 +2330,7 @@ func Value() string {
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			sr := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			sr := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
 			sr.Evaluate = true
 			solveT(ctx, t, client, sr)
 		})
@@ -3879,7 +2546,7 @@ func testNodeNpmGenerator(ctx context.Context, t *testing.T, targetCfg targetCon
 	}
 
 	testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-		reqOpts := append([]srOpt{withBuildTarget(targetCfg.Package), withSpec(ctx, t, spec)}, opts...)
+		reqOpts := append([]srOpt{withBuildTarget(targetCfg.Container), withSpec(ctx, t, spec)}, opts...)
 		req := newSolveRequest(reqOpts...)
 		solveT(ctx, t, client, req)
 	})
@@ -3926,7 +2593,7 @@ func testCustomLinuxWorker(ctx context.Context, t *testing.T, targetCfg targetCo
 		}
 
 		// Make sure the built-in worker can't build this package
-		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Package))
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Container))
 		_, err := gwc.Solve(ctx, sr)
 		if err == nil {
 			t.Fatal("expected solve to fail")
@@ -3955,7 +2622,7 @@ func testCustomLinuxWorker(ctx context.Context, t *testing.T, targetCfg targetCo
 
 		// Now build again with our custom worker
 		// Note, we are solving the main spec, not depSpec here.
-		sr = newSolveRequest(withSpec(ctx, t, spec), withBuildContext(ctx, t, workerCfg.ContextName, worker), withBuildTarget(targetCfg.Package))
+		sr = newSolveRequest(withSpec(ctx, t, spec), withBuildContext(ctx, t, workerCfg.ContextName, worker), withBuildTarget(targetCfg.Container))
 		solveT(ctx, t, gwc, sr)
 
 		// TODO: we should have a test to make sure this also works with source policies.
@@ -4072,12 +2739,8 @@ func testPinnedBuildDeps(ctx context.Context, t *testing.T, cfg testLinuxConfig)
 			pkg := reqToState(ctx, client, sr, t)
 			pkgs = append(pkgs, pkg)
 		}
-
-		pg := dalec.ProgressGroup("Get worker")
-
 		repoPath := filepath.Join("/opt/repo", createRepoSuffix())
-
-		return w.With(cfg.Worker.CreateRepo(llb.Merge(pkgs, pg), repoPath))
+		return w.With(cfg.Worker.CreateRepo(llb.Merge(pkgs), repoPath))
 	}
 
 	for _, tt := range tests {
@@ -4152,7 +2815,7 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package))
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
 			res := solveT(ctx, t, gwc, sr)
 			_, err := res.SingleRef()
 			assert.NilError(t, err)
@@ -4207,7 +2870,7 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package))
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
 			res := solveT(ctx, t, gwc, sr)
 			_, err := res.SingleRef()
 			assert.NilError(t, err)
@@ -4274,7 +2937,7 @@ func testLinuxLibArtirfacts(ctx context.Context, t *testing.T, cfg testLinuxConf
 		}
 
 		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package))
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
 			res := solveT(ctx, t, gwc, sr)
 			_, err := res.SingleRef()
 			assert.NilError(t, err)
@@ -4318,7 +2981,7 @@ func testLinuxSymlinkArtifacts(ctx context.Context, t *testing.T, cfg testLinuxC
 	}
 
 	testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package))
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
 		res := solveT(ctx, t, client, sr)
 		_, err := res.SingleRef()
 		assert.NilError(t, err)
@@ -4410,172 +3073,258 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)
 
-		spec := &dalec.Spec{
-			Name:        "test-package-tests",
-			Version:     "0.0.1",
-			Revision:    "42",
-			Description: "Testing package tests",
-			License:     "MIT",
-			Dependencies: &dalec.PackageDependencies{
-				Test: map[string]dalec.PackageConstraints{"bash": {}},
-			},
-			Image: &dalec.ImageConfig{
-				Post: &dalec.PostInstall{
-					Symlinks: map[string]dalec.SymlinkTarget{
-						"/usr/bin/a-thing-for-symlinking": {Paths: []string{"/some_symlink1"}},
+		newSpec := func() *dalec.Spec {
+			return &dalec.Spec{
+				Name:        "test-package-tests",
+				Version:     "0.0.1",
+				Revision:    "42",
+				Description: "Testing package tests",
+				License:     "MIT",
+				Dependencies: &dalec.PackageDependencies{
+					Test: map[string]dalec.PackageConstraints{"bash": {}},
+				},
+				Image: &dalec.ImageConfig{
+					Post: &dalec.PostInstall{
+						Symlinks: map[string]dalec.SymlinkTarget{
+							"/usr/bin/a-thing-for-symlinking": {Paths: []string{"/some_symlink1"}},
+						},
 					},
 				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{
-						Command: "touch a-thing-for-symlinking",
+				Build: dalec.ArtifactBuild{
+					Steps: []dalec.BuildStep{
+						{
+							Command: "touch a-thing-for-symlinking",
+						},
 					},
 				},
-			},
-			Artifacts: dalec.Artifacts{
-				Binaries: map[string]dalec.ArtifactConfig{
-					"a-thing-for-symlinking": {},
+				Artifacts: dalec.Artifacts{
+					Binaries: map[string]dalec.ArtifactConfig{
+						"a-thing-for-symlinking": {},
+					},
+					Links: []dalec.ArtifactSymlinkConfig{
+						{
+							Source: "/usr/bin/a-thing-for-symlinking",
+							Dest:   "/some_symlink2",
+						},
+						{
+							Source: "/not-a-real-path3",
+							Dest:   "/some_symlink3",
+						},
+						{
+							Source: "/not-a-real-path4",
+							Dest:   "/some_symlink4",
+						},
+					},
 				},
-				Links: []dalec.ArtifactSymlinkConfig{
-					{
-						Source: "/usr/bin/a-thing-for-symlinking",
-						Dest:   "/some_symlink2",
-					},
-					{
-						Source: "/not-a-real-path3",
-						Dest:   "/some_symlink3",
-					},
-					{
-						Source: "/not-a-real-path4",
-						Dest:   "/some_symlink4",
-					},
-				},
-			},
-			Tests: []*dalec.TestSpec{
-				{
-					Name: "Test that tests fail the build",
+			}
+		}
+
+		type testCase struct {
+			err          error
+			test         *dalec.TestSpec
+			isBuildError bool
+		}
+
+		// Because buildkit solves are fail-fast (the build is cancelled on the first failure), the only way to deterministically test
+		// multiple failure cases is to have separate builds for each expected failure.
+		expectedErrs := []testCase{
+			{
+				err: (&dalec.CheckOutputError{Path: "/non-existing-file", Kind: dalec.CheckFileNotExistsKind, Expected: "exists=true", Actual: "exists=false"}),
+				test: &dalec.TestSpec{
+					Name: "Test that non-existing file with no options fails the build",
 					Files: map[string]dalec.FileCheckOutput{
 						"/non-existing-file": {},
 					},
 				},
-				{
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/", Kind: dalec.CheckFilePermissionsKind, Expected: "-rw-r--r--", Actual: "-rwxr-xr-x"}),
+				test: &dalec.TestSpec{
 					Name: "Test that permissions check fails the build",
 					Files: map[string]dalec.FileCheckOutput{
 						"/": {Permissions: 0o644, IsDir: true},
 					},
 				},
-				{
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/", Kind: dalec.CheckFileIsDirKind, Expected: "is_dir=false", Actual: "is_dir=true"}),
+				test: &dalec.TestSpec{
 					Name: "Test that dir check fails the build",
 					Files: map[string]dalec.FileCheckOutput{
 						"/": {IsDir: false},
 					},
 				},
-				{
-					Name: "Test that command exiting non-zero fails the build",
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/some_symlink1", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/not-a-real-path1", Actual: "/usr/bin/a-thing-for-symlinking"}),
+				test: &dalec.TestSpec{
+					Name: "Test that image post symlink target check fails the build",
+					Files: map[string]dalec.FileCheckOutput{
+						"/some_symlink1": {
+							LinkTarget: "/not-a-real-path1",
+						},
+					},
+				},
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/some_symlink2", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/not-a-real-path2", Actual: "/usr/bin/a-thing-for-symlinking"}),
+				test: &dalec.TestSpec{
+					Name: "Test that artifact symlink target check fails the build",
+					Files: map[string]dalec.FileCheckOutput{
+						"/some_symlink2": {
+							LinkTarget: "/not-a-real-path2",
+						},
+					},
+				},
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/some_symlink3", Kind: dalec.CheckFileNotExistsKind, Expected: "exists=true", Actual: "exists=false"}),
+				test: &dalec.TestSpec{
+					Name: "Test that artifact symlink to non-existing file check fails the build",
+					Files: map[string]dalec.FileCheckOutput{
+						"/some_symlink3": {},
+					},
+				},
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "/some_symlink4", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/incorrect-target", Actual: "/not-a-real-path4"}),
+				test: &dalec.TestSpec{
+					Name: "Test that artifact symlink nofollow link target check fails the build",
+					Files: map[string]dalec.FileCheckOutput{
+						"/some_symlink4": {
+							NoFollow:   true,
+							LinkTarget: "/incorrect-target",
+						},
+					},
+				},
+			},
+			{
+				err:          &moby_buildkit_v1_frontend.ExitError{ExitCode: 42, Err: fmt.Errorf("step did not complete successfully")},
+				isBuildError: true,
+				test: &dalec.TestSpec{
+					Name: "Test that command exit code check fails the build",
 					Steps: []dalec.TestStep{
 						{Command: "/bin/sh -ec 'exit 42'"},
 					},
 				},
-				{
-					Name: "Test that command giving the wrong output fails the build",
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "stdout", Kind: dalec.CheckOutputEqualsKind, Expected: "stdout not hello", Actual: "hello\n"}),
+				test: &dalec.TestSpec{
+					Name: "Test that stdout check fails the build",
 					Steps: []dalec.TestStep{
 						{
 							Command: "/bin/sh -ec 'echo hello'",
 							Stdout: dalec.CheckOutput{
 								Equals: "stdout not hello",
 							},
+						},
+					},
+				},
+			},
+			{
+				err: (&dalec.CheckOutputError{Path: "stderr", Kind: dalec.CheckOutputEqualsKind, Expected: "stderr not hello", Actual: "hello\n"}),
+				test: &dalec.TestSpec{
+					Name: "Test that stderr check fails the build",
+					Steps: []dalec.TestStep{
+						{
+							Command: "/bin/sh -ec 'echo hello >&2'",
 							Stderr: dalec.CheckOutput{
 								Equals: "stderr not hello",
 							},
 						},
 					},
 				},
-				{
-					Name: "Test that incorrect symlink path targets fail the build",
-					Files: map[string]dalec.FileCheckOutput{
-						"/some_symlink1": {
-							LinkTarget: "/not-a-real-path1",
-						},
-						"/some_symlink2": {
-							LinkTarget: "/not-a-real-path2",
-						},
-						// check that a symlink pointing to a non-existent path with NoFollow=false should error (with a CheckFileNotExistsKind)
-						"/some_symlink3": {},
-						// And then that we can check symlink target with NoFollow=true when the target doesn't exist
-						"/some_symlink4": {NoFollow: true, LinkTarget: "/incorrect-target"},
-					},
-				},
 			},
 		}
 
-		expectedErrors := []string{
-			(&dalec.CheckOutputError{Path: "/non-existing-file", Kind: dalec.CheckFileNotExistsKind, Expected: "exists=true", Actual: "exists=false"}).Error(),
-			(&dalec.CheckOutputError{Path: "/", Kind: dalec.CheckFilePermissionsKind, Expected: "-rw-r--r--", Actual: "-rwxr-xr-x"}).Error(),
-			(&dalec.CheckOutputError{Path: "/", Kind: dalec.CheckFileIsDirKind, Expected: "ModeFile", Actual: "ModeDir"}).Error(),
-			(&dalec.CheckOutputError{Path: "/some_symlink1", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/not-a-real-path1", Actual: "/usr/bin/a-thing-for-symlinking"}).Error(),
-			(&dalec.CheckOutputError{Path: "/some_symlink2", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/not-a-real-path2", Actual: "/usr/bin/a-thing-for-symlinking"}).Error(),
-			(&dalec.CheckOutputError{Path: "/some_symlink3", Kind: dalec.CheckFileNotExistsKind, Expected: "exists=true", Actual: "exists=false"}).Error(),
-			(&dalec.CheckOutputError{Path: "/some_symlink4", Kind: dalec.CheckFileLinkTargetPathKind, Expected: "/incorrect-target", Actual: "/not-a-real-path4"}).Error(),
-			"step did not complete successfully: exit code: 42",
-			"stdout not hello",
-			"stderr not hello",
+		newLogFile := func(t *testing.T) *os.File {
+			t.Helper()
+			dir := t.TempDir()
+			f, err := os.OpenFile(filepath.Join(dir, "solve-status-log.txt"), os.O_CREATE|os.O_RDWR, 0o644)
+			assert.NilError(t, err)
+			t.Cleanup(func() { f.Close() })
+
+			return f
 		}
 
-		testForTarget := func(target string) func(t *testing.T) {
+		runTest := func(target string) func(t *testing.T) {
 			return func(t *testing.T) {
 				t.Parallel()
-
-				dir := t.TempDir()
-				f, err := os.OpenFile(filepath.Join(dir, "out.txt"), os.O_CREATE|os.O_RDWR, 0o600)
-				assert.NilError(t, err)
-				defer f.Close()
-
-				consumeLogs := func(status *client.SolveStatus) {
-					if status == nil {
-						return
-					}
-
-					for _, v := range status.Logs {
-						_, err := f.Write(v.Data)
-						assert.NilError(t, err)
-					}
-				}
-
 				ctx := startTestSpan(ctx, t)
-				testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-					sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(target))
-					_, err := client.Solve(ctx, sr)
-					assert.Assert(t, err != nil)
 
-					// Make sure the error is an exit error
-					var xErr *moby_buildkit_v1_frontend.ExitError
-					assert.Check(t, cmp.ErrorType(pkgerrors.Cause(err), xErr))
-				}, testenv.WithSolveStatusFn(consumeLogs))
+				for _, tc := range expectedErrs {
+					t.Run(tc.test.Name, func(t *testing.T) {
+						t.Parallel()
+						ctx := startTestSpan(ctx, t)
 
-				_, err = f.Seek(0, 0)
-				assert.NilError(t, err)
+						f := newLogFile(t)
 
-				dt, err := io.ReadAll(f)
-				assert.NilError(t, err)
+						var size int
+						solveStatusFn := testenv.WithSolveStatusFn(func(status *client.SolveStatus) {
+							if status == nil {
+								return
+							}
 
-				for _, expectErr := range expectedErrors {
-					assert.Check(t, cmp.Contains(string(dt), expectErr))
-				}
+							for _, v := range status.Logs {
+								if _, err := f.Write(v.Data); err != nil {
+									t.Error(err)
+								}
+								size += len(v.Data)
+							}
+						})
 
-				if t.Failed() {
-					t.Log("---- Full build log ----\n" + string(dt))
+						spec := newSpec()
+						spec.Tests = []*dalec.TestSpec{tc.test}
+
+						testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+							sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(target), withIgnoreCache(frontend.IgnoreCacheTestsKey))
+							_, err := client.Solve(ctx, sr)
+							assert.Assert(t, err != nil)
+
+							t.Logf("Build Error: %v", err)
+
+							var exErr *moby_buildkit_v1_frontend.ExitError
+							assert.Assert(t, errors.As(err, &exErr), "expected exit error, got: %v", err)
+
+							if !tc.isBuildError {
+								// the error we are looking for is in the build logs, not the exit error
+								return
+							}
+
+							assert.Equal(t, exErr.ExitCode, tc.err.(*moby_buildkit_v1_frontend.ExitError).ExitCode)
+						}, solveStatusFn)
+
+						if tc.isBuildError {
+							return
+						}
+
+						_, err := f.Seek(0, io.SeekStart)
+						assert.NilError(t, err)
+
+						dt, err := io.ReadAll(f)
+						assert.NilError(t, err)
+
+						if !bytes.Contains(dt, []byte(tc.err.Error())) {
+							t.Errorf("expected error not found in logs")
+							t.Logf("Expected error:\n\t%v", tc.err)
+						}
+					})
 				}
 			}
 		}
 
-		t.Run("package", testForTarget(cfg.Target.Package))
-		t.Run("container", testForTarget(cfg.Target.Package))
+		t.Run(path.Base(cfg.Target.Package), runTest(cfg.Target.Package))
+		t.Run(path.Base(cfg.Target.Container), runTest(cfg.Target.Container))
 	})
 
 	t.Run("positive test", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
+
+		equalCheck := func(v string) dalec.CheckOutput {
+			return dalec.CheckOutput{Equals: v}
+		}
 
 		spec := &dalec.Spec{
 			Name:        "test-package-tests",
@@ -4627,6 +3376,24 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 						"/some_symlink1": {LinkTarget: "/usr/share/test-file"},
 						"/some_symlink2": {LinkTarget: "/usr/share/test-file"},
 						"/some_symlink3": {LinkTarget: "/not-a-real-file", NoFollow: true},
+					},
+				},
+				{
+					Name: "Test multiple commands with no fs changes",
+					Steps: []dalec.TestStep{
+						{Command: "/bin/sh -ec 'echo command one'"},
+						{Command: "/bin/sh -ec 'echo command two'"},
+						{Command: "/bin/sh -ec 'echo command three'"},
+						{Command: "/bin/sh -ec 'echo command four'"},
+					},
+				},
+				{
+					Name: "Test multiple commands with stdio checks",
+					Steps: []dalec.TestStep{
+						{Command: "/bin/sh -ec 'echo command one'", Stdout: equalCheck("command one\n")},
+						{Command: "/bin/sh -ec 'echo command two'"},
+						{Command: "/bin/sh -ec 'echo command three'", Stdout: equalCheck("command three\n")},
+						{Command: "/bin/sh -ec 'echo command four'"},
 					},
 				},
 				{
@@ -4700,16 +3467,26 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 			},
 		}
 
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package))
-			res := solveT(ctx, t, client, sr)
-			_, err := res.SingleRef()
-			assert.NilError(t, err)
+		t.Run(path.Base(cfg.Target.Package), func(t *testing.T) {
+			t.Parallel()
+			ctx = startTestSpan(baseCtx, t)
+			testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+				sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package), withIgnoreCache(frontend.IgnoreCacheTestsKey))
+				res := solveT(ctx, t, client, sr)
+				_, err := res.SingleRef()
+				assert.NilError(t, err)
+			})
+		})
 
-			sr = newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
-			res = solveT(ctx, t, client, sr)
-			_, err = res.SingleRef()
-			assert.NilError(t, err)
+		t.Run(path.Base(cfg.Target.Container), func(t *testing.T) {
+			t.Parallel()
+			ctx := startTestSpan(baseCtx, t)
+			testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+				sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container), withIgnoreCache(frontend.IgnoreCacheTestsKey))
+				res := solveT(ctx, t, client, sr)
+				_, err := res.SingleRef()
+				assert.NilError(t, err)
+			})
 		})
 	})
 }
@@ -4883,6 +3660,7 @@ func testDisableStrip(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
 
 			req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Container))
 			solveT(ctx, t, client, req)
+
 		})
 	})
 
@@ -5171,7 +3949,9 @@ func testDisableAutoRequire(ctx context.Context, t *testing.T, cfg targetConfig)
 		spec := newSimpleSpec()
 		spec.Artifacts = dalec.Artifacts{
 			Binaries: map[string]dalec.ArtifactConfig{
-				"test": {},
+				"test": {
+					SubPath: "dalec",
+				},
 			},
 		}
 
@@ -5573,6 +4353,7 @@ echo "This is a third test binary"
 		},
 		Targets: map[string]dalec.Target{
 			"azlinux3":    rpmTarget,
+			"mariner2":    rpmTarget,
 			"almalinux8":  rpmTarget,
 			"almalinux9":  rpmTarget,
 			"rockylinux8": rpmTarget,
@@ -5642,111 +4423,4 @@ echo "This is a third test binary"
 			t.Fatal(err)
 		}
 	})
-}
-
-func testDepsOnly(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
-	t.Run("minimal spec", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(ctx, t)
-
-		spec := &dalec.Spec{
-			Dependencies: &dalec.PackageDependencies{
-				Runtime: map[string]dalec.PackageConstraints{
-					"curl": {},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(testConfig.Target.DepsOnly))
-			res := solveT(ctx, t, client, req)
-
-			ref, err := res.SingleRef()
-			assert.NilError(t, err)
-
-			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/curl"})
-			assert.NilError(t, err)
-		})
-	})
-
-	t.Run("full spec", func(t *testing.T) {
-		t.Parallel()
-		ctx := startTestSpan(ctx, t)
-
-		// Full spec includes sources, build steps, and a shell script artifact.
-		// The deps-only target should install only runtime deps (curl) and NOT
-		// include the built artifact (/usr/bin/my-script) or its implicit dep.
-		spec := fillMetadata("test-deps-only-full", &dalec.Spec{
-			Sources: map[string]dalec.Source{
-				"my-script": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello from deps-only test\n",
-							Permissions: 0o700,
-						},
-					},
-				},
-			},
-			Build: dalec.ArtifactBuild{
-				Steps: []dalec.BuildStep{
-					{Command: "/bin/true"},
-				},
-			},
-			Artifacts: dalec.Artifacts{
-				Binaries: map[string]dalec.ArtifactConfig{
-					"my-script": {},
-				},
-			},
-			Dependencies: &dalec.PackageDependencies{
-				Runtime: map[string]dalec.PackageConstraints{
-					"curl": {},
-				},
-			},
-		})
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(testConfig.Target.DepsOnly))
-			res := solveT(ctx, t, client, req)
-
-			ref, err := res.SingleRef()
-			assert.NilError(t, err)
-
-			// Runtime dep should be installed.
-			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/curl"})
-			assert.NilError(t, err)
-
-			// The shell script artifact should NOT be present — deps-only
-			// never builds the package, so no artifacts are installed.
-			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/my-script"})
-			assert.ErrorContains(t, err, "no such file")
-		})
-	})
-}
-
-func testLinuxSpec(t *testing.T, userSpec dalec.Spec) dalec.Spec {
-	t.Helper()
-
-	result := dalec.Spec{
-		Name:        "test-container-build",
-		Version:     "0.0.1",
-		Revision:    "1",
-		License:     "MIT",
-		Website:     "https://github.com/project-dalec/dalec",
-		Vendor:      "Dalec",
-		Packager:    "Dalec",
-		Description: "Testing container target",
-
-		Dependencies: &dalec.PackageDependencies{
-			Runtime: map[string]dalec.PackageConstraints{
-				"coreutils": {},
-			},
-		},
-	}
-
-	userSpecRaw, err := json.Marshal(userSpec)
-	assert.NilError(t, err, "marshaling user spec to json")
-
-	assert.NilError(t, json.Unmarshal(userSpecRaw, &result), "unmarshalling user spec into result spec")
-
-	return result
 }

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -2880,6 +2880,81 @@ func main() {
 		})
 	})
 
+	t.Run("go module replace", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		pg := dalec.ProgressGroup("Setup gomod replace context")
+
+		contextSt := llb.Scratch().
+			File(llb.Mkfile("/go.mod", 0o644, []byte("module example.com/app\n\ngo 1.18\n\nrequire example.com/dep v0.0.0\n")), pg).
+			File(llb.Mkfile("/main.go", 0o644, []byte(`package main
+
+import (
+	"fmt"
+
+	"example.com/dep"
+)
+
+func main() {
+	fmt.Println(dep.Value())
+}
+`)), pg).
+			File(llb.Mkdir("/dep", 0o755), pg).
+			File(llb.Mkfile("/dep/go.mod", 0o644, []byte("module example.com/dep\n\ngo 1.18\n")), pg).
+			File(llb.Mkfile("/dep/dep.go", 0o644, []byte(`package dep
+
+func Value() string {
+	return "local dep"
+}
+`)), pg)
+
+		const contextName = "gomod-replace-package-test"
+
+		spec := &dalec.Spec{
+			Name:        "test-build-with-gomod-replace",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/project-dalec/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Testing package target gomod replace preprocessing",
+			Sources: map[string]dalec.Source{
+				"src": {
+					Context: &dalec.SourceContext{Name: contextName},
+					Generate: []*dalec.SourceGenerator{
+						{
+							Gomod: &dalec.GeneratorGomod{
+								Edits: &dalec.GomodEdits{
+									Replace: []dalec.GomodReplace{
+										{Original: "example.com/dep", Update: "./dep"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: &dalec.PackageDependencies{
+				Build: map[string]dalec.PackageConstraints{
+					testConfig.GetPackage("golang"): {},
+				},
+			},
+			Build: dalec.ArtifactBuild{
+				Steps: []dalec.BuildStep{
+					{Command: "grep -F 'replace example.com/dep => ./dep' ./src/go.mod"},
+					{Command: "cd ./src && go build"},
+					{Command: "test \"$(cd ./src && go run .)\" = 'local dep'"},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec), withBuildContext(ctx, t, contextName, contextSt))
+			solveT(ctx, t, client, req)
+		})
+	})
+
 	t.Run("cargo home", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)

--- a/test/testenv/build.go
+++ b/test/testenv/build.go
@@ -18,7 +18,6 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -183,6 +182,46 @@ var logBufferPool = &sync.Pool{New: func() any {
 	return bytes.NewBuffer(nil)
 }}
 
+func outputStreamStatusFn(ctx context.Context, t *testing.T) (func(*client.SolveStatus), func()) {
+	var (
+		warnings []*client.VertexWarning
+		errOnce  sync.Once
+
+		done = make(chan struct{})
+		w    = getBuildOutputStream(ctx, t, done)
+	)
+
+	fn := func(msg *client.SolveStatus) {
+		warnings = append(warnings, msg.Warnings...)
+		for _, l := range msg.Logs {
+			if _, err := w.Write(l.Data); err != nil {
+				errOnce.Do(func() {
+					// Don't spam the logs with multiple errors
+					t.Logf("error writing log data: %v", err)
+				})
+			}
+		}
+	}
+
+	return fn, func() {
+		for _, v := range warnings {
+			t.Logf("WARNING: %s", string(v.Short))
+		}
+		close(done)
+	}
+}
+
+func multiStatusFunc(fns ...func(*client.SolveStatus)) func(*client.SolveStatus) {
+	return func(msg *client.SolveStatus) {
+		for _, fn := range fns {
+			if fn == nil {
+				continue
+			}
+			fn(msg)
+		}
+	}
+}
+
 func getBuildOutputStream(ctx context.Context, t *testing.T, done <-chan struct{}) io.Writer {
 	t.Helper()
 
@@ -233,40 +272,34 @@ func getBuildOutputStream(ctx context.Context, t *testing.T, done <-chan struct{
 	return f
 }
 
-func displaySolveStatus(ctx context.Context, t *testing.T) chan *client.SolveStatus {
-	ch := make(chan *client.SolveStatus)
-	done := make(chan struct{})
-
-	output := getBuildOutputStream(ctx, t, done)
-	display, err := progressui.NewDisplay(output, progressui.AutoMode, progressui.WithPhase(t.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	go func() {
-		defer close(done)
-
-		_, err := display.UpdateFrom(ctx, ch)
-		if err != nil {
-			t.Log(err)
+func fowardToSolveStatusFn(ctx context.Context, ch <-chan *client.SolveStatus, fns ...func(*client.SolveStatus)) {
+	f := multiStatusFunc(fns...)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if msg != nil {
+				f(msg)
+				continue
+			}
+			if !ok {
+				return
+			}
 		}
-	}()
-
-	return ch
+	}
 }
 
 // withProjectRoot adds the current project root as the build context for the solve request.
-func withProjectRoot(t *testing.T, opts *client.SolveOpt) {
-	t.Helper()
-
+func withProjectRoot(opts *client.SolveOpt) error {
 	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	projectRoot, err := lookupProjectRoot(cwd)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	if opts.LocalDirs == nil {
@@ -274,6 +307,7 @@ func withProjectRoot(t *testing.T, opts *client.SolveOpt) {
 	}
 	opts.LocalDirs[dockerui.DefaultLocalNameContext] = projectRoot
 	opts.LocalDirs[dockerui.DefaultLocalNameDockerfile] = projectRoot
+	return nil
 }
 
 // lookupProjectRoot looks up the project root from the current working directory.

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"os"
 	"os/exec"
@@ -376,6 +377,104 @@ func WithSocketProxies(proxies ...socketprovider.ProxyConfig) TestRunnerOpt {
 	}
 }
 
+func setSolveOpts(cfg TestRunnerConfig, so *client.SolveOpt) error {
+	if err := withProjectRoot(so); err != nil {
+		return err
+	}
+
+	withResolveLocal(so)
+	err := withSocketProxies(cfg.SocketProxies)(so)
+	if err != nil {
+		return err
+	}
+	withDockerAuth(so)
+
+	err = withSourcePolicy(so)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range cfg.SolveOptFns {
+		f(so)
+	}
+
+	return nil
+}
+
+func (b *BuildxEnv) runTestWithStatus(ctx context.Context, t *testing.T, f TestFunc, opts ...TestRunnerOpt) iter.Seq2[*client.SolveStatus, error] {
+	var cfg TestRunnerConfig
+
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	ch := make(chan *client.SolveStatus)
+	errCh := make(chan error, 1)
+
+	c, err := b.Buildkit(ctx)
+	assert.NilError(t, err)
+
+	var so client.SolveOpt
+	err = setSolveOpts(cfg, &so)
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		_, err := c.Build(ctx, so, "", func(ctx context.Context, gwc gwclient.Client) (_ *gwclient.Result, retErr error) {
+			defer func() {
+				if r := recover(); r != nil {
+					retErr = fmt.Errorf("panic in test build function: %v", r)
+				}
+			}()
+
+			gwc = &clientForceDalecWithInput{gwc}
+			b.mu.Lock()
+			for id, f := range b.refs {
+				gwc = wrapWithInput(gwc, id, f)
+			}
+			b.mu.Unlock()
+			f(ctx, gwc)
+			return gwclient.NewResult(), nil
+		}, ch)
+
+		if err != nil {
+			errCh <- err
+			return
+		}
+	}()
+
+	return func(yield func(*client.SolveStatus, error) bool) {
+		defer cancel()
+
+		for {
+			select {
+			case <-ctx.Done():
+				yield(nil, ctx.Err())
+				return
+			case err := <-errCh:
+				if err != nil {
+					if !yield(nil, err) {
+						return
+					}
+				}
+				// there may still be statuses to read, so continue
+			case status, ok := <-ch:
+				if status != nil {
+					if !yield(status, nil) {
+						return
+					}
+					continue
+				}
+
+				if !ok {
+					return
+				}
+			}
+		}
+	}
+}
+
 func (b *BuildxEnv) RunTest(ctx context.Context, t *testing.T, f TestFunc, opts ...TestRunnerOpt) {
 	var cfg TestRunnerConfig
 
@@ -383,68 +482,32 @@ func (b *BuildxEnv) RunTest(ctx context.Context, t *testing.T, f TestFunc, opts 
 		o(&cfg)
 	}
 
-	c, err := b.Buildkit(ctx)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	statusFn, cancelOutput := outputStreamStatusFn(ctx, t)
+	defer cancelOutput()
 
-	var ch chan *client.SolveStatus
+	ch := make(chan *client.SolveStatus)
+	go fowardToSolveStatusFn(ctx, ch, statusFn, cfg.SolveStatusFn)
 
-	if cfg.SolveStatusFn != nil {
-		ch = make(chan *client.SolveStatus, 1)
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case msg, ok := <-ch:
-					cfg.SolveStatusFn(msg)
-					if !ok {
-						return
-					}
-				}
-			}
-		}()
-		t.Cleanup(func() {
-			// Make sure message processing is done before the test ends
-			select {
-			case <-ctx.Done():
-			case <-done:
-			}
-		})
-	} else {
-		ch = displaySolveStatus(ctx, t)
-	}
+	defer close(ch)
 
-	var so client.SolveOpt
-	withProjectRoot(t, &so)
-	withResolveLocal(&so)
-	withSocketProxies(t, cfg.SocketProxies)(&so)
-	withDockerAuth(&so)
-
-	err = withSourcePolicy(&so)
-	assert.NilError(t, err)
-
-	for _, f := range cfg.SolveOptFns {
-		f(&so)
-	}
-
-	_, err = c.Build(ctx, so, "", func(ctx context.Context, gwc gwclient.Client) (*gwclient.Result, error) {
-		gwc = &clientForceDalecWithInput{gwc}
-
-		b.mu.Lock()
-		for id, f := range b.refs {
-			gwc = wrapWithInput(gwc, id, f)
+	for status, err := range b.runTestWithStatus(ctx, t, f, opts...) {
+		if err != nil {
+			t.Error(err)
+			// drain the status channel
+			// the range itself will stop once everything is done
+			continue
 		}
-		b.mu.Unlock()
-		f(ctx, gwc)
-		return gwclient.NewResult(), nil
-	}, ch)
 
-	if err != nil {
-		t.Fatal(err)
+		if status == nil {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+			return
+		case ch <- status:
+		}
 	}
 }
 
@@ -539,16 +602,18 @@ func withSourcePolicy(so *client.SolveOpt) error {
 	return nil
 }
 
-func withSocketProxies(t *testing.T, proxies []socketprovider.ProxyConfig) func(*client.SolveOpt) {
-	return func(so *client.SolveOpt) {
-		t.Helper()
+func withSocketProxies(proxies []socketprovider.ProxyConfig) func(*client.SolveOpt) error {
+	return func(so *client.SolveOpt) error {
 		if len(proxies) == 0 {
-			return
+			return nil
 		}
 
 		handler, err := socketprovider.NewProxyHandler(proxies)
-		assert.NilError(t, err)
+		if err != nil {
+			return err
+		}
 		so.Session = append(so.Session, handler)
+		return nil
 	}
 }
 

--- a/tests.go
+++ b/tests.go
@@ -5,13 +5,10 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io/fs"
-	"regexp"
-	"strings"
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
-	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -61,26 +58,38 @@ type TestStep struct {
 	Stderr CheckOutput `yaml:"stderr,omitempty" json:"stderr,omitempty"`
 
 	// unexported pointer to parsed source map for this TestStep
-	_sourceMap *sourceMap `json:"-" yaml:"-"`
+	_commandSourceMap *sourceMap `json:"-" yaml:"-"`
 }
 
 func (step *TestStep) UnmarshalYAML(ctx context.Context, node ast.Node) error {
-	type internal TestStep
-	var ti internal
+	type internal struct {
+		Command sourceMappedValue[string] `yaml:"command" json:"command"`
+		Env     map[string]string         `yaml:"env,omitempty" json:"env,omitempty"`
+		Stdin   string                    `yaml:"stdin,omitempty" json:"stdin,omitempty"`
+		Stdout  CheckOutput               `yaml:"stdout,omitempty" json:"stdout,omitempty"`
+		Stderr  CheckOutput               `yaml:"stderr,omitempty" json:"stderr,omitempty"`
+	}
 
+	var i internal
 	dec := getDecoder(ctx)
-	if err := dec.DecodeFromNodeContext(ctx, node, &ti); err != nil {
+	if err := dec.DecodeFromNodeContext(ctx, node, &i); err != nil {
 		return errors.Wrap(err, "failed to decode test step")
 	}
 
-	*step = TestStep(ti)
-	step._sourceMap = newSourceMap(ctx, node)
+	*step = TestStep{
+		Command: i.Command.Value,
+		Env:     i.Env,
+		Stdin:   i.Stdin,
+		Stdout:  i.Stdout,
+		Stderr:  i.Stderr,
+	}
+	step._commandSourceMap = i.Command.sourceMap
 	return nil
 }
 
-// GetSourceLocation returns an llb.ConstraintsOpt for the TestStep
+// GetSourceLocation returns the source mapping for the TestStep's command
 func (ts *TestStep) GetSourceLocation(state llb.State) llb.ConstraintsOpt {
-	return ts._sourceMap.GetLocation(state)
+	return ts._commandSourceMap.GetLocation(state)
 }
 
 // CheckOutput is used to specify the expected output of a check, such as stdout/stderr or a file.
@@ -266,6 +275,7 @@ type CheckOutputError struct {
 	Expected string
 	Actual   string
 	Path     string
+	Index    *int
 }
 
 func (c *CheckOutputError) Error() string {
@@ -413,118 +423,41 @@ func (c *FileCheckOutput) processBuildArgs(lex *shell.Lex, args map[string]strin
 	return nil
 }
 
-// Check is used to check the output stream.
-func (c CheckOutput) Check(dt string, p string) (retErr error) {
-	if c.Empty {
-		if dt != "" {
-			return &CheckOutputError{Kind: CheckOutputEmptyKind, Expected: "", Actual: dt, Path: p}
-		}
-
-		// Anything else would be nonsensical and it would make sense to return early...
-		// But we'll check it anyway and it should fail since this would be an invalid CheckOutput
-	}
-
-	var errs []error
-	if c.Equals != "" && c.Equals != dt {
-		errs = append(errs, &CheckOutputError{Kind: CheckOutputEqualsKind, Expected: c.Equals, Actual: dt, Path: p})
-	}
-
-	for _, contains := range c.Contains {
-		if contains != "" && !strings.Contains(dt, contains) {
-			errs = append(errs, &CheckOutputError{Kind: CheckOutputContainsKind, Expected: contains, Actual: dt, Path: p})
-		}
-	}
-	for _, matches := range c.Matches {
-		regexp, err := regexp.Compile(matches)
-		if err != nil {
-			errs = append(errs, &CheckOutputError{Kind: CheckOutputMatchesKind, Expected: matches, Actual: fmt.Sprintf("invalid regexp %q: %v", matches, err), Path: p})
-			continue
-		}
-
-		if !regexp.Match([]byte(dt)) {
-			errs = append(errs, &CheckOutputError{Kind: CheckOutputMatchesKind, Expected: matches, Actual: dt, Path: p})
-		}
-	}
-
-	if c.StartsWith != "" && !strings.HasPrefix(dt, c.StartsWith) {
-		errs = append(errs, &CheckOutputError{Kind: CheckOutputStartsWithKind, Expected: c.StartsWith, Actual: dt, Path: p})
-	}
-
-	if c.EndsWith != "" && !strings.HasSuffix(dt, c.EndsWith) {
-		errs = append(errs, &CheckOutputError{Kind: CheckOutputEndsWithKind, Expected: c.EndsWith, Actual: dt, Path: p})
-	}
-
-	return goerrors.Join(errs...)
-}
-
-// Check is used to check the output file.
-func (c FileCheckOutput) Check(dt string, mode fs.FileMode, isDir bool, p, target string) error {
-	var errs []error
-
-	if c.LinkTarget != "" {
-		if c.LinkTarget != target {
-			errs = append(errs, &CheckOutputError{Kind: CheckFileLinkTargetPathKind, Expected: c.LinkTarget, Actual: target, Path: p})
-		}
-	}
-
-	if c.IsDir && !isDir {
-		errs = append(errs, &CheckOutputError{Kind: CheckFileIsDirKind, Expected: "ModeDir", Actual: "ModeFile", Path: p})
-	}
-
-	if !c.IsDir && isDir {
-		errs = append(errs, &CheckOutputError{Kind: CheckFileIsDirKind, Expected: "ModeFile", Actual: "ModeDir", Path: p})
-	}
-
-	perm := mode.Perm()
-	if c.Permissions != 0 && c.Permissions != perm {
-		errs = append(errs, &CheckOutputError{Kind: CheckFilePermissionsKind, Expected: c.Permissions.String(), Actual: perm.String(), Path: p})
-	}
-
-	errs = append(errs, c.CheckOutput.Check(dt, p))
-	return goerrors.Join(errs...)
-}
-
-// GetErrSource returns the most specific source map for the given error kind.
-// Falls back to the file-level mapping then to embedded content checks.
-func (c FileCheckOutput) GetErrSource(err *CheckOutputError) *errdefs.Source {
-	switch err.Kind {
+// GetSourceLocation returns the source maps for the check kind + index
+func (c FileCheckOutput) GetSourceLocation(state llb.State, kind string, index int) llb.ConstraintsOpt {
+	switch kind {
 	case CheckFilePermissionsKind:
-		return c.permissionsSourceMap.GetErrdefsSource()
+		return c.permissionsSourceMap.GetLocation(state)
 	case CheckFileIsDirKind:
-		return c.isDirSourceMap.GetErrdefsSource()
+		return c.isDirSourceMap.GetLocation(state)
 	case CheckFileNotExistsKind:
-		return c.notExistSourceMap.GetErrdefsSource()
+		return c.notExistSourceMap.GetLocation(state)
 	case CheckFileLinkTargetPathKind:
-		return c.linkTargetSourceMap.GetErrdefsSource()
+		return c.linkTargetSourceMap.GetLocation(state)
 	default:
 		// Delegate to embedded CheckOutput (equals/contains/...)
-		return c.CheckOutput.GetErrSource(err)
+		return c.CheckOutput.GetSourceLocation(state, kind, index)
 	}
 }
 
-func (c CheckOutput) GetErrSource(err *CheckOutputError) *errdefs.Source {
-	switch err.Kind {
+func (c CheckOutput) GetSourceLocation(state llb.State, kind string, index int) llb.ConstraintsOpt {
+	switch kind {
 	case CheckOutputContainsKind:
-		// locate matching contains entry
-		for i, v := range c.Contains {
-			if v == err.Expected && i < len(c.containsSourceMaps) && c.containsSourceMaps[i] != nil {
-				return c.containsSourceMaps[i].GetErrdefsSource()
-			}
+		if index >= 0 && index < len(c.containsSourceMaps) {
+			return c.containsSourceMaps[index].GetLocation(state)
 		}
 	case CheckOutputMatchesKind:
-		for i, v := range c.Matches {
-			if v == err.Expected && i < len(c.matchesSourceMaps) && c.matchesSourceMaps[i] != nil {
-				return c.matchesSourceMaps[i].GetErrdefsSource()
-			}
+		if index >= 0 && index < len(c.matchesSourceMaps) {
+			return c.matchesSourceMaps[index].GetLocation(state)
 		}
 	case CheckOutputStartsWithKind:
-		return c.startsWithSourceMap.GetErrdefsSource()
+		return c.startsWithSourceMap.GetLocation(state)
 	case CheckOutputEndsWithKind:
-		return c.endsWithSourceMap.GetErrdefsSource()
+		return c.endsWithSourceMap.GetLocation(state)
 	case CheckOutputEmptyKind:
-		return c.emptySourceMap.GetErrdefsSource()
+		return c.emptySourceMap.GetLocation(state)
 	case CheckOutputEqualsKind:
-		return c.equalsSourceMap.GetErrdefsSource()
+		return c.equalsSourceMap.GetLocation(state)
 	}
 
 	return nil

--- a/tests_test.go
+++ b/tests_test.go
@@ -1,0 +1,33 @@
+package dalec
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+)
+
+func TestCheckOutputGetSourceLocationProgrammaticSlices(t *testing.T) {
+	t.Parallel()
+
+	state := llb.Scratch()
+	check := CheckOutput{
+		Contains: []string{"foo"},
+		Matches:  []string{"bar"},
+	}
+
+	for _, tc := range []struct {
+		kind  string
+		index int
+	}{
+		{kind: CheckOutputContainsKind, index: 0},
+		{kind: CheckOutputContainsKind, index: 1},
+		{kind: CheckOutputContainsKind, index: -1},
+		{kind: CheckOutputMatchesKind, index: 0},
+		{kind: CheckOutputMatchesKind, index: 1},
+		{kind: CheckOutputMatchesKind, index: -1},
+	} {
+		if loc := check.GetSourceLocation(state, tc.kind, tc.index); loc != nil {
+			t.Fatalf("expected nil source location for %s index %d, got %#v", tc.kind, tc.index, loc)
+		}
+	}
+}


### PR DESCRIPTION
This moves Dalec spec/package tests into the normal LLB graph instead of running test containers manually through the BuildKit API after the main solve.

The main implementation details and rationale are in `tests: run package tests in LLB graph`.

This also includes small supporting fixes to protect shared test spec mutation and to build docs examples through the existing bake target.
