### PR TITLE
flatcar: add sysupdate sysext target

### DIFF
--- a/targets/linux/build_sysext.sh
+++ b/targets/linux/build_sysext.sh
@@ -12,6 +12,8 @@ ARCH=$3
 OS_ID="${DALEC_SYSEXT_OS_ID:-_any}"
 OS_VERSION_ID="${DALEC_SYSEXT_OS_VERSION_ID:-}"
 SYSEXT_LEVEL="${DALEC_SYSEXT_SYSEXT_LEVEL:-}"
+IMAGE_VERSION="${DALEC_SYSEXT_IMAGE_VERSION:-}"
+SHA256SUMS_NAME="${DALEC_SYSEXT_SHA256SUMS_NAME:-}"
 
 # Map Docker/Go arch to systemd arch.
 case ${ARCH} in
@@ -29,8 +31,15 @@ esac
 IMAGE_BASENAME="${NAME}-${VERSION}-${ARCH}"
 
 # Allow overriding the output basename (e.g. Flatcar expects /etc/extensions/<name>.raw).
+# A versioned image name is useful when publishing images for systemd-sysupdate.
 # If user passes "foo.raw", normalize to "foo".
-IMAGE_NAME="${DALEC_SYSEXT_IMAGE_NAME:-${IMAGE_BASENAME}}"
+if [[ -n "${DALEC_SYSEXT_IMAGE_NAME:-}" ]]; then
+	IMAGE_NAME="${DALEC_SYSEXT_IMAGE_NAME}"
+elif [[ -n "${IMAGE_VERSION}" ]]; then
+	IMAGE_NAME="${NAME}-${IMAGE_VERSION}-${ARCH}"
+else
+	IMAGE_NAME="${IMAGE_BASENAME}"
+fi
 IMAGE_NAME="${IMAGE_NAME%.raw}"
 
 TMPDIR=$(mktemp -d)
@@ -91,3 +100,8 @@ tar \
 		--tar=f \
 		-zlz4hc \
 		"/output/${IMAGE_NAME}.raw"
+
+if [[ -n "${SHA256SUMS_NAME}" ]]; then
+	cd /output
+	sha256sum "${IMAGE_NAME}.raw" > "SHA256SUMS.${SHA256SUMS_NAME}"
+fi

--- a/targets/linux/flatcar/flatcar.go
+++ b/targets/linux/flatcar/flatcar.go
@@ -27,6 +27,10 @@ var DefaultConfig = &Config{
 	Base: ubuntu.NobleConfig,
 }
 
+type sysupdateConfig struct {
+	*Config
+}
+
 // SysextEnv provides Flatcar-friendly defaults.
 // Build args with the DALEC_SYSEXT_* prefix still override these.
 func (c *Config) SysextEnv(spec *dalec.Spec, targetKey string) map[string]string {
@@ -38,12 +42,30 @@ func (c *Config) SysextEnv(spec *dalec.Spec, targetKey string) map[string]string
 	}
 }
 
+func (c *sysupdateConfig) SysextEnv(spec *dalec.Spec, targetKey string) map[string]string {
+	env := c.Config.SysextEnv(spec, targetKey)
+	delete(env, "DALEC_SYSEXT_IMAGE_NAME")
+
+	revision := spec.Revision
+	if revision == "" {
+		revision = "1"
+	}
+
+	env["DALEC_SYSEXT_IMAGE_VERSION"] = fmt.Sprintf("v%s-%s", spec.Version, revision)
+	env["DALEC_SYSEXT_SHA256SUMS_NAME"] = spec.Name
+	return env
+}
+
 func (c *Config) Handle(ctx context.Context, client gwclient.Client) (*gwclient.Result, error) {
 	var mux frontend.BuildMux
 	mux.Add("testing/sysext", linux.HandleSysext(c), &targets.Target{
 		Name:        "testing/sysext",
 		Description: "Build a Flatcar-compatible systemd sysext (.raw)",
 		Default:     true,
+	})
+	mux.Add("testing/sysext/sysupdate", linux.HandleSysext(&sysupdateConfig{Config: c}), &targets.Target{
+		Name:        "testing/sysext/sysupdate",
+		Description: "Build a versioned Flatcar sysext and checksum for systemd-sysupdate.",
 	})
 	mux.Add("worker", c.HandleWorker, &targets.Target{
 		Name:        "worker",

--- a/targets/linux/flatcar/flatcar_test.go
+++ b/targets/linux/flatcar/flatcar_test.go
@@ -19,3 +19,34 @@ func TestSysextEnvDefaults(t *testing.T) {
 		t.Fatalf("unexpected env\n got: %#v\nwant: %#v", got, want)
 	}
 }
+
+func TestSysupdateSysextEnvDefaults(t *testing.T) {
+	cfg := &sysupdateConfig{Config: DefaultConfig}
+	got := cfg.SysextEnv(&dalec.Spec{
+		Name:     "go-md2man",
+		Version:  "2.0.7",
+		Revision: "3",
+	}, TargetKey)
+	want := map[string]string{
+		"DALEC_SYSEXT_OS_ID":           "flatcar",
+		"DALEC_SYSEXT_SYSEXT_LEVEL":    "1.0",
+		"DALEC_SYSEXT_IMAGE_VERSION":   "v2.0.7-3",
+		"DALEC_SYSEXT_SHA256SUMS_NAME": "go-md2man",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected env\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestSysupdateSysextEnvDefaultsRevision(t *testing.T) {
+	cfg := &sysupdateConfig{Config: DefaultConfig}
+	got := cfg.SysextEnv(&dalec.Spec{
+		Name:    "go-md2man",
+		Version: "2.0.7",
+	}, TargetKey)
+
+	if got["DALEC_SYSEXT_IMAGE_VERSION"] != "v2.0.7-1" {
+		t.Fatalf("expected default revision in image version, got: %#v", got)
+	}
+}

--- a/targets/linux/sysext_env_test.go
+++ b/targets/linux/sysext_env_test.go
@@ -7,18 +7,22 @@ import (
 
 func TestSysextEnvFromBuildArgs(t *testing.T) {
 	in := map[string]string{
-		"DALEC_SYSEXT_IMAGE_NAME":    "myext",
-		"DALEC_SYSEXT_OS_ID":         "flatcar",
-		"DALEC_SYSEXT_SYSEXT_LEVEL":  "1.0",
-		"DALEC_SYSEXT_OS_VERSION_ID": "",
-		"SOME_OTHER_ARG":             "x",
+		"DALEC_SYSEXT_IMAGE_NAME":      "myext",
+		"DALEC_SYSEXT_IMAGE_VERSION":   "v1.2.3-1",
+		"DALEC_SYSEXT_OS_ID":           "flatcar",
+		"DALEC_SYSEXT_SHA256SUMS_NAME": "myext",
+		"DALEC_SYSEXT_SYSEXT_LEVEL":    "1.0",
+		"DALEC_SYSEXT_OS_VERSION_ID":   "",
+		"SOME_OTHER_ARG":               "x",
 	}
 
 	got := sysextEnvFromBuildArgs(in)
 	want := map[string]string{
-		"DALEC_SYSEXT_IMAGE_NAME":   "myext",
-		"DALEC_SYSEXT_OS_ID":        "flatcar",
-		"DALEC_SYSEXT_SYSEXT_LEVEL": "1.0",
+		"DALEC_SYSEXT_IMAGE_NAME":      "myext",
+		"DALEC_SYSEXT_IMAGE_VERSION":   "v1.2.3-1",
+		"DALEC_SYSEXT_OS_ID":           "flatcar",
+		"DALEC_SYSEXT_SHA256SUMS_NAME": "myext",
+		"DALEC_SYSEXT_SYSEXT_LEVEL":    "1.0",
 	}
 
 	if !reflect.DeepEqual(got, want) {

--- a/test/target_flatcar_sysupdate_test.go
+++ b/test/target_flatcar_sysupdate_test.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec/targets/linux/flatcar"
+	"gotest.tools/v3/assert"
+)
+
+func TestFlatcarSysupdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := startTestSpan(baseCtx, t)
+	platform := ocispecs.Platform{OS: "linux", Architecture: "amd64"}
+	spec := newSimpleSpec()
+	spec.Name = "flatcar-sysupdate-test"
+	spec.Version = "1.2.3"
+	spec.Revision = "4"
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		res := solveT(ctx, t, gwc, newSolveRequest(
+			withBuildTarget(flatcar.TargetKey+"/testing/sysext/sysupdate"),
+			withPlatform(platform),
+			withSpec(ctx, t, spec),
+		))
+
+		const imageName = "flatcar-sysupdate-test-v1.2.3-4-x86-64.raw"
+		image := readFile(ctx, t, "/"+imageName, res)
+		checksum := strings.TrimSpace(string(readFile(ctx, t, "/SHA256SUMS."+spec.Name, res)))
+
+		wantChecksum := fmt.Sprintf("%x  %s", sha256.Sum256(image), imageName)
+		assert.Equal(t, checksum, wantChecksum)
+	})
+}

--- a/website/docs/examples/targets.md
+++ b/website/docs/examples/targets.md
@@ -34,6 +34,7 @@ debug/pip                        Outputs all the pip dependencies for the spec
 debug/resolve                    Outputs the resolved dalec spec file with build args applied.
 debug/sources                    Outputs all sources from a dalec spec file.
 flatcar/testing/sysext (default) Build a Flatcar-compatible systemd sysext (.raw)
+flatcar/testing/sysext/sysupdate Build a versioned Flatcar sysext and checksum for systemd-sysupdate.
 flatcar/worker                   Builds the worker image used to assemble Flatcar sysext images.
 focal/deb (default)              Builds a deb package.
 focal/dsc                        Builds a Debian source package.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `flatcar/testing/sysext/sysupdate` for publishing Flatcar system extensions through `systemd-sysupdate`.

The new target emits:

- `<name>-v<version>-<revision>-<arch>.raw`
- `SHA256SUMS.<name>`

The existing `flatcar/testing/sysext` target remains unchanged and continues to emit `<name>.raw` for direct installation under `/etc/extensions`.

**Which issue(s) this PR fixes**:

Refs #969

**Special notes for your reviewer**:

This follows the release artifact shape used by Flatcar's sysext bakery without adding the multi-gigabyte Flatcar OS SDK as a default worker. A complete sysupdate configuration is publisher-specific because it must reference the hosting URL.

**Validation**:

- `go run ./cmd/lint ./...`
- `make test`
- `make check-generated`
- CI integration test builds the new target and verifies the checksum matches the generated image
