### PR TITLE
tests: Update cache dir test to not build different distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ COPY . .
 ENV CGO_ENABLED=0
 ARG TARGETARCH TARGETOS GOFLAGS=-trimpath
 ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=${GOFLAGS}
+ARG EXTRA_BUILD_FLAGS=""
 RUN \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /frontend ./cmd/frontend
+    go build -o /frontend ${EXTRA_BUILD_FLAGS} ./cmd/frontend
 
 FROM scratch AS frontend
 COPY --from=frontend-build /frontend /frontend

--- a/internal/frontendapi/alt_targets.go
+++ b/internal/frontendapi/alt_targets.go
@@ -1,0 +1,7 @@
+//go:build alt_testing_targets
+
+package frontendapi
+
+const (
+	includeAltTestingTargets = true
+)

--- a/internal/frontendapi/no_alt_targets.go
+++ b/internal/frontendapi/no_alt_targets.go
@@ -1,0 +1,7 @@
+//go:build !alt_testing_targets
+
+package frontendapi
+
+const (
+	includeAltTestingTargets = false
+)

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -13,11 +13,11 @@ const (
 )
 
 type BuildHandler interface {
-	HandleBuild(ctx context.Context, client client.Client) (*client.Result, error)
+	Handle(ctx context.Context, client client.Client) (*client.Result, error)
 }
 
 type BuildHandlerFunc func(ctx context.Context, client client.Client) (*client.Result, error)
 
-func (f BuildHandlerFunc) HandleBuild(ctx context.Context, client client.Client) (*client.Result, error) {
+func (f BuildHandlerFunc) Handle(ctx context.Context, client client.Client) (*client.Result, error) {
 	return f(ctx, client)
 }

--- a/targets/plugin/init.go
+++ b/targets/plugin/init.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"github.com/project-dalec/dalec/internal/plugins"
 	"github.com/project-dalec/dalec/targets"
 	"github.com/project-dalec/dalec/targets/linux/deb/debian"
 	"github.com/project-dalec/dalec/targets/linux/deb/ubuntu"
@@ -11,23 +12,23 @@ import (
 )
 
 func init() {
-	targets.RegisterBuildTarget(debian.TrixieDefaultTargetKey, debian.TrixieConfig.Handle)
-	targets.RegisterBuildTarget(debian.BookwormDefaultTargetKey, debian.BookwormConfig.Handle)
-	targets.RegisterBuildTarget(debian.BullseyeDefaultTargetKey, debian.BullseyeConfig.Handle)
+	targets.RegisterBuildTarget(debian.TrixieDefaultTargetKey, debian.TrixieConfig)
+	targets.RegisterBuildTarget(debian.BookwormDefaultTargetKey, debian.BookwormConfig)
+	targets.RegisterBuildTarget(debian.BullseyeDefaultTargetKey, debian.BullseyeConfig)
 
-	targets.RegisterBuildTarget(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig.Handle)
-	targets.RegisterBuildTarget(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig.Handle)
-	targets.RegisterBuildTarget(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig.Handle)
-	targets.RegisterBuildTarget(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig.Handle)
+	targets.RegisterBuildTarget(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig)
+	targets.RegisterBuildTarget(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig)
+	targets.RegisterBuildTarget(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig)
+	targets.RegisterBuildTarget(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig)
 
-	targets.RegisterBuildTarget(almalinux.V8TargetKey, almalinux.ConfigV8.Handle)
-	targets.RegisterBuildTarget(almalinux.V9TargetKey, almalinux.ConfigV9.Handle)
+	targets.RegisterBuildTarget(almalinux.V8TargetKey, almalinux.ConfigV8)
+	targets.RegisterBuildTarget(almalinux.V9TargetKey, almalinux.ConfigV9)
 
-	targets.RegisterBuildTarget(rockylinux.V8TargetKey, rockylinux.ConfigV8.Handle)
-	targets.RegisterBuildTarget(rockylinux.V9TargetKey, rockylinux.ConfigV9.Handle)
+	targets.RegisterBuildTarget(rockylinux.V8TargetKey, rockylinux.ConfigV8)
+	targets.RegisterBuildTarget(rockylinux.V9TargetKey, rockylinux.ConfigV9)
 
-	targets.RegisterBuildTarget(azlinux.Mariner2TargetKey, azlinux.Mariner2Config.Handle)
-	targets.RegisterBuildTarget(azlinux.AzLinux3TargetKey, azlinux.Azlinux3Config.Handle)
+	targets.RegisterBuildTarget(azlinux.Mariner2TargetKey, azlinux.Mariner2Config)
+	targets.RegisterBuildTarget(azlinux.AzLinux3TargetKey, azlinux.Azlinux3Config)
 
-	targets.RegisterBuildTarget(windows.DefaultTargetKey, windows.Handle)
+	targets.RegisterBuildTarget(windows.DefaultTargetKey, plugins.BuildHandlerFunc(windows.Handle))
 }

--- a/targets/register.go
+++ b/targets/register.go
@@ -1,16 +1,15 @@
 package targets
 
 import (
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-dalec/dalec/internal/plugins"
 )
 
-func RegisterBuildTarget(name string, build gwclient.BuildFunc) {
+func RegisterBuildTarget(name string, build plugins.BuildHandler) {
 	plugins.Register(&plugins.Registration{
 		ID:   name,
 		Type: plugins.TypeBuildTarget,
 		InitFn: func(*plugins.InitContext) (interface{}, error) {
-			return plugins.BuildHandlerFunc(build), nil
+			return build, nil
 		},
 	})
 }

--- a/test/testenv/build.go
+++ b/test/testenv/build.go
@@ -52,8 +52,10 @@ func buildBaseFrontend(ctx context.Context, c gwclient.Client) (*gwclient.Result
 
 	defPB := def.ToPB()
 	return c.Solve(ctx, gwclient.SolveRequest{
-		Frontend:    "dockerfile.v0",
-		FrontendOpt: map[string]string{},
+		Frontend: "dockerfile.v0",
+		FrontendOpt: map[string]string{
+			"build-arg:EXTRA_BUILD_FLAGS": "-tags alt_testing_targets",
+		},
 		FrontendInputs: map[string]*pb.Definition{
 			dockerui.DefaultLocalNameContext:    defPB,
 			dockerui.DefaultLocalNameDockerfile: dockerfileDef.ToPB(),


### PR DESCRIPTION
This test was always building a distro that is not the current distro under test for the purpose of validating cache key generation. This is undesirable for CI because we want to split each distro into separate jobs.
Before this change the the job for, e.g., testing jammy would also build noble.

This change adds a build tag that we use for tests that injects the same distro implementation twice with but with a modified target key name. e.g. adds "jammy" and "jammyalt".
This allows us to test the same case but without having to build an entirely different distro stack.
