### PR TITLE
rpm: speed up cross-arch worker builds by installing deps into mounted target rootfs

### DIFF
--- a/targets/linux/rpm/almalinux/v8.go
+++ b/targets/linux/rpm/almalinux/v8.go
@@ -20,7 +20,7 @@ var ConfigV8 = &distro.Config{
 	ContextRef: v8WorkerContextName,
 
 	CacheName: dnfCacheNameV8,
-	CacheDir:  "/var/cache/dnf",
+	CacheDir:  []string{"/var/cache/dnf"},
 	// Alma's repo configs do not include the $basearch variable in the mirrorlist URL
 	// This means that the cache key that dnf computes for /var/cache/dnf/<repoid>-<hash>
 	// is the same across x86_64 and aarch64, which leads to incorrect repo metadata

--- a/targets/linux/rpm/almalinux/v9.go
+++ b/targets/linux/rpm/almalinux/v9.go
@@ -20,7 +20,7 @@ var ConfigV9 = &distro.Config{
 	ContextRef: v9WorkerContextName,
 
 	CacheName: dnfCacheNameV9,
-	CacheDir:  "/var/cache/dnf",
+	CacheDir:  []string{"/var/cache/dnf"},
 	// Alma's repo configs do not include the $basearch variable in the mirrorlist URL
 	// This means that the cache key that dnf computes for /var/cache/dnf/<repoid>-<hash>
 	// is the same across x86_64 and aarch64, which leads to incorrect repo metadata

--- a/targets/linux/rpm/azlinux/azlinux3.go
+++ b/targets/linux/rpm/azlinux/azlinux3.go
@@ -19,11 +19,12 @@ var Azlinux3Config = &distro.Config{
 	ImageRef:   Azlinux3Ref,
 	ContextRef: Azlinux3WorkerContextName,
 
-	CacheName: tdnfCacheNameAzlinux3,
-	CacheDir:  "/var/cache/tdnf",
+	CacheName:        tdnfCacheNameAzlinux3,
+	CacheDir:         []string{"/var/cache/tdnf", "/var/cache/dnf"},
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "3.0",
-	BuilderPackages:    builderPackages,
+	BuilderPackages:    append(builderPackages, "dnf"),
 	BasePackages:       basePackages(AzLinux3TargetKey),
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,

--- a/targets/linux/rpm/azlinux/mariner2.go
+++ b/targets/linux/rpm/azlinux/mariner2.go
@@ -17,11 +17,12 @@ var Mariner2Config = &distro.Config{
 	ImageRef:   "mcr.microsoft.com/cbl-mariner/base/core:2.0",
 	ContextRef: Mariner2WorkerContextName,
 
-	CacheName: tdnfCacheNameMariner2,
-	CacheDir:  "/var/cache/tdnf",
+	CacheName:        tdnfCacheNameMariner2,
+	CacheDir:         []string{"/var/cache/tdnf", "/var/cache/dnf"},
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "2.0",
-	BuilderPackages:    builderPackages,
+	BuilderPackages:    append(builderPackages, "dnf"),
 	BasePackages:       basePackages(Mariner2TargetKey),
 	RepoPlatformConfig: &defaultAzlinuxRepoPlatform,
 	InstallFunc:        distro.TdnfInstall,

--- a/targets/linux/rpm/rockylinux/v8.go
+++ b/targets/linux/rpm/rockylinux/v8.go
@@ -19,8 +19,9 @@ var ConfigV8 = &distro.Config{
 	ImageRef:   v8Ref,
 	ContextRef: v8WorkerContextName,
 
-	CacheName: dnfCacheNameV8,
-	CacheDir:  "/var/cache/dnf",
+	CacheName:        dnfCacheNameV8,
+	CacheDir:         []string{"/var/cache/dnf"},
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "8",
 	BuilderPackages:    builderPackages,

--- a/targets/linux/rpm/rockylinux/v9.go
+++ b/targets/linux/rpm/rockylinux/v9.go
@@ -19,8 +19,9 @@ var ConfigV9 = &distro.Config{
 	ImageRef:   v9Ref,
 	ContextRef: v9WorkerContextName,
 
-	CacheName: dnfCacheNameV9,
-	CacheDir:  "/var/cache/dnf",
+	CacheName:        dnfCacheNameV9,
+	CacheDir:         []string{"/var/cache/dnf"},
+	CacheAddPlatform: true,
 
 	ReleaseVer:         "9",
 	BuilderPackages:    append(builderPackages, "systemd-rpm-macros"),


### PR DESCRIPTION
Enable faster and more reliable cross-arch RPM worker builds by installing build dependencies into a mounted target rootfs while running the package manager on the native BuildKit executor platform (avoids slow/full emulation and “exec format error” during install).

**Changes**
- Detect native executor platform from BuildKit worker opts and normalize platform tuples.
- For build != target:
      1. resolve target base image as target platform
      2. run install on build platform and install into mounted target rootfs via --installroot
      3. return the mutated rootfs as the target-platform worker
- Add optional --forcearch support (applied when supported by dnf/tdnf).
- Enable CacheAddPlatform for Rocky 8/9, Azure Linux 3, and Mariner 2 to avoid cross-arch cache/repo metadata collisions.