### PR TITLE
Backport git credential helper fixes to release/0.20

### DIFF
--- a/cmd/frontend/git_credential_helper.go
+++ b/cmd/frontend/git_credential_helper.go
@@ -245,7 +245,7 @@ func generateResponse(payload *gitPayload, secret []byte, kind string) (string, 
 }
 
 func handleSecretHeader(b []byte, payload *gitPayload) (string, error) {
-	s := string(b)
+	s := strings.TrimRight(string(b), "\r\n")
 	authtype, credential, ok := strings.Cut(s, " ")
 	if !ok {
 		return "", fmt.Errorf("improperly formatted auth header")
@@ -261,7 +261,10 @@ func handleSecretHeader(b []byte, payload *gitPayload) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not decode basic auth credential: %w", err)
 		}
-		user, pass, _ := strings.Cut(string(decoded), ":")
+		user, pass, ok := strings.Cut(string(decoded), ":")
+		if !ok {
+			return "", fmt.Errorf("improperly formatted basic auth credential")
+		}
 		payload.username = user
 		payload.password = pass
 	} else {
@@ -284,7 +287,7 @@ func handleSecretToken(token []byte, payload *gitPayload) (string, error) {
 		// Pre-2.46 git does not support authtype/credential protocol fields.
 		// Fall back to username/password which maps to HTTP Basic auth.
 		payload.username = "x-access-token"
-		payload.password = string(token)
+		payload.password = strings.TrimRight(string(token), "\r\n")
 	}
 
 	return printPayload(payload), nil

--- a/cmd/frontend/git_credential_helper_test.go
+++ b/cmd/frontend/git_credential_helper_test.go
@@ -48,6 +48,22 @@ func TestHandleSecretToken(t *testing.T) {
 		assertFieldAbsent(t, resp, keyUsername)
 		assertFieldAbsent(t, resp, keyPassword)
 	})
+
+	t.Run("trailing newline trimmed from token", func(t *testing.T) {
+		// Secrets mounted from files may have trailing newlines.
+		// These must be stripped to avoid breaking the credential protocol response.
+		payload := &gitPayload{
+			protocol: "https",
+			host:     "github.com",
+		}
+
+		resp, err := handleSecretToken([]byte("ghp_abc123\n"), payload)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertFieldEquals(t, resp, keyPassword, "ghp_abc123")
+	})
 }
 
 func TestHandleSecretHeader(t *testing.T) {
@@ -115,6 +131,38 @@ func TestHandleSecretHeader(t *testing.T) {
 		_, err := handleSecretHeader([]byte("nospaceshere"), payload)
 		if err == nil {
 			t.Fatal("expected error for malformed header, got nil")
+		}
+	})
+
+	t.Run("trailing newline trimmed from header", func(t *testing.T) {
+		// Secrets mounted from files may have trailing newlines.
+		payload := &gitPayload{
+			protocol:   "https",
+			host:       "github.com",
+			capability: []string{"authtype"},
+		}
+
+		resp, err := handleSecretHeader([]byte("Bearer eyJhbGciOi\n"), payload)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertFieldEquals(t, resp, keyAuthtype, "Bearer")
+		assertFieldEquals(t, resp, keyCredential, "eyJhbGciOi")
+	})
+
+	t.Run("malformed basic credential no colon", func(t *testing.T) {
+		// A Basic credential that decodes to a string without a colon
+		// is invalid per RFC 7617 and should be rejected.
+		payload := &gitPayload{
+			protocol: "https",
+			host:     "github.com",
+		}
+
+		cred := base64.StdEncoding.EncodeToString([]byte("nocolonhere"))
+		_, err := handleSecretHeader([]byte("Basic "+cred), payload)
+		if err == nil {
+			t.Fatal("expected error for basic credential without colon, got nil")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Backports two credential helper fixes from main:

- **fix: credential helper fallback for git < 2.46** (cherry-pick of dde13cc) — Git versions before 2.46 (including Azure Linux 3's 2.45.4 and Ubuntu Noble's 2.43) do not announce `capability[]=authtype`. The credential helper was unconditionally using authtype/credential (v2 protocol), which git silently discarded, causing authentication failures. This detects whether git announced the authtype capability and falls back to username/password for pre-2.46 git.

- **fix: harden credential helper against trailing newlines and malformed Basic credentials** (cherry-pick of ad3d032) — Trims trailing `\r\n` from mounted secrets before use in both token and header auth paths, and validates that decoded Basic auth credentials contain a colon separator per RFC 7617.