### PR TITLE
sourcemap.go: don't pass empty output state to SourceMap

### DIFF
--- a/sourcemap.go
+++ b/sourcemap.go
@@ -48,6 +48,13 @@ func (sm *sourceMap) getLocation(st *llb.State) llb.ConstraintsOpt {
 	if sm == nil {
 		return ConstraintsOptFunc(func(*llb.Constraints) {})
 	}
+
+	// If source state is given but it has no defined output, creating a source map from it will generate invalid LLM input,
+	// which then cannot be converted to state if needed, therefore omit adding it.
+	if st != nil && st.Output() == nil {
+		st = nil
+	}
+
 	sourceMap := llb.NewSourceMap(st, sm.filename, sm.language, sm.data)
 	return sourceMap.Location([]*pb.Range{sm.pos})
 }

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/project-dalec/dalec"
-	"github.com/project-dalec/dalec/frontend"
 	"github.com/containerd/platforms"
 	"github.com/goccy/go-yaml"
 	"github.com/moby/buildkit/client/llb"
@@ -23,6 +21,8 @@ import (
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 	"github.com/tonistiigi/fsutil/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -258,7 +258,6 @@ func withIgnoreCache(refs ...string) srOpt {
 			v += ","
 		}
 		cfg.req.FrontendOpt["no-cache"] = v + strings.Join(refs, ",")
-
 	}
 }
 
@@ -283,6 +282,11 @@ func solveT(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if err := res.EachRef(func(ref gwclient.Reference) error { _, err := ref.ToState(); return err }); err != nil {
+		t.Fatalf("One of refs cannot be converted to state: %v", err)
+	}
+
 	return res
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As this generates invalid LLB input.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Closes #930

**Special notes for your reviewer**:
