### PR TITLE
feat: Add abilility to drop gomod requires

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -1115,6 +1115,17 @@
 		},
 		"GomodEdits": {
 			"properties": {
+				"drop": {
+					"items": {
+						"type": [
+							"string"
+						]
+					},
+					"type": [
+						"array"
+					],
+					"description": "Drop removes module requirements from go.mod via go mod edit -droprequire.\nEach entry is a module path to remove. This handles cases where a sub-module\nhas been absorbed into its parent module in a newer version\n(e.g. google.golang.org/grpc/stats/opentelemetry merged into grpc at v1.79.0)."
+				},
 				"replace": {
 					"items": {
 						"$ref": "#/$defs/GomodReplace"

--- a/generator_gomod_test.go
+++ b/generator_gomod_test.go
@@ -210,3 +210,89 @@ func TestGomodReplaceGoModEditArg(t *testing.T) {
 		})
 	}
 }
+
+func TestGomodEditArgs_DropRequire(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		gen          *GeneratorGomod
+		expectErr    bool
+		expectedArgs string
+	}{
+		{
+			name: "drop converts to droprequire",
+			gen: &GeneratorGomod{
+				Edits: &GomodEdits{
+					Drop: []string{"example.com/old-submodule"},
+				},
+			},
+			expectedArgs: "-droprequire=example.com/old-submodule",
+		},
+		{
+			name: "multiple drops",
+			gen: &GeneratorGomod{
+				Edits: &GomodEdits{
+					Drop: []string{
+						"example.com/mod-a",
+						"example.com/mod-b",
+					},
+				},
+			},
+			expectedArgs: "-droprequire=example.com/mod-a\n-droprequire=example.com/mod-b",
+		},
+		{
+			name: "mixed drop and replace",
+			gen: &GeneratorGomod{
+				Edits: &GomodEdits{
+					Replace: []GomodReplace{
+						{Original: "example.com/grpc", Update: "example.com/grpc@v1.79.3"},
+					},
+					Drop: []string{"example.com/grpc/stats/otel"},
+				},
+			},
+			expectedArgs: "-replace=example.com/grpc=example.com/grpc@v1.79.3\n-droprequire=example.com/grpc/stats/otel",
+		},
+		{
+			name: "drop with empty module path errors",
+			gen: &GeneratorGomod{
+				Edits: &GomodEdits{
+					Drop: []string{""},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "drop with invalid module path errors",
+			gen: &GeneratorGomod{
+				Edits: &GomodEdits{
+					Drop: []string{"INVALID PATH"},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "nil edits returns empty",
+			gen:          &GeneratorGomod{},
+			expectedArgs: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := gomodEditArgs(tt.gen)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if args != tt.expectedArgs {
+				t.Errorf("expected %q, got %q", tt.expectedArgs, args)
+			}
+		})
+	}
+}

--- a/generator_gomod_test.go
+++ b/generator_gomod_test.go
@@ -272,7 +272,7 @@ func TestGomodEditArgs_DropRequire(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "nil edits returns empty",
+			name:         "nil edits returns empty",
 			gen:          &GeneratorGomod{},
 			expectedArgs: "",
 		},

--- a/preprocess.go
+++ b/preprocess.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/mod/module"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )
@@ -102,7 +104,7 @@ func (s *Spec) preprocessGomodEdits(sOpt SourceOpts, worker llb.State, opts ...l
 	return nil
 }
 
-// gomodEditArgs generates the list of -replace= arguments for go mod edit.
+// gomodEditArgs generates the list of go mod edit arguments from gomod edits.
 // Returns a newline-separated list of arguments that can be safely passed to go mod edit.
 func gomodEditArgs(g *GeneratorGomod) (string, error) {
 	if g == nil || g.Edits == nil {
@@ -118,6 +120,18 @@ func gomodEditArgs(g *GeneratorGomod) (string, error) {
 			return "", err
 		}
 		args = append(args, "-replace="+arg)
+	}
+
+	// Process drop-require directives
+	for _, mod := range g.Edits.Drop {
+		mod = strings.TrimSpace(mod)
+		if mod == "" {
+			return "", errors.New("invalid gomod drop: module path must be non-empty")
+		}
+		if err := module.CheckPath(mod); err != nil {
+			return "", errors.Errorf("invalid gomod drop %q: %v", mod, err)
+		}
+		args = append(args, "-droprequire="+mod)
 	}
 
 	if len(args) == 0 {

--- a/spec.go
+++ b/spec.go
@@ -212,6 +212,11 @@ type GomodEdits struct {
 	// Replace applies go.mod replace directives before downloading module dependencies.
 	// Each entry can be either a string "old => new" or a struct with Old and New fields.
 	Replace []GomodReplace `yaml:"replace,omitempty" json:"replace,omitempty"`
+	// Drop removes module requirements from go.mod via go mod edit -droprequire.
+	// Each entry is a module path to remove. This handles cases where a sub-module
+	// has been absorbed into its parent module in a newer version
+	// (e.g. google.golang.org/grpc/stats/opentelemetry merged into grpc at v1.79.0).
+	Drop []string `yaml:"drop,omitempty" json:"drop,omitempty"`
 }
 
 // GomodReplace represents a go.mod replace directive.

--- a/website/docs/sources.md
+++ b/website/docs/sources.md
@@ -534,6 +534,34 @@ The edits are applied to all modules specified in the `paths` field (or the root
 The generated patches are created during preprocessing and are treated as internal sources. You don't need to manually create or maintain these patch files - Dalec handles this automatically based on your replace directives.
 :::
 
+#### Drop require directives
+
+The `gomod` generator also supports removing module requirements from `go.mod` using `drop` directives. This is useful when:
+- A sub-module has been absorbed into its parent module in a newer version
+- An upstream `go.mod` still requires a module that no longer exists as a separate package
+- A replace directive upgrades a module to a version where a previously-separate sub-module was merged back
+
+When drop directives are specified, Dalec runs `go mod edit -droprequire=<module>` before downloading dependencies.
+
+**Example using drop directive:**
+
+```yaml
+sources:
+  myapp:
+    git:
+      url: https://github.com/example/myapp.git
+      commit: v1.0.0
+    generate:
+      - gomod:
+          edits:
+            replace:
+              - "google.golang.org/grpc => google.golang.org/grpc@v1.79.3"
+            drop:
+              - google.golang.org/grpc/stats/opentelemetry
+```
+
+In this example, `grpc/stats/opentelemetry` was merged into the main `grpc` module at v1.79.0. The replace directive upgrades grpc, and the drop directive removes the now-orphaned sub-module requirement that would otherwise cause `go mod tidy` to fail.
+
 ### Cargohome
 
 Similar to that of the `gomod` generator, we can generate `cargohome` dependencies. The syntax is as follows:


### PR DESCRIPTION
## Problem

When a Go sub-module gets absorbed into its parent module in a newer version, upgrading the parent via a `replace` directive leaves an orphaned `require` in `go.mod` that can no longer be resolved.

**Real-world example:** `google.golang.org/grpc/stats/opentelemetry` was a separate module (with its own `go.mod`) up through grpc v1.68.x. Starting with grpc v1.79.0, it was merged into the main `google.golang.org/grpc` module — the code still exists as a package, but there is no longer a separate `go.mod` at that path.

When a CVE fix upgrades `google.golang.org/grpc` to v1.79.3 via a replace directive, `go mod tidy` fails because it cannot resolve the orphaned `require google.golang.org/grpc/stats/opentelemetry v0.0.0-...` — no module exists at that path in the newer version.

### Current workaround

Spec authors must create a **source patch** that adds a stub `go.mod` file and a **local directory replace** pointing to it. This works but adds maintenance burden.

See [Azure/dalec-build-defs#9887](https://github.com/Azure/dalec-build-defs/pull/9887) for an example.

## Solution

Add a dedicated `Drop` field to `GomodEdits` that emits `go mod edit -droprequire=<module>` arguments. The subsequent `go mod tidy` then cleanly resolves the dependency graph.

### Spec syntax

```yaml
sources:
  kube-state-metrics:
    generate:
      - gomod:
          edits:
            replace:
              - google.golang.org/grpc => google.golang.org/grpc@v1.79.3
            drop:
              - google.golang.org/grpc/stats/opentelemetry
```

### Implementation

- **`spec.go`**: Added `Drop []string` field to `GomodEdits` struct with documentation.
- **`preprocess.go`**: Updated `gomodEditArgs()` to iterate `Drop` entries and emit `-droprequire=` arguments.
- **`generator_gomod_test.go`**: Added tests covering: basic drop, multiple drops, mixed drop+replace, empty-path error, and nil-edits passthrough.
- **`gomod-patch.sh`**: No changes needed — the shell script already iterates edit args line-by-line and passes each to `go mod edit`, which natively supports `-droprequire=`.

### Why a dedicated `Drop` field?

Per reviewer feedback, a dedicated field is preferable to overloading `Replace` with a sentinel value:
- **Clear intent** — `drop:` is unambiguous; readers don't need to know about magic values
- **Type-safe** — `[]string` for module paths, no struct needed
- **No collision risk** — doesn't repurpose an existing field's semantics
- **Validates naturally** — empty strings are the only invalid input

### Verified

Tested locally against `kubernetes/kube-state-metrics` v2.16.0:

```sh
go mod edit \
  -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3 \
  -droprequire google.golang.org/grpc/stats/opentelemetry
go mod tidy   # succeeds
go build ./...  # succeeds
```

All existing tests pass (`go test ./...`).