### PR TITLE
frontend: prefer dnf over tdnf to work around tdnf GPG and forcearch limitations

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,7 +3,7 @@ group "default" {
 }
 
 group "test" {
-    targets = ["runc-test", "test-deps-only"]
+    targets = ["runc-test"]
 }
 
 variable "FRONTEND_REF" {
@@ -226,42 +226,6 @@ target "examples" {
     dockerfile = "docs/examples/${f}.yml"
     tags = ["local/dalec/examples/${f}:${distro}"]
 }
-
-target "deps-only" {
-    name = "deps-only-${distro}"
-    matrix = {
-        distro = ["mariner2"]
-    }
-    dockerfile-inline = <<EOT
-dependencies:
-    runtime:
-        patch: {}
-        bash: {}
-    EOT
-    args = {
-        "BUILDKIT_SYNTAX" = "dalec_frontend"
-    }
-    contexts = {
-        "dalec_frontend" = "target:frontend"
-    }
-    target = "${distro}/container/depsonly"
-    tags = ["local/dalec/deps-only:${distro}"]
-}
-
-target "test-deps-only" {
-    dockerfile-inline = <<EOT
-    FROM deps-only-context
-    # Make sure the deps-only target has the runtime dependencies we expect and not, for instance, "rpm"
-    RUN command -v bash
-    RUN command -v patch
-    RUN if command -v rpm; then echo should be a distroless image but rpm binary is installed; exit 1; fi
-    EOT
-
-    contexts = {
-        "deps-only-context" = "target:deps-only-mariner2"
-    }
-}
-
 
 variable "CI_FRONTEND_CACHE_SCOPE" {
     default = "dalec/frontend/ci"

--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -95,16 +95,36 @@ func (cfg *Config) HandleDepsOnly(ctx context.Context, client gwclient.Client) (
 		}
 
 		pc := dalec.Platform(platform)
-		worker := cfg.Worker(sOpt, pg, pc)
 
-		deps := dalec.SortMapKeys(rtDeps)
+		// NOTE: Deps-only allows bare specs, ie specs with just the runtime deps included.
+		// This means we may need to fill in some of the details that are required by the package manager.
+		depsSpec := &dalec.Spec{
+			Name:        spec.Name + "-runtime-deps",
+			License:     spec.License,
+			Version:     spec.Version,
+			Revision:    spec.Revision,
+			Description: "Runtime dependencies meta package",
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: rtDeps,
+			},
+		}
 
-		withDownloads := worker.Run(dalec.ShArgs("set -ex; mkdir -p /tmp/rpms/RPMS/$(uname -m)")).
-			Run(cfg.Install(deps,
-				DnfDownloadAllDeps("/tmp/rpms/RPMS/$(uname -m)")), pg).Root()
-		rpmDir := llb.Scratch().File(llb.Copy(withDownloads, "/tmp/rpms", "/", dalec.WithDirContentsOnly()), pg)
+		if depsSpec.Name == "-runtime-deps" {
+			// Name cannot start with "-"
+			depsSpec.Name = "dalec-user" + depsSpec.Name
+		}
+		if depsSpec.Version == "" {
+			depsSpec.Version = "0.0.1"
+		}
+		if depsSpec.Revision == "" {
+			depsSpec.Revision = "1"
+		}
+		if depsSpec.License == "" {
+			depsSpec.License = "MIT"
+		}
 
-		ctr := cfg.BuildContainer(ctx, client, sOpt, spec, targetKey, rpmDir, pg, pc)
+		pkg := cfg.BuildPkg(ctx, client, sOpt, depsSpec, targetKey, pg)
+		ctr := cfg.BuildContainer(ctx, client, sOpt, spec, targetKey, pkg, pg)
 
 		def, err := ctr.Marshal(ctx, pc)
 		if err != nil {

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -183,12 +183,18 @@ if [ -x "$import_keys_path" ]; then
 	"$import_keys_path"
 fi
 
+if [ "$cmd" = "tdnf" ] && command -v dnf &>/dev/null; then
+	# tdnf has a lot of limitations that cause issues (no --forcearch, issues with gpg keys on local file installs)
+	# We already have dnf, so prefer that.
+	cmd="dnf"
+fi
+
 if [ -n "$force_arch" ]; then
-        if [ "$cmd" = "tdnf" ]; then
-                echo "tdnf does not support --forcearch; cross-arch installs must use dnf" >&2
-                exit 70
-        fi
-        install_flags="$install_flags --forcearch=$force_arch"
+	if [ "$cmd" = "tdnf" ]; then
+		echo "tdnf does not support --forcearch; cross-arch installs must use dnf" >&2
+		exit 70
+	fi
+	install_flags="$install_flags --forcearch=$force_arch"
 fi
 
 $cmd $dnf_sub_cmd $install_flags "${@}"
@@ -276,6 +282,8 @@ func DnfInstall(cfg *dnfInstallConfig, releaseVer string, pkgs []string) llb.Run
 	return dnfCommand(cfg, releaseVer, "dnf", append([]string{"install"}, pkgs...), nil)
 }
 
+// TdnfInstall uses tdnf to install packages
+// NOTE: tdnf will be automatically upgraded to dnf to work around tdnf limitations *if* dnf is available
 func TdnfInstall(cfg *dnfInstallConfig, releaseVer string, pkgs []string) llb.RunOption {
 	return dnfCommand(cfg, releaseVer, "tdnf", append([]string{"install"}, pkgs...), nil)
 }

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -34,12 +34,6 @@ type dnfInstallConfig struct {
 
 	constraints []llb.ConstraintsOpt
 
-	downloadOnly bool
-
-	allDeps bool
-
-	downloadDir string
-
 	// When true, don't omit docs from the installed RPMs.
 	includeDocs bool
 
@@ -82,14 +76,6 @@ func DnfForceArch(arch string) DnfInstallOpt {
 	}
 }
 
-func DnfDownloadAllDeps(dest string) DnfInstallOpt {
-	return func(cfg *dnfInstallConfig) {
-		cfg.downloadOnly = true
-		cfg.allDeps = true
-		cfg.downloadDir = dest
-	}
-}
-
 func IncludeDocs(v bool) DnfInstallOpt {
 	return func(cfg *dnfInstallConfig) {
 		cfg.includeDocs = v
@@ -108,18 +94,6 @@ func dnfInstallFlags(cfg *dnfInstallConfig) string {
 	if cfg.root != "" {
 		cmdOpts += " --installroot=" + cfg.root
 		cmdOpts += " --setopt=reposdir=/etc/yum.repos.d"
-	}
-
-	if cfg.downloadOnly {
-		cmdOpts += " --downloadonly"
-	}
-
-	if cfg.allDeps {
-		cmdOpts += " --alldeps"
-	}
-
-	if cfg.downloadDir != "" {
-		cmdOpts += " --downloaddir " + cfg.downloadDir
 	}
 
 	if !cfg.includeDocs {

--- a/targets/linux/rpm/distro/worker.go
+++ b/targets/linux/rpm/distro/worker.go
@@ -3,6 +3,7 @@ package distro
 import (
 	"context"
 	"encoding/json"
+	"slices"
 
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
@@ -142,6 +143,14 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 	}
 
 	if samePlatform(targetPlat, buildPlat) {
+		if slices.Contains(cfg.BuilderPackages, "dnf") {
+			// Install dnf first since this will be bootstrapped with a different package manager
+			// This keeps the package cache for the bootstrap mananager separate from the other base packages we use.
+			targetBase = targetBase.Run(
+				dalec.WithConstraints(append(opts, llb.Platform(targetPlat))...),
+				cfg.Install([]string{"dnf"}, installOpts...),
+			).Root()
+		}
 		return targetBase.Run(
 			dalec.WithConstraints(append(opts, llb.Platform(targetPlat))...),
 			cfg.Install(cfg.BuilderPackages, installOpts...),

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -61,6 +61,8 @@ type targetConfig struct {
 	Package string
 	// Container is the target for creating a container
 	Container string
+	// DepsOnly is the target for creating a deps-only container (no package built, only runtime deps installed).
+	DepsOnly string
 	// Worker is the target for creating the worker image.
 	Worker string
 	// Sysext is the target for creating a systemd system extension.
@@ -717,6 +719,16 @@ index 0000000..5260cb1
 
 	t.Run("container", func(t *testing.T) {
 		t.Parallel()
+
+		t.Run("depsonly", func(t *testing.T) {
+			if testConfig.Target.DepsOnly == "" {
+				t.Skip("depsonly target not defined")
+			}
+
+			t.Parallel()
+			ctx := startTestSpan(ctx, t)
+			testDepsOnly(ctx, t, testConfig)
+		})
 
 		t.Run("creates_post_install_symlinks", func(t *testing.T) {
 			t.Parallel()
@@ -5400,6 +5412,85 @@ echo "This is a third test binary"
 		if err != nil {
 			t.Fatal(err)
 		}
+	})
+}
+
+func testDepsOnly(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
+	t.Run("minimal spec", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := &dalec.Spec{
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					"curl": {},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(testConfig.Target.DepsOnly))
+			res := solveT(ctx, t, client, req)
+
+			ref, err := res.SingleRef()
+			assert.NilError(t, err)
+
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/curl"})
+			assert.NilError(t, err)
+		})
+	})
+
+	t.Run("full spec", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		// Full spec includes sources, build steps, and a shell script artifact.
+		// The deps-only target should install only runtime deps (curl) and NOT
+		// include the built artifact (/usr/bin/my-script) or its implicit dep.
+		spec := fillMetadata("test-deps-only-full", &dalec.Spec{
+			Sources: map[string]dalec.Source{
+				"my-script": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents:    "#!/usr/bin/env bash\necho hello from deps-only test\n",
+							Permissions: 0o700,
+						},
+					},
+				},
+			},
+			Build: dalec.ArtifactBuild{
+				Steps: []dalec.BuildStep{
+					{Command: "/bin/true"},
+				},
+			},
+			Artifacts: dalec.Artifacts{
+				Binaries: map[string]dalec.ArtifactConfig{
+					"my-script": {},
+				},
+			},
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: map[string]dalec.PackageConstraints{
+					"curl": {},
+				},
+			},
+		})
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(testConfig.Target.DepsOnly))
+			res := solveT(ctx, t, client, req)
+
+			ref, err := res.SingleRef()
+			assert.NilError(t, err)
+
+			// Runtime dep should be installed.
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/curl"})
+			assert.NilError(t, err)
+
+			// The shell script artifact should NOT be present — deps-only
+			// never builds the package, so no artifacts are installed.
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: "/usr/bin/my-script"})
+			assert.ErrorContains(t, err, "no such file")
+		})
 	})
 }
 

--- a/test/signing_test.go
+++ b/test/signing_test.go
@@ -598,3 +598,105 @@ func distroSkipSigningTest(t *testing.T, spec *dalec.Spec, buildTarget string, e
 		}
 	}
 }
+
+// signRPMs signs all RPM files in the package state using a GPG key.
+// The worker state must have rpmsign available (or tdnf/dnf to install it).
+// The gpgKey state is expected to have a private key at /private.key
+// (as produced by [generateGPGKey]).
+// The pkgState is expected to have RPMs under /RPMS/<arch>/*.rpm
+// (the standard package target output).
+// It returns the modified package state with signed RPMs.
+func signRPMs(worker llb.State, gpgKey llb.State, pkgState llb.State) llb.State {
+	pg := dalec.ProgressGroup("Sign RPMs with GPG key")
+
+	scriptDt := `#!/usr/bin/env bash
+set -eux -o pipefail
+
+if ! command -v rpmsign &> /dev/null; then
+	if command -v tdnf &> /dev/null; then
+		tdnf install -y rpm-sign
+	elif command -v dnf &> /dev/null; then
+		dnf install -y rpm-sign
+	fi
+fi
+
+gpg --import < /tmp/gpg/private.key
+ID=$(gpg --list-keys --keyid-format LONG | awk '/^pub/{print $2}' | cut -d/ -f2 | head -1)
+
+echo "%_gpg_name $ID" > ~/.rpmmacros
+
+find /tmp/rpms/RPMS -name "*.rpm" -exec rpmsign --addsign {} \;
+`
+
+	script := llb.Scratch().File(
+		llb.Mkfile("/script.sh", 0o755, []byte(scriptDt)),
+		pg,
+	)
+
+	return worker.Run(
+		llb.AddMount("/tmp/signing", script, llb.Readonly),
+		llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
+		llb.AddMount("/tmp/rpms", pkgState),
+		dalec.ShArgs("/tmp/signing/script.sh"),
+		pg,
+	).GetMount("/tmp/rpms")
+}
+
+// testSignedRPMCustomBaseImage tests that signed RPMs can be installed into
+// a container with a custom base image.
+//
+// This reproduces a bug where the tdnfrepogpgcheck plugin rejects signed RPMs
+// installed via "tdnf install /path/to/signed.rpm --installroot=/tmp/rootfs"
+// because the @cmdline virtual repo has no gpgkey entry.
+//
+// The distroImageRef parameter is the image reference for the distro's base
+// image (e.g., azlinux.Azlinux3Ref), which is used as the custom base image
+// in the spec.
+func testSignedRPMCustomBaseImage(ctx context.Context, t *testing.T, targetCfg targetConfig, distroImageRef string) {
+	t.Run("signed rpm with custom base image", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			// Get the worker state — we need it to generate GPG keys and sign RPMs.
+			sr := newSolveRequest(withBuildTarget(targetCfg.Worker), withSpec(ctx, t, nil))
+			w := reqToState(ctx, client, sr, t)
+
+			// Generate a GPG key pair for signing.
+			gpgKey := generateGPGKey(w, true)
+
+			// Create a simple spec and build the RPM package.
+			spec := newSimpleSpec()
+			pkgSr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Package))
+			pkgSt := reqToState(ctx, client, pkgSr, t)
+
+			// Sign the RPMs on the worker using rpmsign --addsign.
+			signedPkgSt := signRPMs(w, gpgKey, pkgSt)
+
+			// Create a container spec with a custom base image.
+			// This triggers skipBase=true in BuildContainer, meaning the RPMs
+			// are installed via "tdnf install /path/to/signed.rpm --installroot=/tmp/rootfs"
+			// into the custom base image's rootfs.
+			spec.Image = &dalec.ImageConfig{
+				Entrypoint: "/usr/bin/foo",
+				Bases: []dalec.BaseImage{
+					{
+						Rootfs: dalec.Source{
+							DockerImage: &dalec.SourceDockerImage{
+								Ref: distroImageRef,
+							},
+						},
+					},
+				},
+			}
+
+			containerSr := newSolveRequest(
+				withSpec(ctx, t, spec),
+				withBuildTarget(targetCfg.Container),
+				withBuildContext(ctx, t, dalec.GenericPkg, signedPkgSt),
+			)
+
+			solveT(ctx, t, client, containerSr)
+		})
+	})
+}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -11,7 +12,7 @@ func TestAlmalinux9(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, testLinuxConfig{
+	cfg := testLinuxConfig{
 		Target: targetConfig{
 			Key:       "almalinux9",
 			Package:   "almalinux9/rpm",
@@ -51,14 +52,16 @@ func TestAlmalinux9(t *testing.T) {
 			{OS: "linux", Architecture: "arm64"},
 		},
 		PackageOutputPath: rpmTargetOutputPath("el9"),
-	})
+	}
+	testLinuxDistro(ctx, t, cfg)
+	testAlmalinuxExtra(ctx, t, cfg, almalinux.ConfigV9.ImageRef)
 }
 
 func TestAlmalinux8(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, testLinuxConfig{
+	cfg := testLinuxConfig{
 		Target: targetConfig{
 			Package:   "almalinux8/rpm",
 			Container: "almalinux8/container",
@@ -97,5 +100,11 @@ func TestAlmalinux8(t *testing.T) {
 			{OS: "linux", Architecture: "arm64"},
 		},
 		PackageOutputPath: rpmTargetOutputPath("el8"),
-	})
+	}
+	testLinuxDistro(ctx, t, cfg)
+	testAlmalinuxExtra(ctx, t, cfg, almalinux.ConfigV8.ImageRef)
+}
+
+func testAlmalinuxExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig, distroImageRef string) {
+	testSignedRPMCustomBaseImage(ctx, t, cfg.Target, distroImageRef)
 }

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -17,6 +17,7 @@ func TestAlmalinux9(t *testing.T) {
 			Key:       "almalinux9",
 			Package:   "almalinux9/rpm",
 			Container: "almalinux9/container",
+			DepsOnly:  "almalinux9/container/depsonly",
 			Worker:    "almalinux9/worker",
 			FormatDepEqual: func(v, _ string) string {
 				return v
@@ -65,6 +66,7 @@ func TestAlmalinux8(t *testing.T) {
 		Target: targetConfig{
 			Package:   "almalinux8/rpm",
 			Container: "almalinux8/container",
+			DepsOnly:  "almalinux8/container/depsonly",
 			Worker:    "almalinux8/worker",
 			FormatDepEqual: func(v, _ string) string {
 				return v

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -63,7 +63,7 @@ func TestMariner2(t *testing.T) {
 		Worker: workerConfig{
 			ContextName:    azlinux.Mariner2WorkerContextName,
 			CreateRepo:     createYumRepo(azlinux.Mariner2Config),
-			SignRepo:       signRepoAzLinux,
+			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
 		},
 		Release: OSRelease{
@@ -79,7 +79,7 @@ func TestMariner2(t *testing.T) {
 	}
 
 	testLinuxDistro(ctx, t, cfg)
-	testAzlinuxExtra(ctx, t, cfg)
+	testAzlinuxExtra(ctx, t, cfg, azlinux.Mariner2Config.ImageRef)
 }
 
 func TestAzlinux3(t *testing.T) {
@@ -106,7 +106,7 @@ func TestAzlinux3(t *testing.T) {
 		Worker: workerConfig{
 			ContextName:    azlinux.Azlinux3WorkerContextName,
 			CreateRepo:     createYumRepo(azlinux.Azlinux3Config),
-			SignRepo:       signRepoAzLinux,
+			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
 			SysextWorker:   azlinux.Azlinux3Config.SysextWorker,
 		},
@@ -122,7 +122,7 @@ func TestAzlinux3(t *testing.T) {
 		PackageOutputPath: rpmTargetOutputPath("azl3"),
 	}
 	testLinuxDistro(ctx, t, cfg)
-	testAzlinuxExtra(ctx, t, cfg)
+	testAzlinuxExtra(ctx, t, cfg, azlinux.Azlinux3Config.ImageRef)
 
 	t.Run("ca-certs override", func(t *testing.T) {
 		t.Parallel()
@@ -131,12 +131,14 @@ func TestAzlinux3(t *testing.T) {
 	})
 }
 
-func testAzlinuxExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
+func testAzlinuxExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig, distroImageRef string) {
 	t.Run("base deps", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)
 		testAzlinuxBaseDeps(ctx, t, cfg.Target)
 	})
+
+	testSignedRPMCustomBaseImage(ctx, t, cfg.Target, distroImageRef)
 }
 
 func testAzlinuxCaCertsOverride(ctx context.Context, t *testing.T, target targetConfig) {
@@ -171,49 +173,6 @@ func azlinuxListSignFiles(ver string) func(*dalec.Spec, ocispecs.Platform) []str
 			filepath.Join("SRPMS", fmt.Sprintf("%s.src.rpm", base)),
 			filepath.Join("RPMS", arch, fmt.Sprintf("%s.%s.rpm", base, arch)),
 		}
-	}
-}
-
-func signRepoAzLinux(gpgKey llb.State, repoPath string) llb.StateOption {
-	// key should be a state that has a public key under /public.key
-	return func(in llb.State) llb.State {
-		// For tdnf-based distros (Azlinux, Mariner), only sign repo metadata.
-		// tdnf only verifies repo metadata signatures, not individual package signatures.
-		// This is different from dnf which verifies both.
-
-		scriptDt := `
-#!/usr/bin/env bash
-
-set -eux -o pipefail
-
-gpg --import < /tmp/gpg/private.key
-ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2)
-
-# For tdnf-based distros, only sign repo metadata, not individual packages
-# tdnf only checks repo metadata signatures, not package signatures
-# Signing packages can hang if rpmsign tries to prompt for passphrase
-
-# Regenerate repo metadata
-rm -rf ` + repoPath + `/repodata
-createrepo --compatibility ` + repoPath + `
-
-# Sign only the repo metadata
-gpg --detach-sign --default-key "$ID" --armor --yes ` + repoPath + `/repodata/repomd.xml
-`
-
-		pg := dalec.ProgressGroup("in-signing-script")
-
-		script := llb.Scratch().File(
-			llb.Mkfile("/script.sh", 0o755, []byte(scriptDt)),
-			pg,
-		)
-
-		return in.Run(
-			llb.AddMount("/tmp/signing", script, llb.Readonly),
-			llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
-			dalec.ShArgs("/tmp/signing/script.sh"),
-			pg,
-		).Root()
 	}
 }
 

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -46,6 +46,7 @@ func TestMariner2(t *testing.T) {
 			Key:       azlinux.Mariner2TargetKey,
 			Package:   "mariner2/rpm",
 			Container: "mariner2/container",
+			DepsOnly:  "mariner2/container/depsonly",
 			Worker:    "mariner2/worker",
 			FormatDepEqual: func(v, _ string) string {
 				return v
@@ -91,6 +92,7 @@ func TestAzlinux3(t *testing.T) {
 			Key:                   "azlinux3",
 			Package:               "azlinux3/rpm",
 			Container:             "azlinux3/container",
+			DepsOnly:              "azlinux3/container/depsonly",
 			Worker:                "azlinux3/worker",
 			Sysext:                "azlinux3/testing/sysext",
 			ListExpectedSignFiles: azlinuxListSignFiles("azl3"),

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -11,7 +12,7 @@ func TestRockylinux9(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, testLinuxConfig{
+	cfg := testLinuxConfig{
 		Target: targetConfig{
 			Key:       "rockylinux9",
 			Package:   "rockylinux9/rpm",
@@ -51,14 +52,16 @@ func TestRockylinux9(t *testing.T) {
 			{OS: "linux", Architecture: "arm64"},
 		},
 		PackageOutputPath: rpmTargetOutputPath("el9"),
-	})
+	}
+	testLinuxDistro(ctx, t, cfg)
+	testRockylinuxExtra(ctx, t, cfg, rockylinux.ConfigV9.ImageRef)
 }
 
 func TestRockylinux8(t *testing.T) {
 	t.Parallel()
 
 	ctx := startTestSpan(baseCtx, t)
-	testLinuxDistro(ctx, t, testLinuxConfig{
+	cfg := testLinuxConfig{
 		Target: targetConfig{
 			Package:   "rockylinux8/rpm",
 			Container: "rockylinux8/container",
@@ -97,5 +100,11 @@ func TestRockylinux8(t *testing.T) {
 			{OS: "linux", Architecture: "arm64"},
 		},
 		PackageOutputPath: rpmTargetOutputPath("el8"),
-	})
+	}
+	testLinuxDistro(ctx, t, cfg)
+	testRockylinuxExtra(ctx, t, cfg, rockylinux.ConfigV8.ImageRef)
+}
+
+func testRockylinuxExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig, distroImageRef string) {
+	testSignedRPMCustomBaseImage(ctx, t, cfg.Target, distroImageRef)
 }

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -17,6 +17,7 @@ func TestRockylinux9(t *testing.T) {
 			Key:       "rockylinux9",
 			Package:   "rockylinux9/rpm",
 			Container: "rockylinux9/container",
+			DepsOnly:  "rockylinux9/container/depsonly",
 			Worker:    "rockylinux9/worker",
 			FormatDepEqual: func(v, _ string) string {
 				return v
@@ -65,6 +66,7 @@ func TestRockylinux8(t *testing.T) {
 		Target: targetConfig{
 			Package:   "rockylinux8/rpm",
 			Container: "rockylinux8/container",
+			DepsOnly:  "rockylinux8/container/depsonly",
 			Worker:    "rockylinux8/worker",
 			FormatDepEqual: func(v, _ string) string {
 				return v

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -123,7 +123,7 @@ func signRepoUbuntu(gpgKey llb.State, repoPath string) llb.StateOption {
 			llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
 			dalec.ProgressGroup("Importing gpg key")).
 			Run(
-				dalec.ShArgs(`ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2) && \
+				dalec.ShArgs(`ID=$(gpg --list-keys --keyid-format LONG | awk '/^pub/{print $2}' | cut -d/ -f2 | head -1) && \
 					gpg --list-keys --keyid-format LONG && \
 					gpg --default-key $ID -abs -o `+repoPath+`/Release.gpg `+repoPath+`/Release && \
 					gpg --default-key "$ID" --clearsign -o `+repoPath+`/InRelease `+repoPath+`/Release`),


### PR DESCRIPTION
tdnf fails when installing signed local RPMs (from the cmdline virtual repo) into an installroot with a populated RPM database, because it requires a gpgkey entry for cmdline which is a synthetic repo with no config. This manifests when building containers with a custom base image on azlinux/mariner distros.

Rather than working around individual tdnf bugs, prefer dnf when it is available. The install script now checks for dnf at runtime and switches from tdnf transparently. The same-platform worker bootstrap is updated to install dnf as a separate first step (mirroring the cross-arch path) so that subsequent installs benefit from dnf.

This also exposed a couple of other issues:

1. We weren't testing depsonly anywhere except in the basic "e2e" tests in docker-bake.hcl which is just a holdover from before we had integration tests. I've migrated the tests there and made it run on all distros that support this target (rpm distros only).
2. Instead of manually pulling in all packages into a dir (and incurring extra copying), just pass the list of packages to install to a new method for handling this scenario.

---

This fixes a real issue we saw in our builds where azlinux3/container is used but a custom base image is set instead of building one from scratch (as is the default).
