### PR TITLE
test: include buildkit error stack traces in test output

### DIFF
--- a/test/gomod_git_auth_test.go
+++ b/test/gomod_git_auth_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/util/stack"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
 	gitservices "github.com/project-dalec/dalec/test/git_services"
@@ -138,7 +139,7 @@ go {{ .ModFileGoVersion }}
 			case err := <-httpServer.ErrChan:
 				t.Fatalf("http server unexpectedly failed: %s", err)
 			case err := <-solveErrChan:
-				t.Fatalf("solve failed: %s", err)
+				t.Fatalf("solve failed: %+v", stack.Formatter(err))
 			case r := <-solveResultChan:
 				res = r
 			}
@@ -206,7 +207,7 @@ go {{ .ModFileGoVersion }}
 			case err := <-sshServer.ErrChan:
 				t.Fatalf("ssh server unexpectedly failed: %s", err)
 			case err := <-solveErrChan:
-				t.Fatalf("solve failed: %s", err)
+				t.Fatalf("solve failed: %+v", stack.Formatter(err))
 			case r := <-solveResultChan:
 				res = r
 			}

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goccy/go-yaml"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
+	"github.com/moby/buildkit/util/stack"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/test/testenv"
@@ -125,7 +126,7 @@ func TestHandlerTargetForwarding(t *testing.T) {
 			_, err := gwc.Solve(ctx, sr)
 			expect := "no such handler for target"
 			if err == nil || !strings.Contains(err.Error(), expect) {
-				t.Fatalf("expected error %q, got %v", expect, err)
+				t.Fatalf("expected error %q, got %+v", expect, stack.Formatter(err))
 			}
 		})
 	})

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/stack"
 	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
@@ -291,7 +292,7 @@ func solveT(ctx context.Context, t *testing.T, gwc gwclient.Client, req gwclient
 
 	res, err := gwc.Solve(ctx, req)
 	if err != nil {
-		t.Fatalf("Unexpected error solving request: %v", err)
+		t.Fatalf("Unexpected error solving request: %+v", stack.Formatter(err))
 	}
 
 	// Running this validation as part of this function allows us to verify most test scenarios.

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/go-archive/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
@@ -172,7 +173,7 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 			_, err := gwc.Solve(ctx, sr)
 			var xErr *moby_buildkit_v1_frontend.ExitError
 			if !errors.As(err, &xErr) {
-				t.Fatalf("expected exit error, got %T: %v", errors.Unwrap(err), err)
+				t.Fatalf("expected exit error, got %T: %+v", errors.Unwrap(err), stack.Formatter(err))
 			}
 		})
 	})
@@ -1164,7 +1165,7 @@ echo "$BAR" > bar.txt
 				Definition: def.ToPB(),
 			})
 			if resErr != nil {
-				t.Fatal(resErr)
+				t.Fatalf("error solving: %+v", stack.Formatter(resErr))
 			}
 
 			ref, refErr = res.SingleRef()
@@ -1172,7 +1173,7 @@ echo "$BAR" > bar.txt
 				t.Fatal(refErr)
 			}
 			if evalErr := ref.Evaluate(ctx); evalErr != nil {
-				t.Fatalf("error extracting sysext: %v", evalErr)
+				t.Fatalf("error extracting sysext: %+v", stack.Formatter(evalErr))
 			}
 
 			for _, file := range []string{"/usr/bin/zsh", "/usr/bin/zstd"} {
@@ -2601,7 +2602,7 @@ func testCustomLinuxWorker(ctx context.Context, t *testing.T, targetCfg targetCo
 
 		var xErr *moby_buildkit_v1_frontend.ExitError
 		if !errors.As(err, &xErr) {
-			t.Fatalf("got unexpected error, expected error type %T: %v", xErr, err)
+			t.Fatalf("got unexpected error, expected error type %T: %+v", xErr, stack.Formatter(err))
 		}
 
 		// Build the base package
@@ -3282,10 +3283,10 @@ func testLinuxPackageTestsFail(ctx context.Context, t *testing.T, cfg testLinuxC
 							_, err := client.Solve(ctx, sr)
 							assert.Assert(t, err != nil)
 
-							t.Logf("Build Error: %v", err)
+							t.Logf("Build Error: %+v", stack.Formatter(err))
 
 							var exErr *moby_buildkit_v1_frontend.ExitError
-							assert.Assert(t, errors.As(err, &exErr), "expected exit error, got: %v", err)
+							assert.Assert(t, errors.As(err, &exErr), "expected exit error, got: %+v", stack.Formatter(err))
 
 							if !tc.isBuildError {
 								// the error we are looking for is in the build logs, not the exit error

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -8,6 +8,7 @@ import (
 
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/util/stack"
 	"github.com/project-dalec/dalec"
 	"gotest.tools/v3/assert"
 )
@@ -75,7 +76,7 @@ func testBuildNetworkMode(ctx context.Context, t *testing.T, cfg targetConfig) {
 
 				var xErr *moby_buildkit_v1_frontend.ExitError
 				if !errors.As(err, &xErr) {
-					t.Fatalf("expected exit error, got %T: %v", errors.Unwrap(err), err)
+					t.Fatalf("expected exit error, got %T: %+v", errors.Unwrap(err), stack.Formatter(err))
 				}
 			})
 		})

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/util/stack"
 	"github.com/opencontainers/go-digest"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/frontend/pkg/bkfs"
@@ -446,7 +447,7 @@ func TestSourceHTTP(t *testing.T) {
 		}
 
 		if !strings.Contains(err.Error(), "digest mismatch") {
-			t.Fatalf("expected digest mismatch, got: %v", err)
+			t.Fatalf("expected digest mismatch, got: %+v", stack.Formatter(err))
 		}
 
 		good := newSolveRequest(withBuildTarget("debug/sources"), withSpec(ctx, t, newSpec(url, goodDigest)))
@@ -566,7 +567,7 @@ func TestSourceGitChecksumPreservesTagMetadata(t *testing.T) {
 				t.Fatal("expected git checksum mismatch, but received none")
 			}
 			if !strings.Contains(err.Error(), "expected checksum to match") {
-				t.Fatalf("expected git checksum mismatch, got: %v", err)
+				t.Fatalf("expected git checksum mismatch, got: %+v", stack.Formatter(err))
 			}
 		})
 	})

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/solver/pb"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/util/stack"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/project-dalec/dalec/internal/frontendcoverage"
 	"github.com/project-dalec/dalec/sessionutil/socketprovider"
@@ -492,7 +493,7 @@ func (b *BuildxEnv) RunTest(ctx context.Context, t *testing.T, f TestFunc, opts 
 
 	for status, err := range b.runTestWithStatus(ctx, t, f, opts...) {
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%+v", stack.Formatter(err))
 			// drain the status channel
 			// the range itself will stop once everything is done
 			continue

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/util/stack"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
 	"github.com/project-dalec/dalec/targets/linux/deb/ubuntu"
@@ -168,7 +169,7 @@ func testWindows(ctx context.Context, t *testing.T, tcfg targetConfig) {
 			_, err := gwc.Solve(ctx, sr)
 			var xErr *moby_buildkit_v1_frontend.ExitError
 			if !errors.As(err, &xErr) {
-				t.Fatalf("expected exit error, got %T: %v", errors.Unwrap(err), err)
+				t.Fatalf("expected exit error, got %T: %+v", errors.Unwrap(err), stack.Formatter(err))
 			}
 		})
 	})
@@ -200,7 +201,7 @@ func testWindows(ctx context.Context, t *testing.T, tcfg targetConfig) {
 			_, err := gwc.Solve(ctx, sr)
 			var xErr *moby_buildkit_v1_frontend.ExitError
 			if !errors.As(err, &xErr) {
-				t.Fatalf("expected exit error, got %T: %v", errors.Unwrap(err), err)
+				t.Fatalf("expected exit error, got %T: %+v", errors.Unwrap(err), stack.Formatter(err))
 			}
 		})
 	})
@@ -780,7 +781,7 @@ func testCustomWindowscrossWorker(ctx context.Context, t *testing.T, targetCfg t
 
 		var xErr *moby_buildkit_v1_frontend.ExitError
 		if !errors.As(err, &xErr) {
-			t.Fatalf("got unexpected error, expected error type %T: %v", xErr, err)
+			t.Fatalf("got unexpected error, expected error type %T: %+v", xErr, stack.Formatter(err))
 		}
 
 		// Build the base package


### PR DESCRIPTION
Use `stack.Formatter` with `%+v` formatting when reporting BuildKit solve errors in `RunTest`. This surfaces the full server-side stack traces that BuildKit embeds in gRPC error details, matching how `buildctl` and `buildkitd` format errors.

Previously `t.Error(err)` used default `%v` formatting which only showed the error message without any stack context.