### PR TITLE
ci: report least-covered functions in coverage summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,6 +584,8 @@ jobs:
             echo "- Profiles merged: $(echo "${integration_profiles}" | wc -w) integration + $(echo "${frontend_profiles}" | wc -w) frontend"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+          go run ./cmd/covreport -input coverage/summary.txt -top 20 >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Upload merged coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/cmd/covreport/main.go
+++ b/cmd/covreport/main.go
@@ -1,0 +1,178 @@
+// Command covreport reads the textual output of `go tool cover -func` and
+// renders a markdown section listing the functions with the least coverage.
+//
+// It is meant to be appended to a GitHub Actions job summary so contributors
+// can see what is missing coverage without downloading the full profile.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	cfg := parseFlags(os.Args[1:])
+
+	in := os.Stdin
+	if cfg.input != "" {
+		f, err := os.Open(cfg.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		in = f
+	}
+
+	data, err := io.ReadAll(in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := render(os.Stdout, string(data), cfg.top); err != nil {
+		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type config struct {
+	input string
+	top   int
+}
+
+func parseFlags(args []string) config {
+	cfg := config{top: 20}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-input", "--input":
+			if i+1 < len(args) {
+				i++
+				cfg.input = args[i]
+			}
+		case "-top", "--top":
+			if i+1 < len(args) {
+				i++
+				if n, err := strconv.Atoi(args[i]); err == nil {
+					cfg.top = n
+				}
+			}
+		default:
+			if v, ok := strings.CutPrefix(args[i], "-input="); ok {
+				cfg.input = v
+			} else if v, ok := strings.CutPrefix(args[i], "--input="); ok {
+				cfg.input = v
+			} else if v, ok := strings.CutPrefix(args[i], "-top="); ok {
+				if n, err := strconv.Atoi(v); err == nil {
+					cfg.top = n
+				}
+			} else if v, ok := strings.CutPrefix(args[i], "--top="); ok {
+				if n, err := strconv.Atoi(v); err == nil {
+					cfg.top = n
+				}
+			}
+		}
+	}
+	return cfg
+}
+
+type funcCoverage struct {
+	location string
+	function string
+	percent  float64
+}
+
+// parse extracts per-function coverage entries from `go tool cover -func`
+// output. The trailing "total:" line and any lines that do not match the
+// expected shape are ignored.
+func parse(out string) []funcCoverage {
+	var entries []funcCoverage
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] == "total:" {
+			continue
+		}
+
+		pctField := fields[len(fields)-1]
+		if !strings.HasSuffix(pctField, "%") {
+			continue
+		}
+		pct, err := strconv.ParseFloat(strings.TrimSuffix(pctField, "%"), 64)
+		if err != nil {
+			continue
+		}
+
+		entries = append(entries, funcCoverage{
+			location: strings.TrimSuffix(fields[0], ":"),
+			function: fields[len(fields)-2],
+			percent:  pct,
+		})
+	}
+	return entries
+}
+
+// missing returns the entries below 100% coverage sorted ascending by
+// percentage (least covered first), with deterministic tie-breaks.
+func missing(entries []funcCoverage) []funcCoverage {
+	var out []funcCoverage
+	for _, e := range entries {
+		if e.percent < 100.0 {
+			out = append(out, e)
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].percent != out[j].percent {
+			return out[i].percent < out[j].percent
+		}
+		if out[i].location != out[j].location {
+			return out[i].location < out[j].location
+		}
+		return out[i].function < out[j].function
+	})
+
+	return out
+}
+
+func render(w io.Writer, out string, top int) error {
+	below := missing(parse(out))
+
+	var buf strings.Builder
+	buf.WriteString("## Missing coverage\n\n")
+
+	if len(below) == 0 {
+		buf.WriteString("All tracked functions are fully covered.\n")
+		_, err := io.WriteString(w, buf.String())
+		return err
+	}
+
+	total := len(below)
+	shown := below
+	if top > 0 && total > top {
+		shown = below[:top]
+	}
+
+	summary := fmt.Sprintf("%d least-covered functions (below 100%%)", len(shown))
+	if len(shown) < total {
+		summary = fmt.Sprintf("%d of %d functions below 100%% coverage", len(shown), total)
+	}
+
+	buf.WriteString("<details>\n")
+	fmt.Fprintf(&buf, "<summary>%s</summary>\n\n", summary)
+	buf.WriteString("| Coverage | Function | Location |\n")
+	buf.WriteString("| --- | --- | --- |\n")
+	for _, e := range shown {
+		fmt.Fprintf(&buf, "| %.1f%% | %s | %s |\n", e.percent, e.function, e.location)
+	}
+	buf.WriteString("\n</details>\n")
+
+	_, err := io.WriteString(w, buf.String())
+	return err
+}

--- a/cmd/covreport/main_test.go
+++ b/cmd/covreport/main_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleFuncOutput = `github.com/project-dalec/dalec/a.go:10:	AlphaFunc		100.0%
+github.com/project-dalec/dalec/a.go:20:	BetaFunc		0.0%
+github.com/project-dalec/dalec/b.go:5:	GammaFunc		50.0%
+github.com/project-dalec/dalec/b.go:30:	DeltaFunc		50.0%
+github.com/project-dalec/dalec/c.go:1:	EpsilonFunc		99.9%
+total:							(statements)		70.0%
+`
+
+func TestParse(t *testing.T) {
+	got := parse(sampleFuncOutput)
+	if len(got) != 5 {
+		t.Fatalf("expected 5 entries (total: excluded), got %d: %#v", len(got), got)
+	}
+
+	first := got[0]
+	if first.location != "github.com/project-dalec/dalec/a.go:10" {
+		t.Fatalf("unexpected location: %q", first.location)
+	}
+	if first.function != "AlphaFunc" {
+		t.Fatalf("unexpected function: %q", first.function)
+	}
+	if first.percent != 100.0 {
+		t.Fatalf("unexpected percent: %v", first.percent)
+	}
+}
+
+func TestParseSkipsTotalAndMalformed(t *testing.T) {
+	in := sampleFuncOutput + "this is not a coverage line\nfoo.go:1:\tBar\tnotapercent\n\n"
+	got := parse(in)
+	for _, e := range got {
+		if e.location == "total" || e.location == "total:" {
+			t.Fatalf("total line should be excluded, got %#v", e)
+		}
+		if e.function == "Bar" {
+			t.Fatalf("malformed percent line should be excluded, got %#v", e)
+		}
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected 5 valid entries, got %d", len(got))
+	}
+}
+
+func TestMissingFiltersAndSorts(t *testing.T) {
+	got := missing(parse(sampleFuncOutput))
+
+	if len(got) != 4 {
+		t.Fatalf("expected 4 entries below 100%%, got %d: %#v", len(got), got)
+	}
+
+	// Ascending by percent: 0.0 first, then the two 50.0 (tie-broken by
+	// location: b.go:30 < b.go:5 lexically), then 99.9.
+	wantOrder := []string{"BetaFunc", "DeltaFunc", "GammaFunc", "EpsilonFunc"}
+	for i, want := range wantOrder {
+		if got[i].function != want {
+			t.Fatalf("position %d: expected %q, got %q (full: %#v)", i, want, got[i].function, got)
+		}
+	}
+}
+
+func TestRenderTopCap(t *testing.T) {
+	var sb strings.Builder
+	if err := render(&sb, sampleFuncOutput, 2); err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+	out := sb.String()
+
+	if !strings.Contains(out, "## Missing coverage") {
+		t.Fatalf("missing heading:\n%s", out)
+	}
+	if !strings.Contains(out, "2 of 4 functions below 100% coverage") {
+		t.Fatalf("expected capped summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "| 0.0% | BetaFunc |") {
+		t.Fatalf("expected BetaFunc row:\n%s", out)
+	}
+	if strings.Contains(out, "EpsilonFunc") {
+		t.Fatalf("EpsilonFunc should be capped out:\n%s", out)
+	}
+}
+
+func TestRenderShowsAllWhenUnderCap(t *testing.T) {
+	var sb strings.Builder
+	if err := render(&sb, sampleFuncOutput, 20); err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "4 least-covered functions (below 100%)") {
+		t.Fatalf("expected full-list summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "EpsilonFunc") {
+		t.Fatalf("expected EpsilonFunc present:\n%s", out)
+	}
+}
+
+func TestRenderFullyCovered(t *testing.T) {
+	in := `github.com/project-dalec/dalec/a.go:10:	AlphaFunc		100.0%
+total:							(statements)		100.0%
+`
+	var sb strings.Builder
+	if err := render(&sb, in, 20); err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "All tracked functions are fully covered.") {
+		t.Fatalf("expected fully-covered note, got:\n%s", out)
+	}
+	if strings.Contains(out, "<details>") {
+		t.Fatalf("did not expect a table for fully-covered input:\n%s", out)
+	}
+}
+
+func TestRenderEmptyInput(t *testing.T) {
+	var sb strings.Builder
+	if err := render(&sb, "", 20); err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+	if !strings.Contains(sb.String(), "All tracked functions are fully covered.") {
+		t.Fatalf("expected fully-covered note for empty input, got:\n%s", sb.String())
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	cfg := parseFlags([]string{"-input", "cov.txt", "-top", "5"})
+	if cfg.input != "cov.txt" || cfg.top != 5 {
+		t.Fatalf("unexpected config: %#v", cfg)
+	}
+
+	cfg = parseFlags([]string{"-input=cov.txt", "-top=7"})
+	if cfg.input != "cov.txt" || cfg.top != 7 {
+		t.Fatalf("unexpected config (equals form): %#v", cfg)
+	}
+
+	cfg = parseFlags(nil)
+	if cfg.top != 20 {
+		t.Fatalf("expected default top=20, got %d", cfg.top)
+	}
+}


### PR DESCRIPTION
## What

The `coverage-report` CI job's job summary previously showed only the **total** coverage percentage, giving no visibility into *what* is under-tested.

This adds **`cmd/covreport`**, a small testable helper that parses `go tool cover -func` output and renders a `## Missing coverage` markdown section: a collapsible `<details>` table of the **top 20 functions below 100% coverage, sorted lowest-first** (`Coverage | Function | Location`). It's wired into the `coverage-report` job so the list is appended to `$GITHUB_STEP_SUMMARY` right after the existing total.

## How

- The tool reuses `coverage/summary.txt` (already produced by the `tee` on the `go tool cover -func` line), so no additional profile parsing is needed.
- Flags: `-input` (default stdin), `-top` (default 20).
- Skips the `total:` line and malformed lines; emits "All tracked functions are fully covered." when nothing is below 100%.
- **Reports only** — it never gates the build.

## Tests

`cmd/covreport/main_test.go` covers parsing, `total:`/malformed exclusion, the 100% filter, ascending sort with deterministic tie-breaks, top-N capping, full-list vs capped summaries, empty/all-covered input, and flag parsing.

Verified locally: `go test`, `go vet`, the repo's custom linter, and `go build ./cmd/...` all pass; smoke-tested against real `-func` output.