### PR TITLE
frontend: fix handling no-cache filters

### DIFF
--- a/frontend/request.go
+++ b/frontend/request.go
@@ -1,7 +1,6 @@
 package frontend
 
 import (
-	"bufio"
 	"context"
 	"strconv"
 	"strings"
@@ -320,22 +319,17 @@ func IgnoreCache(client gwclient.Client, refs ...string) llb.ConstraintsOpt {
 		return llb.IgnoreCache
 	}
 
-	rdr := bufio.NewReader(strings.NewReader(v))
 	idx := make(map[string]struct{}, len(refs))
 
 	for _, ref := range refs {
 		idx[ref] = struct{}{}
 	}
 
-	for {
-		ref, err := rdr.ReadString(',')
-		if err != nil {
-			// The only error here should be io.EOF, meaning we got to the end of the string.
-			return dalec.ConstraintsOptFunc(func(c *llb.Constraints) {})
-		}
-
-		if _, ok := idx[ref]; ok {
+	for filter := range strings.SplitSeq(v, ",") {
+		if _, ok := idx[filter]; ok {
 			return llb.IgnoreCache
 		}
 	}
+
+	return dalec.ConstraintsOptFunc(func(c *llb.Constraints) {})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There are at least 2 bugs in the current implementation of IgnoreCache function:

1. bufio.NewReader.ReadString as stated in the docs:

   If ReadString encounters an error before finding a delimiter, it returns the data read before the error and the error itself (often io.EOF).

   This means when there is only a single filter specified, it will be returned together with io.EOF, meaning no cache ignoring will actually happen with existing code.

2. bufio.NewReader.ReadString as stated in the docs:

   ReadString reads until the first occurrence of delim in the input, returning a string containing the data up to and including the delimiter.

   As we register keys without a delimiter but compare them with one, ignoring cache will actually never work.

This patch fixes both issues by using strings.SplitSeq to split the filters.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Closes #949