### PR TITLE
tests: verify worker platform selection without QEMU

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/containerd/plugin v1.0.0
 	github.com/cpuguy83/dockercfg v0.3.2
+	github.com/cpuguy83/ocijoin v0.2.0
 	github.com/distribution/reference v0.6.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/containerd/typeurl/v2 v2.3.0 h1:HZHPhRWo5XMy3QGQoPrUzbW/2ckwjfweHmOwl
 github.com/containerd/typeurl/v2 v2.3.0/go.mod h1:Qk+PAdUYArVj41TnGi6rJ+48RF0PkcTc4i/taoBcK0w=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/cpuguy83/ocijoin v0.2.0 h1:WtsrXOyP+KwezceYYsa/IY7jA5Qd353nPz8AHBI0/UI=
+github.com/cpuguy83/ocijoin v0.2.0/go.mod h1:j69J/KtiUVj3HanO+QMgPUYBdOM79uW9lFtRLNPrI/o=
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
 github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -424,6 +424,20 @@ func withBuildContext(ctx context.Context, t *testing.T, name string, st llb.Sta
 	}
 }
 
+// withOCILayoutContext overrides a named build context to point at an OCI layout
+// store (registered via [testenv.WithOCIStore]) at the given index digest.
+// BuildKit performs platform-specific manifest selection against the referenced
+// index, so this is used to verify that the frontend resolves the correct
+// platform image for a requested build platform.
+func withOCILayoutContext(name, storeID string, dgst digest.Digest) srOpt {
+	return func(cfg *newSolveRequestConfig) {
+		if cfg.req.FrontendOpt == nil {
+			cfg.req.FrontendOpt = make(map[string]string)
+		}
+		cfg.req.FrontendOpt["context:"+name] = "oci-layout:" + storeID + "@" + dgst.String()
+	}
+}
+
 func reqToState(ctx context.Context, gwc gwclient.Client, sr gwclient.SolveRequest, t *testing.T) llb.State {
 	t.Helper()
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -50,7 +50,12 @@ type workerConfig struct {
 	SignRepo   func(st llb.State, repoPath string) llb.StateOption
 	// ContextName is the name of the worker context that the build target will use
 	// to see if a custom worker is provided in a context
-	ContextName    string
+	ContextName string
+	// BaseImageRef is the distro's worker base image reference (the image the
+	// worker target resolves via the llb.Image path). It is used by the
+	// source-policy variant of the cross-platform test to build a marker image
+	// from the real base and to rewrite the base image to that marker store.
+	BaseImageRef   string
 	TestRepoConfig func(keyPath, repoPath string) map[string]dalec.Source
 	Platform       *ocispecs.Platform
 	SysextWorker   func(sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb.State
@@ -108,9 +113,6 @@ type testLinuxConfig struct {
 	Release OSRelease
 
 	SupportsGomodVersionUpdate bool
-
-	Platforms         []ocispecs.Platform
-	PackageOutputPath func(spec *dalec.Spec, platform ocispecs.Platform) string
 }
 
 type OSRelease struct {
@@ -120,33 +122,6 @@ type OSRelease struct {
 
 func (cfg *testLinuxConfig) GetPackage(name string) string {
 	return cfg.Target.GetPackage(name)
-}
-
-func rpmTargetOutputPath(id string) func(spec *dalec.Spec, platform ocispecs.Platform) string {
-	return func(spec *dalec.Spec, platform ocispecs.Platform) string {
-		var arch string
-		switch platform.Architecture {
-		case "amd64":
-			arch = "x86_64"
-		case "arm64":
-			arch = "aarch64"
-		case "arm":
-			// this is not perfect, but all we really support in our tests for now, so its fine.
-			arch = "armv7l"
-		}
-		return fmt.Sprintf("/RPMS/%s/%s-%s-%s.%s.%s.rpm", arch, spec.Name, spec.Version, spec.Revision, id, arch)
-	}
-}
-
-func debTargetOutputPath(id string) func(spec *dalec.Spec, platform ocispecs.Platform) string {
-	return func(spec *dalec.Spec, platform ocispecs.Platform) string {
-		arch := platform.Architecture
-		if arch == "arm" {
-			// this is not perfect, but all we really support in our tests for now, so its fine.
-			arch = "armhf"
-		}
-		return fmt.Sprintf("%s_%s-%s_%s.deb", spec.Name, spec.Version, id+"u"+spec.Revision, arch)
-	}
 }
 
 func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConfig) {
@@ -5122,67 +5097,92 @@ func testDisableStrip(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
 	})
 }
 
+// testTargetPlatform verifies that the frontend selects the correct
+// platform-specific worker image for a requested build platform.
+//
+// A shared multi-platform marker image is built once from the real distro worker
+// base image, with a /platform-marker file injected per platform naming that
+// platform. Two variants then assert the marker matches the requested build
+// platform:
+//
+//   - "worker context": the worker context is overridden to the marker index.
+//     Supplying a worker context short-circuits worker building, so this exercises
+//     the named-context / oci-layout resolver and just returns the selected image.
+//   - "source policy": no context override; a source policy rewrites the worker
+//     base image to the same marker index, so the worker builds via the normal
+//     llb.Image path. Cross-arch installs run natively via dnf --forcearch (no
+//     QEMU) and the marker file is preserved into the result rootfs.
+//
+// Both variants run natively without QEMU regardless of the runner's
+// architecture.
 func testTargetPlatform(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
 	ctx = startTestSpan(ctx, t)
 
-	testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-		bp := readDefaultPlatform(ctx, t, client)
+	if cfg.Worker.BaseImageRef == "" {
+		t.Skip("no worker base image ref configured for this target")
+	}
 
-		var tp ocispecs.Platform
-		for _, p := range cfg.Platforms {
-			if platforms.OnlyStrict(bp).Match(p) {
-				continue
+	cases := []ocispecs.Platform{
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64"},
+	}
+
+	storeID, idxDgst, store := buildWorkerMarkerStore(ctx, t, cfg.Worker.BaseImageRef, cases...)
+
+	// "worker context" supplies the marker index as the worker build context.
+	// Providing a worker context short-circuits worker building, so the worker
+	// target returns the selected image as-is. This exercises the named-context /
+	// oci-layout resolver: BuildKit performs platform-specific manifest selection
+	// against the index for the requested build platform, and we read the marker
+	// from the returned image to confirm the right manifest was chosen. Nothing is
+	// executed, so this never needs QEMU.
+	t.Run("worker context", func(t *testing.T) {
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			for _, p := range cases {
+				t.Run(platforms.Format(p), func(t *testing.T) {
+					sr := newSolveRequest(
+						withSpec(ctx, t, nil),
+						withBuildTarget(cfg.Target.Worker),
+						withPlatform(p),
+						withOCILayoutContext(cfg.Worker.ContextName, storeID, idxDgst),
+					)
+					res := solveT(ctx, t, client, sr)
+
+					dt := readFile(ctx, t, platformMarkerPath, res)
+					assert.Equal(t, string(dt), platformMarkerString(p),
+						"selected worker image does not match requested platform %s", platforms.Format(p))
+				})
 			}
+		}, testenv.WithOCIStore(storeID, store))
+	})
 
-			tp = p
+	// "source policy" exercises the default worker-resolution path used by real
+	// builds, where the worker is built from the distro base image via llb.Image
+	// (no context override). A source policy rewrites that base image to the same
+	// marker index, so BuildKit resolves and selects the per-platform manifest the
+	// same way it would for any image. Because the worker is actually built, the
+	// base must be a functional distro image (hence the real base + injected
+	// marker). Cross-arch installs run natively via dnf/apt --forcearch into a
+	// foreign-arch root, so the marker file is preserved into the result rootfs and
+	// no QEMU is required.
+	t.Run("source policy", func(t *testing.T) {
+		pol := workerRewriteSourcePolicy(cfg.Worker.BaseImageRef, storeID, idxDgst)
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			for _, p := range cases {
+				t.Run(platforms.Format(p), func(t *testing.T) {
+					sr := newSolveRequest(
+						withSpec(ctx, t, nil),
+						withBuildTarget(cfg.Target.Worker),
+						withPlatform(p),
+					)
+					res := solveT(ctx, t, client, sr)
 
-			if bp.Architecture != "arm64" {
-				break
+					dt := readFile(ctx, t, platformMarkerPath, res)
+					assert.Equal(t, string(dt), platformMarkerString(p),
+						"selected worker image does not match requested platform %s", platforms.Format(p))
+				})
 			}
-			// On arm64, let's try and build for armv7 to help speed up tests
-			// Also makes sure that building arm on arm64 gives the correct result since this can run natively (usually)
-			if tp.Architecture == "arm" {
-				break
-			}
-		}
-
-		skip.If(t, tp.OS == "", "No other platforms available to test")
-		assert.Assert(t, tp.Architecture != bp.Architecture, "Target and build arches are the same")
-
-		spec := newSimpleSpec()
-		spec.Args = map[string]string{
-			"TARGETARCH": "",
-		}
-
-		spec.Build.Env = map[string]string{
-			"TARGETARCH": "$TARGETARCH",
-		}
-
-		spec.Build.Steps = []dalec.BuildStep{
-			{
-				Command: fmt.Sprintf(`[ "${TARGETARCH}" = "%s" ]`, tp.Architecture),
-			},
-		}
-
-		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package), withPlatform(tp))
-		res := solveT(ctx, t, client, sr)
-		ref, err := res.SingleRef()
-		assert.NilError(t, err)
-
-		_, err = ref.StatFile(ctx, gwclient.StatRequest{
-			Path: cfg.PackageOutputPath(spec, tp),
-		})
-		assert.NilError(t, err)
-
-		sr = newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(cfg.Target.Package), withPlatform(tp))
-		res = solveT(ctx, t, client, sr)
-		dt, ok := res.Metadata[exptypes.ExporterImageConfigKey]
-		assert.Assert(t, ok, "missing image config in result metadata")
-
-		var img dalec.DockerImageSpec
-		err = json.Unmarshal(dt, &img)
-		assert.NilError(t, err)
-		assert.Assert(t, platforms.OnlyStrict(tp).Match(img.Platform), "platform mismatch, expected %v, got %v", tp, img.Platform)
+		}, testenv.WithOCIStore(storeID, store), testenv.WithSourcePolicy(pol))
 	})
 }
 

--- a/test/platform_worker_test.go
+++ b/test/platform_worker_test.go
@@ -1,0 +1,243 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/platforms"
+	"github.com/cpuguy83/ocijoin"
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	spb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+const (
+	// platformMarkerStoreID is the id used to register the OCI layout store with
+	// the build session and to reference it from a build context or source policy.
+	platformMarkerStoreID = "dalec-worker-platform-test"
+	// platformMarkerPath is the file injected into each worker image whose
+	// contents identify which platform-specific manifest was selected.
+	platformMarkerPath = "/platform-marker"
+)
+
+// buildWorkerMarkerStore builds an OCI layout content store containing a
+// multi-platform index derived from the real distro worker base image
+// (baseRef), with one manifest per provided platform. Each manifest is the real
+// base image for that platform plus an injected marker file
+// ([platformMarkerPath]) whose contents are the formatted platform string
+// ([platformMarkerString]).
+//
+// Using the real base image (rather than a synthetic one) means the resulting
+// worker image is a functional distro image, so it works both when supplied as a
+// worker context (which short-circuits worker building) and when the normal
+// worker build runs dnf install on it. The injected marker file lets a test
+// verify which platform-specific manifest was selected for a requested build
+// platform.
+//
+// It returns the store id (for use with [testenv.WithOCIStore],
+// [withOCILayoutContext], and [workerRewriteSourcePolicy]), the digest of the
+// index, and the content store.
+func buildWorkerMarkerStore(ctx context.Context, t *testing.T, baseRef string, plats ...ocispecs.Platform) (storeID string, indexDigest digest.Digest, store content.Store) {
+	t.Helper()
+
+	bk, err := testEnv.Buildkit(ctx)
+	assert.NilError(t, err)
+
+	dir := t.TempDir()
+
+	build := func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+		res := gwclient.NewResult()
+		expPlatforms := &exptypes.Platforms{Platforms: make([]exptypes.Platform, 0, len(plats))}
+
+		for _, p := range plats {
+			p := p
+			pk := platforms.Format(p)
+
+			st := llb.Image(baseRef, llb.Platform(p)).
+				File(llb.Mkfile(platformMarkerPath, 0o644, []byte(platformMarkerString(p))))
+
+			def, err := st.Marshal(ctx, llb.Platform(p))
+			if err != nil {
+				return nil, err
+			}
+
+			r, err := c.Solve(ctx, gwclient.SolveRequest{Definition: def.ToPB()})
+			if err != nil {
+				return nil, err
+			}
+
+			ref, err := r.SingleRef()
+			if err != nil {
+				return nil, err
+			}
+			res.AddRef(pk, ref)
+
+			// Provide the real base image config (which carries the correct
+			// os/architecture) so the exported manifest is tagged with the right
+			// platform. The exporter reconciles rootfs diff_ids with the actual
+			// layers, so the injected marker layer is included automatically.
+			_, _, cfgDt, err := c.ResolveImageConfig(ctx, baseRef, sourceresolver.Opt{
+				ImageOpt: &sourceresolver.ResolveImageOpt{Platform: &p},
+			})
+			if err != nil {
+				return nil, err
+			}
+			res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, pk), cfgDt)
+
+			expPlatforms.Platforms = append(expPlatforms.Platforms, exptypes.Platform{ID: pk, Platform: p})
+		}
+
+		dt, err := json.Marshal(expPlatforms)
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+		return res, nil
+	}
+
+	so := client.SolveOpt{
+		Exports: []client.ExportEntry{{
+			Type:      client.ExporterOCI,
+			OutputDir: dir,
+			Attrs:     map[string]string{"tar": "false"},
+		}},
+	}
+
+	statusCh := make(chan *client.SolveStatus)
+	go func() {
+		for range statusCh {
+		}
+	}()
+
+	_, err = bk.Build(ctx, so, "", build, statusCh)
+	assert.NilError(t, err)
+
+	// The BuildKit OCI exporter writes the multi-platform index to index.json
+	// (not as an addressable blob) and may include attestation manifests. Use
+	// ocijoin to resolve any nested index, drop non-platform manifests, and
+	// re-nest the platform index as an addressable blob so it can be referenced by
+	// digest from a build context or source policy.
+	layout, err := ocijoin.NewLocalLayout(dir)
+	assert.NilError(t, err)
+
+	keep := func(d ocispecs.Descriptor) bool {
+		if ocijoin.IsAttestation(d) {
+			return false
+		}
+		return d.Platform != nil && d.Platform.OS != "unknown" && d.Platform.Architecture != "unknown"
+	}
+	wrapped := ocijoin.Wrap(ocijoin.Filter(ocijoin.Unwrap(layout), keep), nil)
+
+	outer, err := wrapped.Index(ctx)
+	assert.NilError(t, err)
+	assert.Assert(t, len(outer.Manifests) == 1, "expected wrapped layout to nest a single platform index")
+	indexDigest = outer.Manifests[0].Digest
+
+	// A Layout is already a content.Provider; layoutStore adapts it to the
+	// content.Store that BuildKit's OCIStores expects, without copying blobs to
+	// an on-disk store.
+	return platformMarkerStoreID, indexDigest, &layoutStore{layout: wrapped}
+}
+
+// layoutStore adapts an ocijoin.Layout (a read-only content.Provider) into the
+// containerd content.Store that BuildKit's SolveOpt.OCIStores requires.
+//
+// BuildKit's oci-layout source only exercises the read path: ReaderAt to fetch
+// blobs and Info to size the root descriptor. Every other content.Store method
+// is promoted from the embedded nil content.Store; none are called on the read
+// path and would panic if they were.
+type layoutStore struct {
+	content.Store // nil: unimplemented methods, never called on the read path
+	layout        ocijoin.Layout
+}
+
+func (s *layoutStore) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	return s.layout.ReaderAt(ctx, desc)
+}
+
+// Info reports the digest and size of a blob. ReaderAt only requires the digest
+// to be set, so the size is read from the returned reader.
+func (s *layoutStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	ra, err := s.layout.ReaderAt(ctx, ocispecs.Descriptor{Digest: dgst})
+	if err != nil {
+		return content.Info{}, err
+	}
+	defer func() { _ = ra.Close() }()
+	return content.Info{Digest: dgst, Size: ra.Size()}, nil
+}
+
+// workerRewriteSourcePolicy returns a source policy that rewrites the distro
+// worker base image (baseRef, resolved via the llb.Image path as
+// "docker-image://<baseRef>") to the multi-platform marker index in the OCI
+// layout store (storeID) at indexDigest.
+//
+// This exercises the default llb.Image worker-resolution path (unlike the worker
+// context override, which short-circuits worker building). BuildKit performs
+// platform-specific manifest selection against the rewritten oci-layout source
+// using the source op's platform, so the resulting worker carries the marker for
+// the requested build platform. The store id is supplied via the oci.store attr;
+// the session id is left empty so BuildKit resolves the store from the current
+// build session.
+func workerRewriteSourcePolicy(baseRef, storeID string, indexDigest digest.Digest) *spb.Policy {
+	// The oci-layout source identifier is parsed as an image reference, which
+	// requires a normalized (domain-qualified) name; a bare single-component name
+	// makes the digest parse as a port. Normalize the store id for the identifier
+	// while keeping the raw store id in the oci.store attr so it matches the store
+	// registered with the session.
+	named, err := reference.ParseNormalizedNamed(storeID)
+	if err != nil {
+		panic(err)
+	}
+	dgstRef, err := reference.WithDigest(named, indexDigest)
+	if err != nil {
+		panic(err)
+	}
+
+	return &spb.Policy{
+		Rules: []*spb.Rule{{
+			Action: spb.PolicyAction_CONVERT,
+			Selector: &spb.Selector{
+				MatchType:  spb.MatchType_WILDCARD,
+				Identifier: "docker-image://" + baseRef + "*",
+			},
+			Updates: &spb.Update{
+				Identifier: "oci-layout://" + dgstRef.String(),
+				// An oci-layout source has two parts: the identifier
+				// (oci-layout://<name>@<digest>) says *what* to fetch by digest,
+				// while pb.AttrOCILayoutStoreID ("oci.store") says *where* to fetch
+				// it from. Its value is the id of the content store registered with
+				// the session via SolveOpt.OCIStores (testenv.WithOCIStore here), so
+				// it must equal that registration key. Unlike the identifier name it
+				// is matched literally, not parsed as an image ref, so it keeps the
+				// raw storeID. The sibling pb.AttrOCILayoutSessionID ("oci.session")
+				// is intentionally omitted: leaving it empty makes BuildKit's
+				// oci-layout resolver fall back to any store in the current build
+				// session, which is exactly the store we just registered.
+				Attrs: map[string]string{
+					pb.AttrOCILayoutStoreID: storeID,
+				},
+			},
+		}},
+	}
+}
+
+// platformMarkerString is the marker contents for a platform image, also used
+// by tests as the expected value when that image is selected.
+func platformMarkerString(p ocispecs.Platform) string {
+	s := p.OS + "/" + p.Architecture
+	if p.Variant != "" {
+		s += "/" + p.Variant
+	}
+	return s
+}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec/targets/linux/rpm/almalinux"
 )
 
@@ -39,6 +38,7 @@ func TestAlmalinux9(t *testing.T) {
 		Libdir: "/usr/lib64",
 		Worker: workerConfig{
 			ContextName:    almalinux.ConfigV9.ContextRef,
+			BaseImageRef:   almalinux.ConfigV9.ImageRef,
 			CreateRepo:     createYumRepo(almalinux.ConfigV9),
 			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
@@ -48,11 +48,6 @@ func TestAlmalinux9(t *testing.T) {
 			VersionID: "9",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("el9"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testAlmalinuxExtra(ctx, t, cfg, almalinux.ConfigV9.ImageRef)
@@ -88,6 +83,7 @@ func TestAlmalinux8(t *testing.T) {
 		Libdir: "/usr/lib64",
 		Worker: workerConfig{
 			ContextName:    almalinux.ConfigV8.ContextRef,
+			BaseImageRef:   almalinux.ConfigV8.ImageRef,
 			CreateRepo:     createYumRepo(almalinux.ConfigV8),
 			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
@@ -97,11 +93,6 @@ func TestAlmalinux8(t *testing.T) {
 			VersionID: "8",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("el8"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testAlmalinuxExtra(ctx, t, cfg, almalinux.ConfigV8.ImageRef)

--- a/test/target_azlinux_test.go
+++ b/test/target_azlinux_test.go
@@ -61,6 +61,7 @@ func TestAzlinux3(t *testing.T) {
 		},
 		Worker: workerConfig{
 			ContextName:    azlinux.Azlinux3WorkerContextName,
+			BaseImageRef:   azlinux.Azlinux3Config.ImageRef,
 			CreateRepo:     createYumRepo(azlinux.Azlinux3Config),
 			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
@@ -71,11 +72,6 @@ func TestAzlinux3(t *testing.T) {
 			VersionID: "3.0",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("azl3"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testAzlinuxExtra(ctx, t, cfg, azlinux.Azlinux3Config.ImageRef)
@@ -129,11 +125,6 @@ func TestAzlinux4(t *testing.T) {
 			VersionID: "4.0",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("azl4"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testAzlinuxExtra(ctx, t, cfg, azlinux.Azlinux4Config.ImageRef)

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec/targets/linux/rpm/rockylinux"
 )
 
@@ -39,6 +38,7 @@ func TestRockylinux9(t *testing.T) {
 		Libdir: "/usr/lib64",
 		Worker: workerConfig{
 			ContextName:    rockylinux.ConfigV9.ContextRef,
+			BaseImageRef:   rockylinux.ConfigV9.ImageRef,
 			CreateRepo:     createYumRepo(rockylinux.ConfigV9),
 			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
@@ -48,11 +48,6 @@ func TestRockylinux9(t *testing.T) {
 			VersionID: "9",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("el9"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testRockylinuxExtra(ctx, t, cfg, rockylinux.ConfigV9.ImageRef)
@@ -88,6 +83,7 @@ func TestRockylinux8(t *testing.T) {
 		Libdir: "/usr/lib64",
 		Worker: workerConfig{
 			ContextName:    rockylinux.ConfigV8.ContextRef,
+			BaseImageRef:   rockylinux.ConfigV8.ImageRef,
 			CreateRepo:     createYumRepo(rockylinux.ConfigV8),
 			SignRepo:       signRepoDnf,
 			TestRepoConfig: azlinuxTestRepoConfig,
@@ -97,11 +93,6 @@ func TestRockylinux8(t *testing.T) {
 			VersionID: "8",
 		},
 		SupportsGomodVersionUpdate: true,
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-		},
-		PackageOutputPath: rpmTargetOutputPath("el8"),
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testRockylinuxExtra(ctx, t, cfg, rockylinux.ConfigV8.ImageRef)

--- a/test/target_ubuntu_test.go
+++ b/test/target_ubuntu_test.go
@@ -57,20 +57,14 @@ func debLinuxTestConfigFor(targetKey string, cfg *distro.Config, opts ...func(*t
 			Targets: "/etc/systemd/system",
 		},
 		Worker: workerConfig{
-			ContextName: cfg.ContextRef,
+			ContextName:  cfg.ContextRef,
+			BaseImageRef: cfg.ImageRef,
 			// /pkg1.deb ...
 			CreateRepo:     ubuntuCreateRepo(cfg),
 			SignRepo:       signRepoUbuntu,
 			TestRepoConfig: ubuntuTestRepoConfig,
 			SysextWorker:   cfg.SysextWorker,
 		},
-
-		Platforms: []ocispecs.Platform{
-			{OS: "linux", Architecture: "amd64"},
-			{OS: "linux", Architecture: "arm64"},
-			{OS: "linux", Architecture: "arm", Variant: "v7"},
-		},
-		PackageOutputPath: debTargetOutputPath(cfg.VersionID),
 	}
 
 	for _, o := range opts {

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/content"
 	"github.com/cpuguy83/dockercfg"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -376,6 +377,38 @@ func WithHostNetworking(trc *TestRunnerConfig) {
 func WithSocketProxies(proxies ...socketprovider.ProxyConfig) TestRunnerOpt {
 	return func(cfg *TestRunnerConfig) {
 		cfg.SocketProxies = append(cfg.SocketProxies, proxies...)
+	}
+}
+
+// WithOCIStore registers an OCI layout content store with the build session under
+// the provided id. The store can then be referenced from a build context using an
+// "oci-layout:<id>@<digest>" value, allowing platform-specific manifest selection
+// from a multi-platform index without needing a registry.
+func WithOCIStore(id string, store content.Store) TestRunnerOpt {
+	return func(cfg *TestRunnerConfig) {
+		cfg.SolveOptFns = append(cfg.SolveOptFns, func(so *client.SolveOpt) {
+			if so.OCIStores == nil {
+				so.OCIStores = make(map[string]content.Store)
+			}
+			so.OCIStores[id] = store
+		})
+	}
+}
+
+// WithSourcePolicy merges the given source policy rules into the build's source
+// policy. Rules are appended to any policy already configured (e.g. via the
+// EXPERIMENTAL_BUILDKIT_SOURCE_POLICY environment variable).
+func WithSourcePolicy(pol *spb.Policy) TestRunnerOpt {
+	return func(cfg *TestRunnerConfig) {
+		cfg.SolveOptFns = append(cfg.SolveOptFns, func(so *client.SolveOpt) {
+			if pol == nil {
+				return
+			}
+			if so.SourcePolicy == nil {
+				so.SourcePolicy = &spb.Policy{}
+			}
+			so.SourcePolicy.Rules = append(so.SourcePolicy.Rules, pol.Rules...)
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

The `cross platform` integration test built packages for a foreign architecture (arm64 on amd64 CI runners), which required QEMU emulation. QEMU frequently crashes in CI during this test (e.g. https://github.com/project-dalec/dalec/actions/runs/26779889971/job/78941218259?pr=1068).

## Approach

Replace it with a native test that proves what the test actually cares about: **the frontend selects the correct platform-specific worker image for a requested build platform** — without any emulation or rebuilding the world.

- A custom multi-platform worker image is built as an **OCI layout index** with one manifest per real platform the distros ship (`linux/amd64` and `linux/arm64`). Each manifest embeds a `/platform-marker` file naming its own platform.
- The index is registered with the build session (`SolveOpt.OCIStores`) and supplied as the distro worker context via an `oci-layout:` named context.
- For each requested build platform, the test solves the **`worker` target** and asserts the returned image's `/platform-marker` matches the requested platform.

The distro worker target short-circuits when a worker context image is provided and returns it directly, so nothing is executed (no rpmbuild/dpkg, no emulation) — the worker image is only inspected. Requesting `arm64` on an `amd64` runner therefore needs no QEMU.

Real `amd64`/`arm64` platforms are used (rather than a made-up platform) because the worker handler resolves the real distro image config at the requested platform, so the requested platform must actually exist on that image.