### PR TITLE
Add more tests to building (deb) containers

### DIFF
--- a/internal/test/llb.go
+++ b/internal/test/llb.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+)
+
+// LLBOpsFromState extracts the list of LLB operations from the provided LLB state.
+//
+// This function and LLBOp type has been inspired by
+// https://github.com/moby/buildkit/blob/c70e8e666f8f6ee3c0d83b20c338be5aedeaa97a/cmd/buildctl/debug/dumpllb.go#L59.
+func LLBOpsFromState(ctx context.Context, state llb.State) ([]LLBOp, error) {
+	def, err := state.Marshal(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling state: %w", err)
+	}
+
+	var ops []LLBOp
+	for _, dt := range def.Def {
+		var op pb.Op
+		if err := op.UnmarshalVT(dt); err != nil {
+			return nil, fmt.Errorf("parsing op: %w", err)
+		}
+		dgst := digest.FromBytes(dt)
+		ent := LLBOp{Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}
+
+		ops = append(ops, ent)
+	}
+
+	if len(ops) > 0 {
+		ops = ops[:len(ops)-1] // Last operation is a final export, it has no operations.
+	}
+
+	return ops, nil
+}
+
+// LLBOpsToJSON converts a list of LLB operations to a JSON string.
+func LLBOpsToJSON(ops []LLBOp) (string, error) {
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+	for _, op := range ops {
+		if err := enc.Encode(op); err != nil {
+			return "", err
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// LLBOp represents a single LLB operation along with its metadata.
+type LLBOp struct {
+	Op         *pb.Op
+	OpMetadata *pb.OpMetadata
+}

--- a/targets/linux/deb/distro/container_test.go
+++ b/targets/linux/deb/distro/container_test.go
@@ -1,0 +1,479 @@
+package distro
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/internal/test"
+)
+
+func Test_Building_container(t *testing.T) {
+	t.Parallel()
+
+	// Base image is test suite specific, since RPM packages can not always be installed on base
+	// DEB image, hence local test instead of integration one.
+	t.Run("uses_base_image_from_spec", func(t *testing.T) {
+		t.Parallel()
+
+		c := &Config{
+			DefaultOutputImage: "foo",
+		}
+
+		client := &testClient{
+			buildOpts: client.BuildOpts{},
+		}
+
+		expectedRef := "bar"
+
+		spec := &dalec.Spec{
+			Image: &dalec.ImageConfig{
+				Bases: []dalec.BaseImage{
+					{
+						Rootfs: dalec.Source{
+							DockerImage: &dalec.SourceDockerImage{
+								Ref: expectedRef,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		ctx := t.Context()
+
+		state := c.BuildContainer(ctx, client, dalec.SourceOpts{}, spec, "target", llb.State{})
+
+		ops, err := test.LLBOpsFromState(ctx, state)
+		if err != nil {
+			t.Fatalf("failed to get llb ops from state: %v", err)
+		}
+
+		if len(ops) == 0 {
+			t.Fatalf("expected at least one llb op, got none")
+		}
+
+		s := ops[0].Op.GetSource()
+		if s == nil {
+			t.Fatalf("expected source op, got nil")
+		}
+
+		if !strings.Contains(s.Identifier, expectedRef) {
+			t.Fatalf("expected source identifier to contain %q, got %q", expectedRef, s.Identifier)
+		}
+	})
+
+	// Most tests here must assert values in Config which are not user-configurable, hence
+	// they cannot be placed in integration tests.
+	t.Run("uses_default_output_image_if_spec_does_not_set_one", func(t *testing.T) {
+		t.Parallel()
+
+		expectedRef := "foo"
+
+		c := &Config{
+			DefaultOutputImage: expectedRef,
+		}
+
+		client := &testClient{
+			buildOpts: client.BuildOpts{},
+		}
+
+		spec := &dalec.Spec{}
+
+		ctx := t.Context()
+
+		state := c.BuildContainer(ctx, client, dalec.SourceOpts{}, spec, "target", llb.State{})
+
+		ops, err := test.LLBOpsFromState(ctx, state)
+		if err != nil {
+			t.Fatalf("failed to get llb ops from state: %v", err)
+		}
+
+		if len(ops) == 0 {
+			t.Fatalf("expected at least one llb op, got none")
+		}
+
+		s := ops[0].Op.GetSource()
+		if s == nil {
+			t.Fatalf("expected source op, got nil")
+		}
+
+		if !strings.Contains(s.Identifier, expectedRef) {
+			t.Fatalf("expected source identifier to contain %q, got %q", expectedRef, s.Identifier)
+		}
+	})
+
+	t.Run("installs_spec_package", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with_extra_distro_config_repos_mounted", func(t *testing.T) {
+			t.Parallel()
+
+			extraInstallRepo := "extra-install-repo"
+
+			c := &Config{
+				DefaultOutputImage: "foo",
+				ExtraRepos: []dalec.PackageRepositoryConfig{
+					{
+						Envs: []string{"install"},
+						Config: map[string]dalec.Source{
+							extraInstallRepo: {
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: extraInstallRepo,
+									},
+								},
+							},
+						},
+					},
+					{
+						Envs: []string{"build"},
+						Config: map[string]dalec.Source{
+							extraInstallRepo: {
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: "unexpected-repo",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := t.Context()
+
+			ops, err := test.LLBOpsFromState(ctx, c.BuildContainer(ctx, &testClient{}, dalec.SourceOpts{}, &dalec.Spec{}, "target", llb.State{}))
+			if err != nil {
+				t.Fatalf("failed to get llb ops from state: %v", err)
+			}
+
+			found := false
+			for _, op := range ops {
+				f := op.Op.GetFile()
+				if f == nil {
+					continue
+				}
+
+				for _, a := range f.Actions {
+					mkfile := a.GetMkfile()
+					if mkfile == nil {
+						continue
+					}
+
+					if string(mkfile.Data) == extraInstallRepo {
+						found = true
+						break
+					}
+
+					if string(mkfile.Data) == "unexpected-repo" {
+						t.Errorf("Found mount for extra install repo in wrong env")
+					}
+				}
+			}
+
+			if !found {
+				t.Errorf("Expected to find mount for extra install repo %q, but did not", extraInstallRepo)
+			}
+		})
+
+		t.Run("with_mounted_apt_cache", func(t *testing.T) {
+			t.Parallel()
+
+			aptCachePrefix := "apt-cache-prefix"
+
+			c := &Config{
+				DefaultOutputImage: "foo",
+				VersionID:          "bar",
+				ContextRef:         "distro-context-ref",
+				AptCachePrefix:     aptCachePrefix,
+			}
+
+			ctx := t.Context()
+
+			sopt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					s := llb.Scratch()
+
+					return &s, nil
+				},
+			}
+
+			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
+
+			ops, err := test.LLBOpsFromState(ctx, state)
+			if err != nil {
+				t.Fatalf("failed to get llb ops from state: %v", err)
+			}
+
+			aptCacheFound := false
+
+			for _, op := range ops {
+				e := op.Op.GetExec()
+				if e == nil {
+					continue
+				}
+
+				for _, mount := range e.Mounts {
+					if mount.Dest == "/var/cache/apt" {
+						aptCacheFound = true
+
+						t.Run("with_configured_apt_cache_prefix", func(t *testing.T) {
+							t.Parallel()
+
+							if mount.CacheOpt == nil {
+								t.Fatalf("Expected cache mount to have cache options, got none")
+							}
+
+							if !strings.HasPrefix(mount.CacheOpt.ID, aptCachePrefix) {
+								t.Fatalf("Expected cache mount ID to have prefix %q, got %q", aptCachePrefix, mount.CacheOpt.ID)
+							}
+						})
+
+						break
+					}
+				}
+			}
+
+			if !aptCacheFound {
+				t.Fatalf("Apt cache mount not found before installing base packages")
+			}
+		})
+	})
+
+	t.Run("installs_base_packages", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with_upgrades_enabled", func(t *testing.T) {
+			t.Parallel()
+
+			c := &Config{
+				DefaultOutputImage: "foo",
+				BasePackages:       []string{"base-package-1"},
+				VersionID:          "bar",
+				ContextRef:         "distro-context-ref",
+			}
+
+			ctx := t.Context()
+
+			sopt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					s := llb.Scratch()
+
+					return &s, nil
+				},
+			}
+
+			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
+
+			ops, err := test.LLBOpsFromState(ctx, state)
+			if err != nil {
+				t.Fatalf("failed to get llb ops from state: %v", err)
+			}
+
+			for _, op := range ops {
+				e := op.Op.GetExec()
+				if e == nil || op.OpMetadata.ProgressGroup.Name != "Install base image packages" {
+					continue
+				}
+
+				for _, v := range e.Meta.Env {
+					s := strings.Split(v, "=")
+					if len(s) != 2 {
+						continue
+					}
+
+					if s[0] != "DALEC_UPGRADE" {
+						continue
+					}
+
+					expectedValue := "true"
+
+					if s[1] != expectedValue {
+						t.Fatalf("Expected DALEC_UPGRADE env to be %q, got %q", expectedValue, s[1])
+					}
+
+					return
+				}
+			}
+
+			t.Fatalf("Expected DALEC_UPGRADE to be set when installing base packages")
+		})
+
+		t.Run("before_installing_spec_package", func(t *testing.T) {
+			t.Parallel()
+
+			c := &Config{
+				DefaultOutputImage: "foo",
+				BasePackages:       []string{"base-package-1"},
+				VersionID:          "bar",
+				ContextRef:         "distro-context-ref",
+			}
+
+			ctx := t.Context()
+
+			sopt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					s := llb.Scratch()
+
+					return &s, nil
+				},
+			}
+
+			pkgSpec := &dalec.Spec{
+				Name:     "spec-package",
+				Packager: "foo",
+			}
+
+			pkg := c.BuildPkg(ctx, &testClient{}, sopt, pkgSpec, "target", dalec.ProgressGroup("foo"))
+
+			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", pkg, dalec.ProgressGroup("foo"))
+
+			ops, err := test.LLBOpsFromState(ctx, state)
+			if err != nil {
+				t.Fatalf("failed to get llb ops from state: %v", err)
+			}
+
+			basePkgFound := false
+			pkgFound := false
+
+			for _, op := range ops {
+				f := op.Op.GetFile()
+				if f == nil {
+					continue
+				}
+
+				for _, a := range f.Actions {
+					mkfile := a.GetMkfile()
+					if mkfile == nil {
+						continue
+					}
+
+					if string(mkfile.Path) != "/debian/control" {
+						continue
+					}
+
+					if strings.Contains(string(mkfile.Data), "base-package-1") {
+						if pkgFound {
+							t.Errorf("Base package found after spec package")
+						}
+
+						basePkgFound = true
+					}
+
+					if strings.Contains(string(mkfile.Data), "spec-package") {
+						pkgFound = true
+					}
+				}
+			}
+
+			if !basePkgFound {
+				t.Errorf("Base package not found in installation")
+			}
+		})
+
+		t.Run("with_apt_cache_mounts", func(t *testing.T) {
+			t.Parallel()
+
+			aptCachePrefix := "apt-cache-prefix"
+
+			c := &Config{
+				DefaultOutputImage: "foo",
+				BasePackages:       []string{"base-package-1"},
+				VersionID:          "bar",
+				ContextRef:         "distro-context-ref",
+				AptCachePrefix:     aptCachePrefix,
+			}
+
+			ctx := t.Context()
+
+			sopt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					s := llb.Scratch()
+
+					return &s, nil
+				},
+			}
+
+			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
+
+			ops, err := test.LLBOpsFromState(ctx, state)
+			if err != nil {
+				t.Fatalf("failed to get llb ops from state: %v", err)
+			}
+
+			aptCacheFound := false
+
+			for _, op := range ops {
+				e := op.Op.GetExec()
+				if e == nil || op.OpMetadata.ProgressGroup.Name != "Install base image packages" {
+					continue
+				}
+
+				for _, mount := range e.Mounts {
+					if mount.Dest == "/var/cache/apt" {
+						aptCacheFound = true
+
+						t.Run("with_configured_apt_cache_prefix", func(t *testing.T) {
+							t.Parallel()
+
+							if mount.CacheOpt == nil {
+								t.Fatalf("Expected cache mount to have cache options, got none")
+							}
+
+							if !strings.HasPrefix(mount.CacheOpt.ID, aptCachePrefix) {
+								t.Fatalf("Expected cache mount ID to have prefix %q, got %q", aptCachePrefix, mount.CacheOpt.ID)
+							}
+						})
+
+						break
+					}
+				}
+			}
+
+			if !aptCacheFound {
+				t.Fatalf("Apt cache mount not found before installing base packages")
+			}
+		})
+	})
+}
+
+// testClient should implement client.Client interface for testing purposes.
+type testClient struct {
+	buildOpts client.BuildOpts
+}
+
+func (tc *testClient) BuildOpts() client.BuildOpts {
+	return tc.buildOpts
+}
+
+func (tc *testClient) Solve(ctx context.Context, req client.SolveRequest) (*client.Result, error) {
+	return nil, nil
+}
+
+func (tc *testClient) Inputs(ctx context.Context) (map[string]llb.State, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (tc *testClient) NewContainer(ctx context.Context, req client.NewContainerRequest) (client.Container, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (tc *testClient) ResolveImageConfig(ctx context.Context, ref string, opt sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	return "", "", nil, errors.New("not implemented")
+}
+
+func (tc *testClient) ResolveSourceMetadata(ctx context.Context, op *pb.SourceOp, opt sourceresolver.Opt) (*sourceresolver.MetaResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (tc *testClient) Warn(ctx context.Context, dgst digest.Digest, msg string, opts client.WarnOpts) error {
+	return errors.New("not implemented")
+}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -20,11 +20,10 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/frontend"
+	"github.com/project-dalec/dalec/internal/test"
 	"github.com/tonistiigi/fsutil/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -295,14 +294,14 @@ func solveT(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient
 func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclient.Result) {
 	t.Helper()
 
-	allOps := []llbOp{}
+	allOps := []test.LLBOp{}
 
 	if err := res.EachRef(func(ref gwclient.Reference) error {
 		res := &gwclient.Result{
 			Ref: ref,
 		}
 
-		ops, err := llbOpsFromState(ctx, resultToState(t, res))
+		ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
 		if err != nil {
 			t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
 		}
@@ -314,7 +313,7 @@ func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclie
 		t.Fatalf("Unexpected error iterating over refs: %v", err)
 	}
 
-	badOps := []llbOp{}
+	badOps := []test.LLBOp{}
 
 	for _, op := range allOps {
 		// - Checking metadata for progress group presence is a good gauge for constraints propagation.
@@ -332,57 +331,12 @@ func verifyConstraintsPropagation(ctx context.Context, t *testing.T, res *gwclie
 		return
 	}
 
-	opsJSON, err := llbOpsToJSON(badOps)
+	opsJSON, err := test.LLBOpsToJSON(badOps)
 	if err != nil {
 		t.Fatalf("Unexpected error converting bad ops to JSON: %v", err)
 	}
 
 	t.Errorf("Found %d operations without progress group metadata:\n%s", len(badOps), opsJSON)
-}
-
-// This function and llbOp type has been inspired by
-// https://github.com/moby/buildkit/blob/c70e8e666f8f6ee3c0d83b20c338be5aedeaa97a/cmd/buildctl/debug/dumpllb.go#L59.
-func llbOpsFromState(ctx context.Context, state llb.State) ([]llbOp, error) {
-	def, err := state.Marshal(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var ops []llbOp
-	for _, dt := range def.Def {
-		var op pb.Op
-		if err := op.UnmarshalVT(dt); err != nil {
-			return nil, errors.Wrap(err, "failed to parse op")
-		}
-		dgst := digest.FromBytes(dt)
-		ent := llbOp{Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}
-
-		ops = append(ops, ent)
-	}
-
-	if len(ops) != 0 {
-		ops = ops[:len(ops)-1] // Last operation is a final export, it has no operations.
-	}
-
-	return ops, nil
-}
-
-func llbOpsToJSON(ops []llbOp) (string, error) {
-	var buf bytes.Buffer
-
-	enc := json.NewEncoder(&buf)
-	for _, op := range ops {
-		if err := enc.Encode(op); err != nil {
-			return "", err
-		}
-	}
-
-	return buf.String(), nil
-}
-
-type llbOp struct {
-	Op         *pb.Op
-	OpMetadata *pb.OpMetadata
 }
 
 func solveTCh(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient.SolveRequest, rc chan<- *gwclient.Result, ec chan<- error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of #448, to minimize a chance for regression once we re-implement deb container building to use minimal images, this PR adds additional tests to deb container building to cover untested parts of code. New tests can easily be extended to cover RPM containers as well.

Some tests cannot be written as integration tests, hence they are written as unit tests for container building.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Part of #448
