### PR TITLE
test: bind git HTTP test server to ephemeral port

### DIFF
--- a/test/git_services/attributes.go
+++ b/test/git_services/attributes.go
@@ -24,7 +24,9 @@ type Attributes struct {
 	// PrivateGomoduleHost is the hostname of the git server
 	PrivateGomoduleHost string
 
-	// HTTPPort is the port on which the http git server runs
+	// HTTPPort is the requested port on which the http git server listens. Use
+	// "0" to request an ephemeral port; the actual bound port is reported back
+	// and written here once the server is online.
 	HTTPPort string
 	// SSHPort is the port on which the ssh git server runs
 	SSHPort string

--- a/test/git_services/attributes.go
+++ b/test/git_services/attributes.go
@@ -25,11 +25,11 @@ type Attributes struct {
 	PrivateGomoduleHost string
 
 	// HTTPPort is the requested port on which the http git server listens. Use
-	// "0" to request an ephemeral port; the actual bound port is reported back
+	// 0 to request an ephemeral port; the actual bound port is reported back
 	// and written here once the server is online.
-	HTTPPort string
+	HTTPPort int
 	// SSHPort is the port on which the ssh git server runs
-	SSHPort string
+	SSHPort int
 
 	// HTTPServerBuildDir is the location at which the HTTP server program's
 	// code will be loaded for building

--- a/test/git_services/cmd/server/main.go
+++ b/test/git_services/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 
 	githttp "github.com/AaronO/go-git-http"
 	"github.com/AaronO/go-git-http/auth"
@@ -64,12 +65,23 @@ func runServe() error {
 		return false, nil
 	})
 
-	// Bind to all interfaces
+	// Bind to all interfaces. A port of "0" lets the kernel pick a free
+	// ephemeral port, which avoids collisions when multiple servers run
+	// concurrently in a shared network namespace.
 	addr := fmt.Sprintf("0.0.0.0:%s", port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
+
+	// Resolve the port actually bound, which differs from the requested port
+	// when "0" was requested.
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		listener.Close()
+		return fmt.Errorf("unexpected listener address type %T", listener.Addr())
+	}
+	actualPort := strconv.Itoa(tcpAddr.Port)
 
 	// Get the container's IP address
 	ip, err := getContainerIP()
@@ -78,8 +90,8 @@ func runServe() error {
 		return fmt.Errorf("failed to get container IP: %w", err)
 	}
 
-	// Emit the ready event with the IP and port
-	emitReady(ip, port)
+	// Emit the ready event with the IP and the actual bound port
+	emitReady(ip, actualPort)
 
 	http.Handle("/", authr(gitHandler))
 	s := &http.Server{}

--- a/test/git_services/cmd/server/main.go
+++ b/test/git_services/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strconv"
 
 	githttp "github.com/AaronO/go-git-http"
 	"github.com/AaronO/go-git-http/auth"
@@ -81,7 +80,6 @@ func runServe() error {
 		listener.Close()
 		return fmt.Errorf("unexpected listener address type %T", listener.Addr())
 	}
-	actualPort := strconv.Itoa(tcpAddr.Port)
 
 	// Get the container's IP address
 	ip, err := getContainerIP()
@@ -91,7 +89,7 @@ func runServe() error {
 	}
 
 	// Emit the ready event with the IP and the actual bound port
-	emitReady(ip, actualPort)
+	emitReady(ip, tcpAddr.Port)
 
 	http.Handle("/", authr(gitHandler))
 	s := &http.Server{}
@@ -133,7 +131,7 @@ func getContainerIP() (string, error) {
 	return "", errors.New("no suitable IP address found")
 }
 
-func emitReady(ip, port string) {
+func emitReady(ip string, port int) {
 	event := gitservices.ServerEvent{
 		Type:  gitservices.EventTypeReady,
 		Ready: &gitservices.ReadyEvent{IP: ip, Port: port},

--- a/test/git_services/protocol.go
+++ b/test/git_services/protocol.go
@@ -22,7 +22,7 @@ type ReadyEvent struct {
 	// IP is the IP address the server is bound to (usually the container's IP).
 	IP string `json:"ip" yaml:"ip"`
 	// Port is the port the server is listening on.
-	Port string `json:"port" yaml:"port"`
+	Port int `json:"port" yaml:"port"`
 }
 
 // ErrorEvent indicates an error occurred.

--- a/test/git_services/teststate.go
+++ b/test/git_services/teststate.go
@@ -127,6 +127,11 @@ func (ts *TestState) StartHTTPGitServer(ctx context.Context, gitHost llb.State) 
 	t.Log("waiting for http server to come online")
 	ready := ts.waitForReady(ctx, proc, waitOnlineTimeout)
 
+	// The server may have been asked to bind an ephemeral port ("0"), so record
+	// the actual port it bound. Downstream spec and gitconfig generation read
+	// ts.Attr.HTTPPort, so they must observe the real port.
+	ts.Attr.HTTPPort = ready.Port
+
 	t.Logf("http server is online at %s:%s", ready.IP, ready.Port)
 
 	return ServerResult{IP: ready.IP, Port: ready.Port, ErrChan: proc.ErrChan()}

--- a/test/git_services/teststate.go
+++ b/test/git_services/teststate.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"iter"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -60,7 +61,7 @@ func (ts *TestState) Client() gwclient.Client {
 // Dalec spec boilerplate
 func (ts *TestState) GenerateSpec(gomodContents string, auth dalec.GomodGitAuth) *dalec.Spec {
 	const sourceName = "gitauth"
-	var port string
+	var port int
 
 	switch {
 	case auth.Token != "":
@@ -88,7 +89,7 @@ func (ts *TestState) GenerateSpec(gomodContents string, auth dalec.GomodGitAuth)
 					{
 						Gomod: &dalec.GeneratorGomod{
 							Auth: map[string]dalec.GomodGitAuth{
-								fmt.Sprintf("%s:%s", ts.Attr.PrivateGomoduleHost, port): auth,
+								fmt.Sprintf("%s:%d", ts.Attr.PrivateGomoduleHost, port): auth,
 							},
 						},
 					},
@@ -104,7 +105,7 @@ type ServerResult struct {
 	// IP is the IP address of the container running the server.
 	IP string
 	// Port is the port the server is listening on.
-	Port string
+	Port int
 	// ErrChan receives errors from the server process.
 	ErrChan <-chan error
 }
@@ -121,18 +122,18 @@ func (ts *TestState) StartHTTPGitServer(ctx context.Context, gitHost llb.State) 
 		ts.Attr.HTTPServerPath,
 		"serve",
 		ts.Attr.ServerRoot,
-		ts.Attr.HTTPPort,
+		strconv.Itoa(ts.Attr.HTTPPort),
 	})
 
 	t.Log("waiting for http server to come online")
 	ready := ts.waitForReady(ctx, proc, waitOnlineTimeout)
 
-	// The server may have been asked to bind an ephemeral port ("0"), so record
+	// The server may have been asked to bind an ephemeral port (0), so record
 	// the actual port it bound. Downstream spec and gitconfig generation read
 	// ts.Attr.HTTPPort, so they must observe the real port.
 	ts.Attr.HTTPPort = ready.Port
 
-	t.Logf("http server is online at %s:%s", ready.IP, ready.Port)
+	t.Logf("http server is online at %s:%d", ready.IP, ready.Port)
 
 	return ServerResult{IP: ready.IP, Port: ready.Port, ErrChan: proc.ErrChan()}
 }
@@ -257,7 +258,7 @@ func (ts *TestState) StartSSHServer(ctx context.Context, gitHost llb.State) Serv
             done
 
             # Output ready event as JSON
-            printf '{"type":"ready","ready":{"ip":"%s","port":"%s"}}\n' "$IP" "$PORT"
+            printf '{"type":"ready","ready":{"ip":"%s","port":%s}}\n' "$IP" "$PORT"
 
             # Wait for server process
             wait $SERVER_PID
@@ -273,7 +274,7 @@ func (ts *TestState) StartSSHServer(ctx context.Context, gitHost llb.State) Serv
 	t.Log("waiting for ssh server to come online")
 	ready := ts.waitForReady(ctx, proc, waitOnlineTimeout)
 
-	t.Logf("ssh server is online at %s:%s", ready.IP, ready.Port)
+	t.Logf("ssh server is online at %s:%d", ready.IP, ready.Port)
 
 	return ServerResult{IP: ready.IP, Port: ready.Port, ErrChan: proc.ErrChan()}
 }

--- a/test/gomod_git_auth_test.go
+++ b/test/gomod_git_auth_test.go
@@ -32,15 +32,18 @@ func TestGomodGitAuth(t *testing.T) {
 	sshID := "dalecssh"
 
 	// Base attributes for the git services.
-	// Note: HTTPPort and SSHPort are still used to configure what port the servers
-	// listen on inside their containers.
+	// Note: SSHPort is still used to configure what port the SSH server
+	// listens on inside its container. HTTPPort is "0" so the kernel picks a
+	// free ephemeral port, avoiding collisions between concurrent servers; the
+	// actual port is reported back and recorded in Attr.HTTPPort once the
+	// server is online.
 	attr := gitservices.Attributes{
 		ServerRoot:             "/",
 		PrivateRepoPath:        "username/private",
 		DependingRepoPath:      "username/public",
 		HTTPServerPath:         "/usr/local/bin/git_http_server",
 		PrivateGomoduleHost:    "host.docker.internal",
-		HTTPPort:               "8080",
+		HTTPPort:               "0",
 		SSHPort:                "2222",
 		HTTPServerBuildDir:     "/tmp/dalec/internal/dalec_coderoot",
 		HTTPServeCodeLocalPath: "./test/cmd/git_repo",

--- a/test/gomod_git_auth_test.go
+++ b/test/gomod_git_auth_test.go
@@ -33,7 +33,7 @@ func TestGomodGitAuth(t *testing.T) {
 
 	// Base attributes for the git services.
 	// Note: SSHPort is still used to configure what port the SSH server
-	// listens on inside its container. HTTPPort is "0" so the kernel picks a
+	// listens on inside its container. HTTPPort is 0 so the kernel picks a
 	// free ephemeral port, avoiding collisions between concurrent servers; the
 	// actual port is reported back and recorded in Attr.HTTPPort once the
 	// server is online.
@@ -43,8 +43,8 @@ func TestGomodGitAuth(t *testing.T) {
 		DependingRepoPath:      "username/public",
 		HTTPServerPath:         "/usr/local/bin/git_http_server",
 		PrivateGomoduleHost:    "host.docker.internal",
-		HTTPPort:               "0",
-		SSHPort:                "2222",
+		HTTPPort:               0,
+		SSHPort:                2222,
 		HTTPServerBuildDir:     "/tmp/dalec/internal/dalec_coderoot",
 		HTTPServeCodeLocalPath: "./test/cmd/git_repo",
 		OutDir:                 "/tmp/dalec/internal/output",

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -477,7 +477,7 @@ func TestSourceGitChecksumPreservesTagMetadata(t *testing.T) {
 				ServerRoot:      "/",
 				PrivateRepoPath: "username/private",
 				HTTPServerPath:  "/usr/local/bin/git_http_server",
-				HTTPPort:        "8080",
+				HTTPPort:        "0",
 			}
 
 			testState := gitservices.NewTestState(t, gwc, &attr)

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -477,7 +478,7 @@ func TestSourceGitChecksumPreservesTagMetadata(t *testing.T) {
 				ServerRoot:      "/",
 				PrivateRepoPath: "username/private",
 				HTTPServerPath:  "/usr/local/bin/git_http_server",
-				HTTPPort:        "0",
+				HTTPPort:        0,
 			}
 
 			testState := gitservices.NewTestState(t, gwc, &attr)
@@ -513,7 +514,7 @@ func TestSourceGitChecksumPreservesTagMetadata(t *testing.T) {
 					Sources: map[string]dalec.Source{
 						sourceName: {
 							Git: &dalec.SourceGit{
-								URL:        "http://" + httpServer.IP + ":" + httpServer.Port + "/" + attr.PrivateRepoPath,
+								URL:        "http://" + httpServer.IP + ":" + strconv.Itoa(httpServer.Port) + "/" + attr.PrivateRepoPath,
 								Commit:     tagName,
 								Checksum:   checksum,
 								KeepGitDir: true,


### PR DESCRIPTION
## Problem

`TestSourceGitChecksumPreservesTagMetadata` (and occasionally `TestGomodGitAuth/HTTP`) failed intermittently with:

```
server error: failed to listen on 0.0.0.0:8080: listen tcp 0.0.0.0:8080: bind: address already in use
```

The integration-test git HTTP server hardcoded binding `0.0.0.0:8080`. The gateway containers that run these servers share the BuildKit worker's network namespace, so when two servers were alive at the same time the second `net.Listen` hit `EADDRINUSE`.

`TestSourceGitChecksumPreservesTagMetadata` runs two `t.Parallel()` subtests, each starting an HTTP git server on 8080, and `TestGomodGitAuth/HTTP` uses 8080 too. The failure only surfaced when these overlapped under the test scheduler, which is why it was flaky.

## Fix

Let the kernel assign a free port instead of hardcoding 8080:

- `cmd/server` (`runServe`): accepts `"0"` as the requested port, then reads the actual bound port from `listener.Addr()` and reports it in the ready event.
- `StartHTTPGitServer`: records the real port back into `Attr.HTTPPort` so the spec and client gitconfig generation that run afterward use it.
- `source_test.go` / `gomod_git_auth_test.go`: request port `"0"` instead of `8080`.

## Trade-off

Callers must start the HTTP server before generating specs or client gitconfig, since the concrete port is only known once the server is online. Current call sites already follow this order.

SSH (port 2222) is left unchanged — only one SSH server is started per test process, so it can't collide.