### PR TITLE
release: fix warning in attestation artifacts

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -28,6 +28,7 @@ jobs:
       packages: write
       id-token: write  # Required for cosign OIDC signing
       attestations: write  # Required for GitHub attestations
+      artifact-metadata: write # Required for certain parts of GitHub attestations (actions/attest complains if not set)
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/worker-images.yml
+++ b/.github/workflows/worker-images.yml
@@ -42,6 +42,7 @@ jobs:
       packages: write
       id-token: write  # Required for cosign OIDC signing
       attestations: write  # Required for GitHub attestations
+      artifact-metadata: write # Required for certain parts of GitHub attestations (actions/attest complains if not set)
     needs: load-matrix
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
Noticed a warning in https://github.com/project-dalec/dalec/actions/runs/21650731806

```
Run actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f
Run actions/attest-build-provenance/predicate@864457a58d4733d7f1574bd8821fa24e02cf7538
Run actions/attest@e59cbc1ad1ac2d59339667419eb8cdde6eb61e3d Warning: Failed to create storage record: Error: Failed to persist storage record: no artifacts found - https://docs.github.com/rest/orgs/artifact-metadata#create-artifact-metadata-storage-record Warning: Please check that the "artifact-metadata:write" permission has been included Attestation created for ghcr.io/project-dalec/dalec/frontend@sha256:8fef7a51dfb9852b97d53ca35ba6eb6828ab5a1bb7ae7709ba6ec23032597bad
```

This should take care of that warning.
