### PR TITLE
REPRO: buildkit finalize-snapshot flake (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,26 @@ on:
         description: 'Enable BuildKit source policy'
         type: boolean
         default: false
-  pull_request:
-    branches:
-      - main
-      - release/**
-    paths-ignore:
-      - 'website/**'
-      - 'docs/**'
-      - '*.md'
-      - 'CODEOWNERS'
-      - 'LICENSE'
-      - '.github/copilot-instructions.md'
-      - '.github/workflows/retag.yml'
-      - '.github/workflows/retag/**'
-      - 'cmd/retagger/**'
-      - 'cmd/worker-image-matrix/**'
-      - '.github/workflows/worker-images/**'
-      - '.github/workflows/worker-images.yml'
-      - '.github/workflows/dependabot.yml'
-      - '.github/workflows/release.yml'
-      - '.github/workflows/deploy-docs.yml'
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - release/**
+  #   paths-ignore:
+  #     - 'website/**'
+  #     - 'docs/**'
+  #     - '*.md'
+  #     - 'CODEOWNERS'
+  #     - 'LICENSE'
+  #     - '.github/copilot-instructions.md'
+  #     - '.github/workflows/retag.yml'
+  #     - '.github/workflows/retag/**'
+  #     - 'cmd/retagger/**'
+  #     - 'cmd/worker-image-matrix/**'
+  #     - '.github/workflows/worker-images/**'
+  #     - '.github/workflows/worker-images.yml'
+  #     - '.github/workflows/dependabot.yml'
+  #     - '.github/workflows/release.yml'
+  #     - '.github/workflows/deploy-docs.yml'
 
   push:
     branches:

--- a/.github/workflows/repro-finalize-flake.yml
+++ b/.github/workflows/repro-finalize-flake.yml
@@ -12,11 +12,20 @@ permissions:
 
 jobs:
   shards:
+    # Cycle distros across shards. The narrow `negative_test/container`
+    # scope removed the racy parallel siblings that cause the finalize
+    # flake, so go wide: run the full Test<Distro> like the integration job.
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        suite:
+          - Noble
+          - Jammy
+          - Bookworm
+          - Focal
+          - Bionic
+        shard: [1, 2]
     steps:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -36,6 +45,9 @@ jobs:
       - name: download deps
         run: go mod download
 
+      - name: Setup QEMU
+        run: docker run --rm --privileged tonistiigi/binfmt:latest --install all
+
       - name: Aggressive cleanup
         run: |
           docker system prune -af --volumes || true
@@ -49,19 +61,24 @@ jobs:
         uses: ./.github/actions/dns-spoof-ubuntu-archive
 
       - name: Pre-build base images
+        env:
+          TEST_SUITE: ${{ matrix.suite }}
         run: |
           set -eu
           docker buildx bake frontend
-          export WORKER_TARGET=noble/worker
+          worker="${TEST_SUITE,,}"
+          export WORKER_TARGET="${worker}/worker"
           docker buildx bake worker
 
-      - name: Run focused test
+      - name: Run full Test<Distro>
         continue-on-error: true
+        env:
+          TEST_SUITE: ${{ matrix.suite }}
         run: |
           set -ex
           mkdir -p /tmp/testlogs
-          go test -timeout=45m -v -json \
-            -run 'TestNoble/test_package_tests_cause_build_to_fail/negative_test/container' \
+          go test -timeout=59m -v -json \
+            -run "${TEST_SUITE}" \
             ./test \
             | tee /tmp/testlogs/raw.jsonl \
             | go run ./cmd/test2json2gha --slow 120s --logdir /tmp/testlogs
@@ -77,7 +94,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: repro-shard${{ matrix.shard }}
+          name: repro-${{ matrix.suite }}-shard${{ matrix.shard }}
           path: |
             /tmp/reports/*
             /tmp/testlogs/*

--- a/.github/workflows/repro-finalize-flake.yml
+++ b/.github/workflows/repro-finalize-flake.yml
@@ -4,9 +4,7 @@ name: repro-finalize-flake
 # 10 fresh runners on a draft PR. Not for merging.
 
 on:
-  push:
-    branches:
-      - 'repro_bk_missing_snapshot_issue'
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/repro-finalize-flake.yml
+++ b/.github/workflows/repro-finalize-flake.yml
@@ -1,0 +1,87 @@
+name: repro-finalize-flake
+
+# Throwaway workflow to hammer the buildkit finalize-snapshot flake across
+# 10 fresh runners on a draft PR. Not for merging.
+
+on:
+  push:
+    branches:
+      - 'repro_bk_missing_snapshot_issue'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  shards:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    steps:
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Update Docker
+        run: |
+          set -e
+          sudo apt update
+          sudo apt install -y moby-engine=29.4.* moby-buildx=0.33.* moby-cli=29.4.* moby-containerd=2.3.*
+
+      - uses: ./.github/actions/enable-containerd
+
+      - name: download deps
+        run: go mod download
+
+      - name: Aggressive cleanup
+        run: |
+          docker system prune -af --volumes || true
+          sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift \
+                     /usr/local/.ghcup /usr/local/julia* \
+                     /usr/local/lib/android /usr/local/share/chromium \
+                     /opt/microsoft /opt/google /usr/local/share/powershell || true
+          df -h
+
+      - name: Use azure ubuntu archive
+        uses: ./.github/actions/dns-spoof-ubuntu-archive
+
+      - name: Pre-build base images
+        run: |
+          set -eu
+          docker buildx bake frontend
+          export WORKER_TARGET=noble/worker
+          docker buildx bake worker
+
+      - name: Run focused test
+        continue-on-error: true
+        run: |
+          set -ex
+          mkdir -p /tmp/testlogs
+          go test -timeout=45m -v -json \
+            -run 'TestNoble/test_package_tests_cause_build_to_fail/negative_test/container' \
+            ./test \
+            | tee /tmp/testlogs/raw.jsonl \
+            | go run ./cmd/test2json2gha --slow 120s --logdir /tmp/testlogs
+
+      - name: Dump daemon journals
+        if: always()
+        run: |
+          mkdir -p /tmp/reports
+          sudo journalctl -u docker --no-pager > /tmp/reports/dockerd.log || true
+          sudo journalctl -u containerd --no-pager > /tmp/reports/containerd.log || true
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: repro-shard${{ matrix.shard }}
+          path: |
+            /tmp/reports/*
+            /tmp/testlogs/*
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
Draft PR to fire the `repro-finalize-flake` workflow across 10 parallel fresh runners and try to reproduce:

```
failed to finalize upper parent during diff: failed to commit ... during finalize:
  failed to stat active key during commit: snapshot ... does not exist: not found
```

The workflow runs `TestNoble/test_package_tests_cause_build_to_fail/negative_test/container` in a CI-matching env (docker 29.4, buildx 0.33, containerd 2.3, containerd-snapshotter) and uploads dockerd/containerd journals + test logs with 30-day retention so any reproducing shard's forensic data survives.

**Not intended to be merged** — pure forensic capture for the BuildKit team.