### PR TITLE
 docs(examples): add tutorial-style Dalec examples (inline, config+systemd, patching, kitchen-sink)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -205,10 +205,16 @@ target "build" {
 }
 
 target "examples" {
-    name = "examples-${f}"
+    name = "examples-${replace(f, ".", "-")}"
     matrix = {
         distro = ["azlinux3"]
-        f = ["go-md2man"]
+        f = [
+            "go-md2man",
+            "hello.inline",
+            "config-and-systemd",
+            "patch-during-build",
+            "my-daemon.kitchensink",
+        ]
     }
     args = {
         "BUILDKIT_SYNTAX" = "dalec_frontend"

--- a/docs/examples/config-and-systemd.yml
+++ b/docs/examples/config-and-systemd.yml
@@ -1,0 +1,172 @@
+# syntax=ghcr.io/project-dalec/dalec/frontend:latest
+#
+# docs/examples/config-and-systemd.yml
+#
+# Goal:
+#   Show the "daemon package layout" patterns:
+#   - createDirectories for /etc/<name> and /var/lib/<name>
+#   - configFiles under /etc
+#   - systemd unit packaging
+#   - a tiny script "daemon" that can print config
+#
+# Try:
+#   docker build -f docs/examples/config-and-systemd.yml --target=azlinux3/rpm --output=_output .
+#   docker build -f docs/examples/config-and-systemd.yml --target=azlinux3 -t cfgd:dev .
+#   docker run --rm cfgd:dev --print-config
+
+args:
+  VERSION: 0.1.0
+
+name: cfgd
+description: "Dalec example: configFiles + createDirectories + systemd unit."
+license: Apache-2.0
+website: https://github.com/project-dalec/dalec
+version: ${VERSION}
+revision: 1
+
+targets:
+  azlinux3:
+    image:
+      base: mcr.microsoft.com/azurelinux/base/core:3.0
+      entrypoint: /usr/bin/cfgd
+      cmd: "--print-config"
+
+      # Your Dalec frontend expects env as a list (sequence), not a mapping.
+      env:
+        - CFG_D_CONFIG=/etc/cfgd/cfgd.conf
+
+dependencies:
+  test:
+    bash: {}
+    coreutils: {}
+
+sources:
+  src:
+    inline:
+      dir:
+        permissions: 0o755
+        files:
+          cfgd.sh:
+            permissions: 0o755
+            contents: |
+              #!/bin/sh
+              set -eu
+
+              CONF="${CFG_D_CONFIG:-/etc/cfgd/cfgd.conf}"
+
+              case "${1:-}" in
+                --print-config)
+                  # For the tutorial, just print whatever the config file contains.
+                  if [ -f "$CONF" ]; then
+                    cat "$CONF"
+                  else
+                    echo "missing config: $CONF" >&2
+                    exit 2
+                  fi
+                  ;;
+                --version)
+                  echo "cfgd ${VERSION}"
+                  ;;
+                *)
+                  echo "cfgd running (config=$CONF)"
+                  ;;
+              esac
+
+          cfgd.conf:
+            permissions: 0o644
+            contents: |
+              # Example config packaged under /etc/cfgd/cfgd.conf
+              port=8080
+              log_level=info
+
+          cfgd.service:
+            permissions: 0o644
+            contents: |
+              [Unit]
+              Description=cfgd (Dalec example)
+              After=network-online.target
+              Wants=network-online.target
+
+              [Service]
+              Type=simple
+              Environment=CFG_D_CONFIG=/etc/cfgd/cfgd.conf
+              ExecStart=/usr/bin/cfgd
+              Restart=on-failure
+
+              [Install]
+              WantedBy=multi-user.target
+
+build:
+  env:
+    VERSION: ${VERSION}
+  steps:
+    - command: |
+        set -euo pipefail
+        mkdir -p out
+
+        # The script contains a literal "${VERSION}" token.
+        # Dalec does NOT substitute inside file contents, so we replace it here.
+        sed "s/\\\${VERSION}/${VERSION}/g" src/cfgd.sh > out/cfgd
+        chmod 0755 out/cfgd
+
+artifacts:
+  binaries:
+    out/cfgd:
+      subpath: ""
+      permissions: 0o755
+
+  createDirectories:
+    config:
+      cfgd:
+        mode: 0o755
+    state:
+      cfgd:
+        mode: 0o755
+
+  # IMPORTANT (Dalec version detail):
+  # subpath is treated as a DIRECTORY, and Dalec appends the source filename.
+  # So this creates: /etc/cfgd/cfgd.conf  (file)
+  configFiles:
+    src/cfgd.conf:
+      subpath: "cfgd"
+      permissions: 0o644
+
+  systemd:
+    units:
+      src/cfgd.service:
+        enable: false
+        start: false
+        name: ""
+
+tests:
+  - name: cfgd installed and executable
+    files:
+      /usr/bin/cfgd:
+        permissions: 0o755
+
+  - name: config file packaged under /etc
+    files:
+      /etc/cfgd/cfgd.conf:
+        permissions: 0o644
+        contains:
+          - "port=8080"
+          - "log_level=info"
+
+  - name: print-config prints packaged config
+    steps:
+      - command: /usr/bin/cfgd --print-config
+        stdout:
+          contains:
+            - "port=8080"
+            - "log_level=info"
+        stderr:
+          empty: true
+
+  # Unit file install paths can vary slightly by distro; check both common locations.
+  - name: systemd unit installed (common locations)
+    steps:
+      - command: >
+          /bin/sh -c 'test -f /usr/lib/systemd/system/cfgd.service || test -f /lib/systemd/system/cfgd.service'
+        stderr:
+          empty: true
+

--- a/docs/examples/go-md2man.yml
+++ b/docs/examples/go-md2man.yml
@@ -42,4 +42,4 @@ tests:
   - name: Check bin
     files:
       /usr/bin/go-md2man:
-        permissions: 0755
+        permissions: 0o755

--- a/docs/examples/hello.inline.yml
+++ b/docs/examples/hello.inline.yml
@@ -1,0 +1,109 @@
+# syntax=ghcr.io/project-dalec/dalec/frontend:latest
+#
+# docs/examples/hello.inline.yml
+#
+# Goal:
+#   The smallest “real” Dalec example:
+#   - Inline source directory (C code)
+#   - Build with gcc
+#   - Install a binary
+#   - Run tests that execute the binary
+#
+# Try:
+#   docker build -f docs/examples/hello.inline.yml --target=azlinux3/rpm --output=_output .
+#   docker build -f docs/examples/hello.inline.yml --target=azlinux3 -t hello-inline:dev .
+#   docker run --rm hello-inline:dev
+
+args:
+  VERSION: 0.1.0
+
+  # Built-in args (opt-in substitution). Not used directly here, but included
+  # for tutorial consistency across examples.
+  TARGETOS:
+  TARGETARCH:
+  TARGETPLATFORM:
+  TARGETVARIANT:
+  DALEC_TARGET:
+
+name: hello-inline
+description: "Minimal Dalec example: inline C source -> binary -> tests."
+license: Apache-2.0
+website: https://github.com/project-dalec/dalec
+version: ${VERSION}
+revision: 1
+
+targets:
+  azlinux3:
+    image:
+      base: mcr.microsoft.com/azurelinux/base/core:3.0
+      entrypoint: /usr/bin/hello-inline
+
+      # NOTE: cmd (if set) is typically a string in these examples (not a YAML list).
+      # Leaving it out means “no default args”.
+      labels:
+        org.opencontainers.image.title: hello-inline
+        org.opencontainers.image.description: "Minimal Dalec example"
+        org.opencontainers.image.licenses: Apache-2.0
+
+dependencies:
+  build:
+    gcc: {}
+  test:
+    bash: {}
+
+sources:
+  # `src/` will appear in the build environment as a directory named "src".
+  src:
+    inline:
+      dir:
+        permissions: 0o755
+        files:
+          main.c:
+            permissions: 0o644
+            contents: |
+              #include <stdio.h>
+              #include <stdlib.h>
+
+              #ifndef VERSION
+              #define VERSION "dev"
+              #endif
+
+              int main(void) {
+                const char* os = getenv("TARGETOS") ? getenv("TARGETOS") : "unknown";
+                const char* arch = getenv("TARGETARCH") ? getenv("TARGETARCH") : "unknown";
+                printf("hello-inline %s (%s/%s)\n", VERSION, os, arch);
+                return 0;
+              }
+
+build:
+  env:
+    VERSION: ${VERSION}
+  steps:
+    - command: |
+        set -euo pipefail
+        mkdir -p out
+        cc -O2 -DVERSION=\"${VERSION}\" -o out/hello-inline src/main.c
+
+artifacts:
+  binaries:
+    out/hello-inline:
+      # subpath is joined under /usr/bin/<subpath>.
+      # Using "" means install as /usr/bin/<filename> (here: /usr/bin/hello-inline).
+      subpath: ""
+      permissions: 0o755
+
+tests:
+  - name: binary exists and is executable
+    files:
+      /usr/bin/hello-inline:
+        permissions: 0o755
+
+  - name: running binary prints version/platform
+    steps:
+      - command: /usr/bin/hello-inline
+        stdout:
+          contains:
+            - "hello-inline ${VERSION}"
+        stderr:
+          empty: true
+

--- a/docs/examples/my-daemon.kitchensink.yml
+++ b/docs/examples/my-daemon.kitchensink.yml
@@ -1,0 +1,304 @@
+# syntax=ghcr.io/project-dalec/dalec/frontend:latest
+#
+# docs/examples/my-daemon.kitchensink.yml
+#
+# A "kitchen sink" Dalec spec that demonstrates (with lots of comments):
+# - args + built-in args opt-in substitution
+# - sources: inline dir + http file
+# - dependencies (build/runtime/recommends/test)
+# - build steps
+# - artifacts: binaries, configFiles, docs, licenses, systemd units, createDirectories
+# - tests: file checks + command checks
+# - image configuration + post symlinks (without colliding with packaged files)
+#
+# Try it:
+#   # Build RPM output
+#   docker build -f docs/examples/my-daemon.kitchensink.yml --target=azlinux3/rpm --output=_output .
+#
+#   # Build container image (RPM installed into base image)
+#   docker build -f docs/examples/my-daemon.kitchensink.yml --target=azlinux3 -t my-daemon:dev .
+#   docker run --rm my-daemon:dev --version
+#   docker run --rm my-daemon:dev --print-config
+#
+# Override VERSION:
+#   docker build -f docs/examples/my-daemon.kitchensink.yml --build-arg VERSION=0.2.0 --target=azlinux3 -t my-daemon:0.2.0 .
+
+# -----------------------------------------------------------------------------
+# Args: values you can override via `docker build --build-arg ...`
+# NOTE: args are scalars. Built-in args must be listed (opt-in) with NO default.
+# -----------------------------------------------------------------------------
+args:
+  VERSION: 0.1.0
+  REVISION: 1
+
+  # Built-in args (opt-in substitution)
+  TARGETOS:
+  TARGETARCH:
+  TARGETPLATFORM:
+  TARGETVARIANT:
+  DALEC_TARGET:
+
+# -----------------------------------------------------------------------------
+# Package metadata
+# -----------------------------------------------------------------------------
+name: my-daemon
+description: "Dalec kitchen-sink example: build an RPM and a container image from it."
+license: Apache-2.0
+website: https://github.com/project-dalec/dalec
+packager: Dalec Authors
+vendor: Dalec Authors
+version: ${VERSION}
+revision: ${REVISION}
+
+# -----------------------------------------------------------------------------
+# Targets: per-target config (we focus on azlinux3 here)
+# -----------------------------------------------------------------------------
+targets:
+  azlinux3:
+    image:
+      # Base image for the final container image (after installing the RPM).
+      base: mcr.microsoft.com/azurelinux/base/core:3.0
+
+      # Runtime settings for the image.
+      entrypoint: /usr/bin/my-daemon
+      # Dalec image cmd is a STRING (not a YAML list).
+      cmd: "--print-config"
+
+      # IMPORTANT: your Dalec frontend expects env as a sequence (list), not a mapping.
+      env:
+        - MY_DAEMON_CONFIG=/etc/my-daemon/my-daemon.conf
+
+      labels:
+        org.opencontainers.image.title: my-daemon
+        org.opencontainers.image.description: "Dalec kitchen-sink example"
+        org.opencontainers.image.licenses: Apache-2.0
+
+      stop_signal: SIGINT
+
+      # Example "state" location for the daemon.
+      volumes:
+        /var/lib/my-daemon: {}
+
+      # Post-processing for the image filesystem.
+      # IMPORTANT:
+      # - Do NOT try to create /usr/bin/my-daemon as a symlink: the RPM already installs it.
+      # - Only create *new* link paths that don't already exist.
+      post:
+        symlinks:
+          # This means:
+          #   /my-daemon      -> /usr/bin/my-daemon
+          #   /usr/bin/daemon -> /usr/bin/my-daemon
+          /usr/bin/my-daemon:
+            paths:
+              - /my-daemon
+              - /usr/bin/daemon
+
+# -----------------------------------------------------------------------------
+# Dependencies:
+# - build: needed for compilation
+# - runtime: installed when the RPM is installed
+# - recommends: optional goodies (no version constraints here to keep RPM syntax safe)
+# - test: packages only installed for running test "steps"
+# -----------------------------------------------------------------------------
+dependencies:
+  build:
+    gcc: {}
+  runtime:
+    ca-certificates: {}
+  recommends:
+    curl: {}
+  test:
+    bash: {}
+    coreutils: {}
+
+# -----------------------------------------------------------------------------
+# Sources: each source is placed into the build input directory under its name.
+# -----------------------------------------------------------------------------
+sources:
+  # Inline directory source containing C code + license.
+  src:
+    inline:
+      dir:
+        permissions: 0o755
+        files:
+          main.c:
+            permissions: 0o644
+            contents: |
+              #include <stdio.h>
+              #include <string.h>
+              #include <stdlib.h>
+
+              #ifndef VERSION
+              #define VERSION "dev"
+              #endif
+
+              static const char* default_cfg =
+                "port=8080\n"
+                "log_level=info\n";
+
+              int main(int argc, char** argv) {
+                if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+                  printf("my-daemon version %s\n", VERSION);
+                  return 0;
+                }
+                if (argc > 1 && strcmp(argv[1], "--print-config") == 0) {
+                  // For the example: print defaults so it works even in minimal images.
+                  printf("%s", default_cfg);
+                  return 0;
+                }
+
+                // "daemon" placeholder
+                printf("my-daemon running on %s/%s (target=%s platform=%s)\n",
+                       getenv("TARGETOS") ? getenv("TARGETOS") : "unknown",
+                       getenv("TARGETARCH") ? getenv("TARGETARCH") : "unknown",
+                       getenv("DALEC_TARGET") ? getenv("DALEC_TARGET") : "unknown",
+                       getenv("TARGETPLATFORM") ? getenv("TARGETPLATFORM") : "unknown");
+                return 0;
+              }
+
+          LICENSE:
+            permissions: 0o644
+            contents: |
+              Apache License 2.0
+              (Example file for Dalec documentation.)
+
+  # Inline directory source for config + systemd unit.
+  config:
+    inline:
+      dir:
+        permissions: 0o755
+        files:
+          my-daemon.conf:
+            permissions: 0o644
+            contents: |
+              # Example config file (packaged under /etc/my-daemon/)
+              port=8080
+              log_level=info
+
+          my-daemon.service:
+            permissions: 0o644
+            contents: |
+              [Unit]
+              Description=My Daemon (Dalec example)
+              After=network-online.target
+              Wants=network-online.target
+
+              [Service]
+              Type=simple
+              ExecStart=/usr/bin/my-daemon
+              Restart=on-failure
+
+              [Install]
+              WantedBy=multi-user.target
+
+  # HTTP file source (downloaded and packaged as docs).
+  # NOTE: As a source, the file name is "rfc3339" (not "rfc3339.txt"),
+  # so we copy it to out/rfc3339.txt in the build step for nicer docs naming.
+  rfc3339:
+    http:
+      url: https://www.rfc-editor.org/rfc/rfc3339.txt
+      permissions: 0o644
+
+# -----------------------------------------------------------------------------
+# Build: runs in the build environment after sources are laid out.
+# Output artifacts must be relative to this build root.
+# -----------------------------------------------------------------------------
+build:
+  env:
+    VERSION: ${VERSION}
+  steps:
+    - command: |
+        set -euo pipefail
+
+        mkdir -p out
+
+        # Compile into a stable "out/" directory so artifacts are simple.
+        cc -O2 -DVERSION=\"${VERSION}\" -o out/my-daemon src/main.c
+
+        # Rename the http source to have .txt extension for docs.
+        cp rfc3339 out/rfc3339.txt
+
+# -----------------------------------------------------------------------------
+# Artifacts: what gets installed + where.
+#
+# IMPORTANT detail for your Dalec version:
+# - subpath is treated as a DIRECTORY, and Dalec appends the source filename.
+# - Therefore, for binaries we want subpath "" (put file directly in /usr/bin)
+# - For configFiles we want subpath "my-daemon" (directory), so file becomes:
+#     /etc/my-daemon/my-daemon.conf
+# - For docs we install out/rfc3339.txt with subpath "" so it becomes:
+#     /usr/share/doc/my-daemon/rfc3339.txt
+# -----------------------------------------------------------------------------
+artifacts:
+  binaries:
+    out/my-daemon:
+      subpath: ""
+      permissions: 0o755
+
+  createDirectories:
+    config:
+      my-daemon:
+        mode: 0o755
+    state:
+      my-daemon:
+        mode: 0o755
+
+  configFiles:
+    config/my-daemon.conf:
+      subpath: my-daemon
+      permissions: 0o644
+
+  systemd:
+    units:
+      config/my-daemon.service:
+        enable: false
+        start: false
+        name: ""
+
+  docs:
+    out/rfc3339.txt:
+      subpath: ""
+      permissions: 0o644
+
+  licenses:
+    src/LICENSE:
+      subpath: ""
+      permissions: 0o644
+
+# -----------------------------------------------------------------------------
+# Tests: lightweight sanity checks.
+# -----------------------------------------------------------------------------
+tests:
+  - name: my-daemon installed and executable
+    files:
+      /usr/bin/my-daemon:
+        permissions: 0o755
+
+  - name: version flag prints version
+    steps:
+      - command: /usr/bin/my-daemon --version
+        stdout:
+          starts_with: "my-daemon version ${VERSION}"
+        stderr:
+          empty: true
+
+  - name: print-config outputs defaults
+    steps:
+      - command: /usr/bin/my-daemon --print-config
+        stdout:
+          contains:
+            - "port=8080"
+            - "log_level=info"
+        stderr:
+          empty: true
+
+  - name: packaged config file exists
+    files:
+      /etc/my-daemon/my-daemon.conf:
+        permissions: 0o644
+
+  - name: packaged docs exist
+    files:
+      /usr/share/doc/my-daemon/rfc3339.txt:
+        permissions: 0o644
+

--- a/docs/examples/patch-during-build.yml
+++ b/docs/examples/patch-during-build.yml
@@ -1,0 +1,124 @@
+# syntax=ghcr.io/project-dalec/dalec/frontend:latest
+#
+# docs/examples/patch-during-build.yml
+#
+# Goal:
+#   Demonstrate a common packaging workflow:
+#   - Define source
+#   - Apply a patch in the build phase
+#   - Build + package + test
+#
+# NOTE (important for your Dalec version):
+#   Variable substitution like ${VERSION} does NOT happen inside patch file contents.
+#   So we patch the code to print a C macro (VERSION) and pass -DVERSION at compile time.
+#
+# Try:
+#   docker build -f docs/examples/patch-during-build.yml --target=azlinux3/rpm --output=_output .
+#   docker build -f docs/examples/patch-during-build.yml --target=azlinux3 -t patched-hello:dev .
+#   docker run --rm patched-hello:dev --version
+
+args:
+  VERSION: 0.1.0
+
+  # Built-in args (opt-in substitution). Not used directly here, but included
+  # for tutorial consistency across examples.
+  TARGETOS:
+  TARGETARCH:
+  TARGETPLATFORM:
+  TARGETVARIANT:
+  DALEC_TARGET:
+
+name: patched-hello
+description: "Dalec example: apply an inline patch during build."
+license: Apache-2.0
+website: https://github.com/project-dalec/dalec
+version: ${VERSION}
+revision: 1
+
+targets:
+  azlinux3:
+    image:
+      base: mcr.microsoft.com/azurelinux/base/core:3.0
+      entrypoint: /usr/bin/patched-hello
+      cmd: "--version"
+
+dependencies:
+  build:
+    gcc: {}
+    patch: {}
+  test:
+    bash: {}
+
+sources:
+  src:
+    inline:
+      dir:
+        permissions: 0o755
+        files:
+          hello.c:
+            permissions: 0o644
+            contents: |
+              #include <stdio.h>
+              #include <string.h>
+
+              #ifndef VERSION
+              #define VERSION "dev"
+              #endif
+
+              int main(int argc, char** argv) {
+                if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+                  printf("patched-hello (unpatched)\n");
+                  return 0;
+                }
+                printf("hello\n");
+                return 0;
+              }
+
+  # Inline FILE source: unified diff. Keep it STATIC (no ${VERSION} here).
+  hello.patch:
+    inline:
+      file:
+        permissions: 0o644
+        contents: |
+          --- a/src/hello.c
+          +++ b/src/hello.c
+          @@ -6,7 +6,7 @@
+           int main(int argc, char** argv) {
+             if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+          -    printf("patched-hello (unpatched)\n");
+          +    printf("patched-hello %s\n", VERSION);
+               return 0;
+             }
+             printf("hello\n");
+             return 0;
+           }
+
+build:
+  env:
+    VERSION: ${VERSION}
+  steps:
+    - command: |
+        set -euo pipefail
+
+        # Apply patch in-place to the source tree.
+        patch -p1 < hello.patch
+
+        mkdir -p out
+        # Inject VERSION via compiler define (this substitution DOES work here).
+        cc -O2 -DVERSION=\"${VERSION}\" -o out/patched-hello src/hello.c
+
+artifacts:
+  binaries:
+    out/patched-hello:
+      subpath: ""
+      permissions: 0o755
+
+tests:
+  - name: version includes patched VERSION
+    steps:
+      - command: /usr/bin/patched-hello --version
+        stdout:
+          starts_with: "patched-hello ${VERSION}"
+        stderr:
+          empty: true
+


### PR DESCRIPTION
This PR adds several tutorial-style example specs under docs/examples/ to help new users understand how Dalec specs map to packages + images.

Fixes: #828