### PR TITLE
fix(gomod): auto-append +incompatible for non-module-path major versions

### DIFF
--- a/generator_gomod_test.go
+++ b/generator_gomod_test.go
@@ -118,6 +118,60 @@ func TestGomodReplaceGoModEditArg(t *testing.T) {
 			expectedArg: "github.com/stretchr/testify=github.com/stretchr/testify@v1.8.0",
 		},
 		{
+			name: "adds incompatible for v2+ module path without major suffix",
+			repl: GomodReplace{
+				Original: "github.com/docker/cli",
+				Update:   "github.com/docker/cli@v29.2.0",
+			},
+			expectErr:   false,
+			expectedArg: "github.com/docker/cli=github.com/docker/cli@v29.2.0+incompatible",
+		},
+		{
+			name: "keeps existing incompatible suffix",
+			repl: GomodReplace{
+				Original: "github.com/docker/cli",
+				Update:   "github.com/docker/cli@v29.2.0+incompatible",
+			},
+			expectErr:   false,
+			expectedArg: "github.com/docker/cli=github.com/docker/cli@v29.2.0+incompatible",
+		},
+		{
+			name: "does not add incompatible for proper /v2 path",
+			repl: GomodReplace{
+				Original: "example.com/mod/v2",
+				Update:   "example.com/mod/v2@v2.3.4",
+			},
+			expectErr:   false,
+			expectedArg: "example.com/mod/v2=example.com/mod/v2@v2.3.4",
+		},
+		{
+			name: "does not add incompatible for v1",
+			repl: GomodReplace{
+				Original: "github.com/stretchr/testify",
+				Update:   "github.com/stretchr/testify@v1.8.0",
+			},
+			expectErr:   false,
+			expectedArg: "github.com/stretchr/testify=github.com/stretchr/testify@v1.8.0",
+		},
+		{
+			name: "does not rewrite local path replacements",
+			repl: GomodReplace{
+				Original: "github.com/docker/cli",
+				Update:   "../docker-cli",
+			},
+			expectErr:   false,
+			expectedArg: "github.com/docker/cli=../docker-cli",
+		},
+		{
+			name: "does not add incompatible when other build metadata is present",
+			repl: GomodReplace{
+				Original: "example.com/mod",
+				Update:   "example.com/mod@v2.0.0+meta",
+			},
+			expectErr:   false,
+			expectedArg: "example.com/mod=example.com/mod@v2.0.0+meta",
+		},
+		{
 			name: "empty old",
 			repl: GomodReplace{
 				Original: "",

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621
+	golang.org/x/mod v0.33.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/tools v0.42.0
 	google.golang.org/grpc v1.80.0
@@ -96,7 +97,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/spec.go
+++ b/spec.go
@@ -12,6 +12,8 @@ import (
 	"github.com/goccy/go-yaml/parser"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
 )
 
 // Spec is the specification for a package build.
@@ -230,11 +232,45 @@ func (r GomodReplace) String() string {
 	return r.Original + " => " + r.Update
 }
 
+func normalizeGomodReplaceTarget(target string) string {
+	at := strings.LastIndex(target, "@")
+	if at <= 0 || at == len(target)-1 {
+		return target
+	}
+
+	path := target[:at]
+	version := target[at+1:]
+
+	if !semver.IsValid(version) {
+		return target
+	}
+
+	if strings.HasSuffix(version, "+incompatible") {
+		return target
+	}
+
+	if strings.Contains(version, "+") {
+		return target
+	}
+
+	_, pathMajor, ok := module.SplitPathVersion(path)
+	if !ok || pathMajor != "" {
+		return target
+	}
+
+	switch semver.Major(version) {
+	case "v0", "v1":
+		return target
+	default:
+		return path + "@" + version + "+incompatible"
+	}
+}
+
 func (r GomodReplace) goModEditArg() (string, error) {
 	if r.Original == "" || r.Update == "" {
 		return "", errors.Errorf("invalid gomod replace, old and new must be non-empty")
 	}
-	return r.Original + "=" + r.Update, nil
+	return r.Original + "=" + normalizeGomodReplaceTarget(r.Update), nil
 }
 
 func (r *GomodReplace) UnmarshalYAML(ctx context.Context, node ast.Node) error {

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -2199,6 +2199,67 @@ func main() {
 		})
 	})
 
+	t.Run("gomod replace directive incompatible version", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+
+		spec := &dalec.Spec{
+			Name:        "test-gomod-replace-incompatible",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/project-dalec/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Testing gomod replace directive with in-compatible version",
+			Sources: map[string]dalec.Source{
+				"src": {
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"go.mod": {Contents: "module example.com/test\n\ngo 1.18\n\nrequire github.com/docker/cli v29.2.1+incompatible\n"},
+								"main.go": {Contents: `package main
+
+import _ "github.com/docker/cli/pkg/kvfile"
+
+func main() {}
+`},
+							},
+						},
+					},
+					Generate: []*dalec.SourceGenerator{
+						{
+							Gomod: &dalec.GeneratorGomod{
+								Edits: &dalec.GomodEdits{
+									Replace: []dalec.GomodReplace{
+										{Original: "github.com/docker/cli", Update: "github.com/docker/cli@v29.2.1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: &dalec.PackageDependencies{
+				Build: map[string]dalec.PackageConstraints{
+					testConfig.GetPackage("golang"): {},
+				},
+			},
+			Build: dalec.ArtifactBuild{
+				Steps: []dalec.BuildStep{
+					{Command: "grep -F 'replace github.com/docker/cli => github.com/docker/cli v29.2.1+incompatible' ./src/go.mod"},
+					{Command: "[ -d \"${GOMODCACHE}/github.com/docker/cli@v29.2.1+incompatible\" ]"},
+					{Command: "cd ./src && go build"},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(withBuildTarget(testConfig.Target.Package), withSpec(ctx, t, spec))
+			solveT(ctx, t, client, req)
+		})
+	})
+
 	t.Run("gomod multi-module with paths", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)


### PR DESCRIPTION
## Summary

Normalize gomod replacement targets that use a v2+ semver on a module path
without a `/vN` suffix by automatically appending `+incompatible`.

This prevents builds from failing for replace targets such as:

- `github.com/docker/cli@v29.2.0`

which should be normalized to:

- `github.com/docker/cli@v29.2.0+incompatible`

## What changed

- updated `GomodReplace.goModEditArg()` to normalize replacement targets

## Why

Go module versioning requires `/vN` suffixes for major versions 2 and above.
For repositories that do not follow semantic import versioning, `+incompatible`
is required. This change makes Dalec handle that case automatically instead of
requiring each spec author to know and write the normalized version manually.

## Testing

- `go test ./... -run TestGomodReplaceGoModEditArg -v`
- `go test --test.short ./...`
- `make verify`