### PR TITLE
docs: Update version of nodejs to 24 (latest LTS)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Get yarn cache
         id: yarn-cache


### PR DESCRIPTION
This is what's cached on the github runner currently so use that. This prevents the deploy-docs job from failing.
24 is the latest LTS version.

Rather than opening up the step-security to allow more URL's, just use what's cached on the node.

v20 is EOL and is no longer cached on the node, hence CI on main is failing.