### PR TITLE
Scope stuct tag linter to dalec.Spec by default.

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(linters.YamlJSONTagsMatch)
+	singlechecker.Main(linters.NewYamlJSONTagsAnalyzer())
 }

--- a/linters/yaml_json_tags.go
+++ b/linters/yaml_json_tags.go
@@ -1,36 +1,178 @@
 package linters
 
 import (
+	"flag"
 	"go/ast"
+	"go/types"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
 
-var YamlJSONTagsMatch = &analysis.Analyzer{
-	Name: "yaml_json_names_match",
-	Doc:  "check that struct tags for json and yaml use the same name",
-	Run:  structTagLinter{}.Run,
+// NewYamlJSONTagsAnalyzer creates an analyzer that checks struct tags for json
+// and yaml use the same name in types reachable from the root type.
+func NewYamlJSONTagsAnalyzer() *analysis.Analyzer {
+	linter := &structTagLinter{
+		// This tool is designed primarily for use with dalec.Spec
+		// Customizable mainly for testing purposes.
+		rootType: "github.com/project-dalec/dalec.Spec",
+	}
+
+	var flags flag.FlagSet
+	flags.StringVar(&linter.rootType, "type",
+		linter.rootType,
+		"fully qualified type to use as root for validation")
+
+	return &analysis.Analyzer{
+		Name:  "yaml_json_names_match",
+		Doc:   "check that struct tags for json and yaml use the same name in types reachable from the root type",
+		Run:   linter.Run,
+		Flags: flags,
+	}
 }
 
-type structTagLinter struct{}
+type structTagLinter struct {
+	rootType string // fully qualified type reference, e.g. "github.com/project-dalec/dalec.Spec"
+}
 
-func (l structTagLinter) Run(pass *analysis.Pass) (interface{}, error) {
+func (l *structTagLinter) Run(pass *analysis.Pass) (interface{}, error) {
+	// Determine which types to validate based on reachability from root type
+	var reachableTypes map[*types.Named]bool
+
+	// Only use type-scoping if type information is available
+	if pass.Pkg != nil && pass.TypesInfo != nil {
+		pkgPath, typeName := parseTypeRef(l.rootType)
+		root := findType(pass, pkgPath, typeName)
+		if root == nil {
+			// Package doesn't define or import the root type - skip validation
+			return nil, nil
+		}
+		reachableTypes = make(map[*types.Named]bool)
+		collectReachableTypes(root, reachableTypes)
+	}
+
 	for _, file := range pass.Files {
 		ast.Inspect(file, func(n ast.Node) bool {
-			switch x := n.(type) {
-			case *ast.TypeSpec:
-				if structType, ok := x.Type.(*ast.StructType); ok {
-					l.checkStructTags(structType, pass)
+			typeSpec, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			// If we have type scoping, check if this type is reachable from root
+			if reachableTypes != nil {
+				if !l.isReachable(pass, typeSpec, reachableTypes) {
+					return true
 				}
 			}
+
+			l.checkStructTags(structType, pass)
 			return true
 		})
 	}
 	return nil, nil
 }
 
-func (structTagLinter) checkStructTags(structType *ast.StructType, pass *analysis.Pass) {
+// parseTypeRef splits a fully qualified type reference into package path and type name.
+// e.g. "github.com/project-dalec/dalec.Spec" -> ("github.com/project-dalec/dalec", "Spec")
+func parseTypeRef(ref string) (pkgPath, typeName string) {
+	idx := strings.LastIndex(ref, ".")
+	if idx == -1 {
+		return "", ref
+	}
+	return ref[:idx], ref[idx+1:]
+}
+
+// findType locates a type by package path and type name.
+// Returns nil if not found (package doesn't define or import the type).
+func findType(pass *analysis.Pass, pkgPath, typeName string) *types.Named {
+	var pkg *types.Package
+
+	if pass.Pkg.Path() == pkgPath {
+		pkg = pass.Pkg
+	} else {
+		for _, imp := range pass.Pkg.Imports() {
+			if imp.Path() == pkgPath {
+				pkg = imp
+				break
+			}
+		}
+	}
+
+	if pkg == nil {
+		return nil
+	}
+
+	obj := pkg.Scope().Lookup(typeName)
+	if obj == nil {
+		return nil
+	}
+
+	tn, ok := obj.(*types.TypeName)
+	if !ok {
+		return nil
+	}
+
+	named, _ := tn.Type().(*types.Named)
+	return named
+}
+
+// collectReachableTypes recursively collects all named types
+// reachable from the given root type.
+func collectReachableTypes(root types.Type, visited map[*types.Named]bool) {
+	switch t := root.(type) {
+	case *types.Named:
+		if visited[t] {
+			return
+		}
+		visited[t] = true
+		collectReachableTypes(t.Underlying(), visited)
+
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			collectReachableTypes(t.Field(i).Type(), visited)
+		}
+
+	case *types.Pointer:
+		collectReachableTypes(t.Elem(), visited)
+
+	case *types.Slice:
+		collectReachableTypes(t.Elem(), visited)
+
+	case *types.Array:
+		collectReachableTypes(t.Elem(), visited)
+
+	case *types.Map:
+		collectReachableTypes(t.Key(), visited)
+		collectReachableTypes(t.Elem(), visited)
+	}
+}
+
+// isReachable checks if the given type declaration is in the set of reachable types.
+func (l *structTagLinter) isReachable(pass *analysis.Pass, typeSpec *ast.TypeSpec, reachable map[*types.Named]bool) bool {
+	obj := pass.TypesInfo.Defs[typeSpec.Name]
+	if obj == nil {
+		return false
+	}
+
+	typeName, ok := obj.(*types.TypeName)
+	if !ok {
+		return false
+	}
+
+	named, ok := typeName.Type().(*types.Named)
+	if !ok {
+		return false
+	}
+
+	return reachable[named]
+}
+
+func (l *structTagLinter) checkStructTags(structType *ast.StructType, pass *analysis.Pass) {
 	for _, field := range structType.Fields.List {
 		if field.Tag != nil {
 			tag := field.Tag.Value

--- a/linters/yaml_json_tags_test.go
+++ b/linters/yaml_json_tags_test.go
@@ -2,8 +2,10 @@ package linters
 
 import (
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"testing"
 
 	"golang.org/x/tools/go/analysis"
@@ -116,7 +118,8 @@ func TestCheckStructTags(t *testing.T) {
 				},
 			}
 
-			linter := structTagLinter{}
+			// Use a linter without type info - falls back to checking all structs
+			linter := &structTagLinter{}
 			_, err = linter.Run(pass)
 			assert.NilError(t, err)
 
@@ -177,4 +180,112 @@ func TestGetYamlJSONNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTypeScoping(t *testing.T) {
+	const testPkgPath = "example.com/testpkg"
+
+	// Source with Spec type and reachable/unreachable types
+	src := `
+package testpkg
+
+type Spec struct {
+	Name   string  ` + "`json:\"name\" yaml:\"name\"`" + `
+	Nested *Nested ` + "`json:\"nested\" yaml:\"nested\"`" + `
+}
+
+type Nested struct {
+	// This should be validated (reachable from Spec)
+	Value string ` + "`json:\"value\" yaml:\"wrong\"`" + `
+}
+
+type Unrelated struct {
+	// This should NOT be validated (not reachable from Spec)
+	Data string ` + "`json:\"data\" yaml:\"different\"`" + `
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "spec.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	// Type-check to get full type information
+	conf := types.Config{Importer: importer.Default()}
+	info := &types.Info{
+		Defs: make(map[*ast.Ident]types.Object),
+	}
+	pkg, err := conf.Check(testPkgPath, fset, []*ast.File{file}, info)
+	if err != nil {
+		t.Fatalf("type check failed: %v", err)
+	}
+
+	var reports []string
+	pass := &analysis.Pass{
+		Fset:      fset,
+		Files:     []*ast.File{file},
+		Pkg:       pkg,
+		TypesInfo: info,
+		Report: func(d analysis.Diagnostic) {
+			reports = append(reports, d.Message)
+		},
+	}
+
+	// Configure linter to use our test package's Spec as root type
+	linter := &structTagLinter{
+		rootType: testPkgPath + ".Spec",
+	}
+	_, err = linter.Run(pass)
+	if err != nil {
+		t.Fatalf("linter failed: %v", err)
+	}
+
+	// Should only report the mismatch in Nested, not Unrelated
+	expected := []string{"mismatch in struct tags: json=value, yaml=wrong"}
+	assert.Assert(t, cmp.DeepEqual(reports, expected))
+}
+
+func TestTypeScopingSkipsUnrelatedPackages(t *testing.T) {
+	// Source for a package that doesn't match the root type's package
+	src := `
+package unrelated
+
+type Config struct {
+	// This has mismatched tags but should NOT be validated
+	// because this package doesn't contain or import the root type
+	Data string ` + "`json:\"data\" yaml:\"different\"`" + `
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "config.go", src, parser.ParseComments)
+	assert.NilError(t, err)
+
+	// Type-check to get full type information
+	conf := types.Config{Importer: importer.Default()}
+	info := &types.Info{
+		Defs: make(map[*ast.Ident]types.Object),
+	}
+	pkg, err := conf.Check("example.com/unrelated", fset, []*ast.File{file}, info)
+	assert.NilError(t, err)
+
+	var reports []string
+	pass := &analysis.Pass{
+		Fset:      fset,
+		Files:     []*ast.File{file},
+		Pkg:       pkg,
+		TypesInfo: info,
+		Report: func(d analysis.Diagnostic) {
+			reports = append(reports, d.Message)
+		},
+	}
+
+	// Use default root type - this package doesn't contain or import it
+	linter := &structTagLinter{
+		rootType: "github.com/project-dalec/dalec.Spec",
+	}
+	_, err = linter.Run(pass)
+	assert.NilError(t, err)
+
+	// Should report nothing - package doesn't contain or import the root type
+	assert.Assert(t, cmp.Len(reports, 0), "expected no reports for unrelated package, got: %v", reports)
 }


### PR DESCRIPTION
This was only ever intended to lint dalec.Spec, but is linting everything.
For some cases we got hit by the linter for a type that is unrelated to the spec and just went ahead and fixed it to pass CI and just never got around to fixing the linter.