### PR TITLE
Fix version matching test

### DIFF
--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go/version"
 	"io"
 	"io/fs"
 	"os"
@@ -97,10 +96,11 @@ type testLinuxConfig struct {
 		Units   string
 		Targets string
 	}
-	Libdir    string
-	Worker    workerConfig
-	Release   OSRelease
-	GoVersion string
+	Libdir  string
+	Worker  workerConfig
+	Release OSRelease
+
+	SupportsGomodVersionUpdate bool
 
 	Platforms         []ocispecs.Platform
 	PackageOutputPath func(spec *dalec.Spec, platform ocispecs.Platform) string
@@ -2274,8 +2274,7 @@ func True(t interface{}, value bool, msgAndArgs ...interface{}) bool {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
 
-		// Skip on distros with Go versions below 1.21 that can't handle automatic toolchain management
-		skip.If(t, testConfig.GoVersion == "" || version.Compare("go"+testConfig.GoVersion, "go1.21") < 0,
+		skip.If(t, !testConfig.SupportsGomodVersionUpdate,
 			"Test requires Go 1.21+ for automatic toolchain management")
 
 		// Start with go.mod and go.work both at go 1.18

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -45,7 +45,7 @@ func TestAlmalinux9(t *testing.T) {
 			ID:        "almalinux",
 			VersionID: "9",
 		},
-		GoVersion: "1.25",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},
@@ -91,7 +91,7 @@ func TestAlmalinux8(t *testing.T) {
 			ID:        "almalinux",
 			VersionID: "8",
 		},
-		GoVersion: "1.25",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -70,7 +70,7 @@ func TestMariner2(t *testing.T) {
 			ID:        "mariner",
 			VersionID: "2.0",
 		},
-		GoVersion: "1.22",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},
@@ -114,7 +114,7 @@ func TestAzlinux3(t *testing.T) {
 			ID:        "azurelinux",
 			VersionID: "3.0",
 		},
-		GoVersion: "1.25",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},

--- a/test/target_debian_test.go
+++ b/test/target_debian_test.go
@@ -16,7 +16,7 @@ func TestTrixie(t *testing.T) {
 	testConf := debLinuxTestConfigFor(
 		debian.TrixieDefaultTargetKey,
 		debian.TrixieConfig,
-		withGoVersion("1.24"),
+		withSupportGomodVersionUpdate(),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", "bazel-bootstrap"),
 	)
@@ -32,7 +32,6 @@ func TestBookworm(t *testing.T) {
 	testConf := debLinuxTestConfigFor(
 		debian.BookwormDefaultTargetKey,
 		debian.BookwormConfig,
-		withGoVersion("1.19"),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", "bazel-bootstrap"),
 	)
@@ -48,7 +47,6 @@ func TestBullseye(t *testing.T) {
 	testConf := debLinuxTestConfigFor(
 		debian.BullseyeDefaultTargetKey,
 		debian.BullseyeConfig,
-		withGoVersion("1.19"),
 		withPackageOverride("golang", "golang-1.19"),
 		withPackageOverride("rust", "cargo-web"),
 		withPackageOverride("bazel", noPackageAvailable),

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -45,7 +45,7 @@ func TestRockylinux9(t *testing.T) {
 			ID:        "rocky",
 			VersionID: "9",
 		},
-		GoVersion: "1.25",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},
@@ -91,7 +91,7 @@ func TestRockylinux8(t *testing.T) {
 			ID:        "rocky",
 			VersionID: "8",
 		},
-		GoVersion: "1.25",
+		SupportsGomodVersionUpdate: true,
 		Platforms: []ocispecs.Platform{
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64"},

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -23,9 +23,9 @@ func withPackageOverride(oldPkg, newPkg string) func(cfg *testLinuxConfig) {
 	}
 }
 
-func withGoVersion(version string) func(cfg *testLinuxConfig) {
+func withSupportGomodVersionUpdate() func(cfg *testLinuxConfig) {
 	return func(cfg *testLinuxConfig) {
-		cfg.GoVersion = version
+		cfg.SupportsGomodVersionUpdate = true
 	}
 }
 
@@ -160,7 +160,6 @@ func TestJammy(t *testing.T) {
 
 	ctx := startTestSpan(baseCtx, t)
 	testConf := debLinuxTestConfigFor(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig,
-		withGoVersion("1.18"),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", noPackageAvailable),
 		withPackageOverride("python", "python3 python3-pip"),
@@ -175,7 +174,7 @@ func TestNoble(t *testing.T) {
 
 	ctx := startTestSpan(baseCtx, t)
 	testConf := debLinuxTestConfigFor(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig,
-		withGoVersion("1.22"),
+		withSupportGomodVersionUpdate(),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", "bazel-bootstrap"),
 	)
@@ -188,7 +187,7 @@ func TestFocal(t *testing.T) {
 
 	ctx := startTestSpan(baseCtx, t)
 	testConf := debLinuxTestConfigFor(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig,
-		withGoVersion("1.22"),
+		withSupportGomodVersionUpdate(),
 		withPackageOverride("golang", "golang-1.22"),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", noPackageAvailable),
@@ -203,7 +202,6 @@ func TestBionic(t *testing.T) {
 
 	ctx := startTestSpan(baseCtx, t)
 	testConf := debLinuxTestConfigFor(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig,
-		withGoVersion("1.18"),
 		withPackageOverride("golang", "golang-1.18"),
 		withPackageOverride("rust", "rust-all"),
 		withPackageOverride("bazel", noPackageAvailable),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with the version matching test where the go version gets bumped too high and we need to set whether each distro supports go mod version updates

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
