### PR TITLE
docs: clarify target package metadata

### DIFF
--- a/load.go
+++ b/load.go
@@ -271,7 +271,7 @@ func (s *Spec) SubstituteArgs(env map[string]string, opts ...SubstituteOpt) erro
 		for i, ver := range v.Version {
 			updated, err := expandArgs(lex, ver, args, cfg.AllowArg)
 			if err != nil {
-				appendErr(errors.Wrapf(err, "replaces %s version %d", k, i))
+				appendErr(errors.Wrapf(err, "conflicts %s version %d", k, i))
 			}
 			s.Conflicts[k].Version[i] = updated
 		}

--- a/load_test.go
+++ b/load_test.go
@@ -729,6 +729,30 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 					"": {},
 				},
 			},
+			Provides: map[string]PackageConstraints{
+				"p1": {
+					Version: []string{
+						"1.0",
+						"$FOO",
+					},
+				},
+			},
+			Replaces: map[string]PackageConstraints{
+				"p1": {
+					Version: []string{
+						"1.0",
+						"$FOO",
+					},
+				},
+			},
+			Conflicts: map[string]PackageConstraints{
+				"p1": {
+					Version: []string{
+						"1.0",
+						"$FOO",
+					},
+				},
+			},
 		},
 	}
 
@@ -792,6 +816,12 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].PackageConfig.Signer.Args["WHATEVER"], argWithDefault))
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].PackageConfig.Signer.Args["REGULAR"], plainOleValue))
 	assert.Check(t, cmp.Equal(spec.Targets["t2"].Image.Labels["foo"], foo))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Provides["p1"].Version[0], "1.0"))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Provides["p1"].Version[1], "foo"))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Replaces["p1"].Version[0], "1.0"))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Replaces["p1"].Version[1], "foo"))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Conflicts["p1"].Version[0], "1.0"))
+	assert.Check(t, cmp.Equal(spec.Targets["t2"].Conflicts["p1"].Version[1], "foo"))
 
 	assert.Check(t, cmp.Equal(spec.Dependencies.Build["p1"].Version[0], "1.0"))
 	assert.Check(t, cmp.Equal(spec.Dependencies.Build["p1"].Version[1], "foo"))
@@ -799,6 +829,79 @@ func TestSpec_SubstituteBuildArgs(t *testing.T) {
 	assert.Check(t, cmp.Equal(spec.Dependencies.Runtime["p1"].Version[1], "foo"))
 	assert.Check(t, cmp.Equal(spec.Provides["p1"].Version[0], "1.0"))
 	assert.Check(t, cmp.Equal(spec.Replaces["p1"].Version[0], "1.0"))
+}
+
+func TestLoadSpec_TargetPackageMetadata(t *testing.T) {
+	dt := []byte(`
+name: test-pkg
+description: Test package
+website: https://example.com
+version: 1.0.0
+revision: 1
+license: MIT
+provides:
+  common-pkg:
+    version:
+      - "= 1.0.0"
+conflicts:
+  common-conflict:
+replaces:
+  common-replace:
+targets:
+  rpm:
+    provides:
+      rpm-virtual:
+        version:
+          - "= 2.0.0"
+    conflicts:
+      rpm-conflict:
+    replaces:
+      rpm-replace:
+  deb:
+    provides:
+      deb-virtual:
+        version:
+          - ">= 3.0.0"
+    conflicts:
+      deb-conflict:
+    replaces:
+      deb-replace:
+  empty:
+    provides: {}
+    conflicts: {}
+    replaces: {}
+`)
+
+	spec, err := LoadSpec(dt)
+	assert.NilError(t, err)
+
+	rpmProvides := spec.GetProvides("rpm")
+	assert.Check(t, cmp.Len(rpmProvides, 1))
+	assert.Check(t, cmp.DeepEqual(rpmProvides["rpm-virtual"].Version, []string{"= 2.0.0"}))
+	_, ok := spec.GetConflicts("rpm")["rpm-conflict"]
+	assert.Check(t, ok)
+	_, ok = spec.GetReplaces("rpm")["rpm-replace"]
+	assert.Check(t, ok)
+
+	debProvides := spec.GetProvides("deb")
+	assert.Check(t, cmp.Len(debProvides, 1))
+	assert.Check(t, cmp.DeepEqual(debProvides["deb-virtual"].Version, []string{">= 3.0.0"}))
+	_, ok = spec.GetConflicts("deb")["deb-conflict"]
+	assert.Check(t, ok)
+	_, ok = spec.GetReplaces("deb")["deb-replace"]
+	assert.Check(t, ok)
+
+	rootProvides := spec.GetProvides("unknown")
+	assert.Check(t, cmp.Len(rootProvides, 1))
+	assert.Check(t, cmp.DeepEqual(rootProvides["common-pkg"].Version, []string{"= 1.0.0"}))
+	_, ok = spec.GetConflicts("unknown")["common-conflict"]
+	assert.Check(t, ok)
+	_, ok = spec.GetReplaces("unknown")["common-replace"]
+	assert.Check(t, ok)
+
+	assert.Check(t, cmp.Len(spec.GetProvides("empty"), 0))
+	assert.Check(t, cmp.Len(spec.GetConflicts("empty"), 0))
+	assert.Check(t, cmp.Len(spec.GetReplaces("empty"), 0))
 }
 
 func TestCustomRepoFillDefaults(t *testing.T) {

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -174,20 +174,19 @@ For more details on how Artifacts are structured and configured, see the [Artifa
 
 ### Target defined package metadata
 
-`conflicts`, `replaces`, and `provides` can be defined at the target level in addition to the [globalspec level](spec.md#additional-metadata).
-This allows you to define package metadata that is specific to a target.
+`conflicts`, `replaces`, and `provides` can be defined at the target level in addition to the [global spec level](spec.md#additional-metadata).
+This allows you to define package metadata that is specific to a target. If a target defines one of these fields, the target value replaces the global value for that field.
 
 ```yaml
 targets:
   azlinux3:
-    package:
-      conflicts:
-        - "foo"
-        - "bar"
-      replaces:
-        - foo"
-      provides:
-        - "qux"
+    conflicts:
+      foo:
+      bar:
+    replaces:
+      foo:
+    provides:
+      qux:
 ```
 
 ## Special considerations
@@ -291,4 +290,3 @@ This is considered a "break glass" way to work around issues when building on De
 Overriding some rules, such as `dh_install`, will also interfere with dalec functionality.
 
 In the future dalec may stop using dpkg-buildpackage and these rules would not be applicable anymore.
-


### PR DESCRIPTION
Document the supported target-level conflicts, provides, and replaces shape without the invalid package nesting. Add load and substitution coverage so target-specific metadata behavior stays protected.

Also fix the conflicts substitution error label.