### PR TITLE
Pin gocovmerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,7 +552,7 @@ jobs:
       - name: Merge coverage + generate report
         run: |
           set -eux
-          go install github.com/wadey/gocovmerge@latest
+          go install github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c
 
           integration_profiles="$(find coverage/_integration -type f -name 'integration-*.out' | sort | tr '\n' ' ')"
           frontend_profiles="$(find coverage/_integration -type f -name 'frontend-*.out' | sort | tr '\n' ' ')"


### PR DESCRIPTION
This hasn't changed in 10 years, but good to pin so a malicious or breaking commit doesn't cause us headache.

