### PR TITLE
tests: avoid cross-distro build in cache dir test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ COPY . .
 ENV CGO_ENABLED=0
 ARG TARGETARCH TARGETOS GOFLAGS=-trimpath
 ARG DALEC_FRONTEND_COVERAGE=0
+ARG EXTRA_BUILD_FLAGS=""
 ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=${GOFLAGS}
 RUN \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ "${DALEC_FRONTEND_COVERAGE}" = "1" ]; then \
-	go build -cover -covermode=atomic -coverpkg=./... -o /frontend ./cmd/frontend ; \
+	go build ${EXTRA_BUILD_FLAGS} -cover -covermode=atomic -coverpkg=./... -o /frontend ./cmd/frontend ; \
     else \
-        go build -o /frontend ./cmd/frontend ; \
+        go build ${EXTRA_BUILD_FLAGS} -o /frontend ./cmd/frontend ; \
     fi
 
 FROM scratch AS frontend

--- a/targets/plugin/alt_testing_targets.go
+++ b/targets/plugin/alt_testing_targets.go
@@ -1,0 +1,5 @@
+//go:build alt_testing_targets
+
+package plugin
+
+const includeAltTestingTargets = true

--- a/targets/plugin/init.go
+++ b/targets/plugin/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/project-dalec/dalec/frontend"
 	"github.com/project-dalec/dalec/targets"
 	"github.com/project-dalec/dalec/targets/linux/deb/debian"
+	debdistro "github.com/project-dalec/dalec/targets/linux/deb/distro"
 	"github.com/project-dalec/dalec/targets/linux/deb/ubuntu"
 	"github.com/project-dalec/dalec/targets/linux/flatcar"
 	"github.com/project-dalec/dalec/targets/linux/rpm/almalinux"
@@ -15,60 +16,63 @@ import (
 	"github.com/project-dalec/dalec/targets/windows"
 )
 
+const testingAltVersionIDSuffix = "testingalt"
+
+type routeFunc func(prefix string, spec *dalec.Spec) ([]frontend.Route, error)
+
 func init() {
-	registerRoutes(debian.TrixieDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return debian.TrixieConfig.Routes(debian.TrixieDefaultTargetKey, spec)
-	})
-	registerRoutes(debian.BookwormDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return debian.BookwormConfig.Routes(debian.BookwormDefaultTargetKey, spec)
-	})
-	registerRoutes(debian.BullseyeDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return debian.BullseyeConfig.Routes(debian.BullseyeDefaultTargetKey, spec)
+	registerDebRoutes(debian.TrixieDefaultTargetKey, debian.TrixieConfig)
+	registerDebRoutes(debian.BookwormDefaultTargetKey, debian.BookwormConfig)
+	registerDebRoutes(debian.BullseyeDefaultTargetKey, debian.BullseyeConfig)
+
+	registerDebRoutes(ubuntu.BionicDefaultTargetKey, ubuntu.BionicConfig)
+	registerDebRoutes(ubuntu.FocalDefaultTargetKey, ubuntu.FocalConfig)
+	registerDebRoutes(ubuntu.JammyDefaultTargetKey, ubuntu.JammyConfig)
+	registerDebRoutes(ubuntu.NobleDefaultTargetKey, ubuntu.NobleConfig)
+
+	registerRoutes(almalinux.V8TargetKey, almalinux.ConfigV8.Routes)
+	registerRoutes(almalinux.V9TargetKey, almalinux.ConfigV9.Routes)
+
+	registerRoutes(rockylinux.V8TargetKey, rockylinux.ConfigV8.Routes)
+	registerRoutes(rockylinux.V9TargetKey, rockylinux.ConfigV9.Routes)
+
+	registerRoutes(azlinux.AzLinux3TargetKey, azlinux.Azlinux3Config.Routes)
+	registerRoutes(azlinux.AzLinux4TargetKey, azlinux.Azlinux4Config.Routes)
+
+	registerRoutes(flatcar.TargetKey, flatcar.DefaultConfig.Routes)
+
+	registerRoutes(windows.DefaultTargetKey, windows.Routes)
+}
+
+func registerRoutes(name string, routes routeFunc) {
+	targets.RegisterRouteProvider(name, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
+		return routes(name, spec)
 	})
 
-	registerRoutes(ubuntu.BionicDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return ubuntu.BionicConfig.Routes(ubuntu.BionicDefaultTargetKey, spec)
-	})
-	registerRoutes(ubuntu.FocalDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return ubuntu.FocalConfig.Routes(ubuntu.FocalDefaultTargetKey, spec)
-	})
-	registerRoutes(ubuntu.JammyDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return ubuntu.JammyConfig.Routes(ubuntu.JammyDefaultTargetKey, spec)
-	})
-	registerRoutes(ubuntu.NobleDefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return ubuntu.NobleConfig.Routes(ubuntu.NobleDefaultTargetKey, spec)
-	})
+	if !includeAltTestingTargets {
+		return
+	}
 
-	registerRoutes(almalinux.V8TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return almalinux.ConfigV8.Routes(almalinux.V8TargetKey, spec)
-	})
-	registerRoutes(almalinux.V9TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return almalinux.ConfigV9.Routes(almalinux.V9TargetKey, spec)
-	})
-
-	registerRoutes(rockylinux.V8TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return rockylinux.ConfigV8.Routes(rockylinux.V8TargetKey, spec)
-	})
-	registerRoutes(rockylinux.V9TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return rockylinux.ConfigV9.Routes(rockylinux.V9TargetKey, spec)
-	})
-
-	registerRoutes(azlinux.AzLinux3TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return azlinux.Azlinux3Config.Routes(azlinux.AzLinux3TargetKey, spec)
-	})
-	registerRoutes(azlinux.AzLinux4TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return azlinux.Azlinux4Config.Routes(azlinux.AzLinux4TargetKey, spec)
-	})
-
-	registerRoutes(flatcar.TargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return flatcar.DefaultConfig.Routes(flatcar.TargetKey, spec)
-	})
-
-	registerRoutes(windows.DefaultTargetKey, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
-		return windows.Routes(windows.DefaultTargetKey, spec)
+	altName := targets.TestingAltTargetKey(name)
+	targets.RegisterRouteProvider(altName, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
+		return routes(altName, spec)
 	})
 }
 
-func registerRoutes(name string, routes func(ctx context.Context, spec *dalec.Spec) ([]frontend.Route, error)) {
-	targets.RegisterRouteProvider(name, routes)
+func registerDebRoutes(name string, cfg *debdistro.Config) {
+	targets.RegisterRouteProvider(name, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
+		return cfg.Routes(name, spec)
+	})
+
+	if !includeAltTestingTargets {
+		return
+	}
+
+	altName := targets.TestingAltTargetKey(name)
+	altCfg := *cfg
+	altCfg.VersionID += testingAltVersionIDSuffix
+
+	targets.RegisterRouteProvider(altName, func(_ context.Context, spec *dalec.Spec) ([]frontend.Route, error) {
+		return altCfg.Routes(altName, spec)
+	})
 }

--- a/targets/plugin/no_alt_testing_targets.go
+++ b/targets/plugin/no_alt_testing_targets.go
@@ -1,0 +1,5 @@
+//go:build !alt_testing_targets
+
+package plugin
+
+const includeAltTestingTargets = false

--- a/targets/testing.go
+++ b/targets/testing.go
@@ -1,0 +1,8 @@
+package targets
+
+const testingAltTargetSuffix = "-testing-alt"
+
+// TestingAltTargetKey returns the test-only alternate target key for key.
+func TestingAltTargetKey(key string) string {
+	return key + testingAltTargetSuffix
+}

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -130,18 +129,12 @@ func testArtifactBuildCacheDir(ctx context.Context, t *testing.T, cfg targetConf
 		solveT(ctx, t, client, sr)
 	}
 
-	// Used to validate that caches with namespaced dirs are not shared between distros and that
-	// caches with no namespace are shared between distros.
-	checkDistro := func(ctx context.Context, t *testing.T, client gwclient.Client) {
-		distro2 := "noble"
-		if distro == distro2 {
-			distro2 = "jammy"
-		}
-
-		t.Log("using distro", distro2)
-		target := path.Join(distro2, "deb")
-
-		// Note: cache3/hello3 should have the content written by the first test
+	// Used to validate that caches with namespaced dirs are not shared between targets and that
+	// caches with no namespace are shared between targets.
+	checkAltTarget := func(ctx context.Context, t *testing.T, client gwclient.Client) {
+		altDistro := targets.TestingAltTargetKey(distro)
+		target := altDistro + strings.TrimPrefix(cfg.Package, distro)
+		t.Log("using alternate target", target)
 		for i, c := range caches {
 			dir := getDir(t, c)
 
@@ -152,11 +145,11 @@ func testArtifactBuildCacheDir(ctx context.Context, t *testing.T, cfg targetConf
 
 			switch {
 			case c.Dir != nil:
-				// Use the *original* distro name here since that is what wrote the file
+				// Use the *original* target name here since that is what wrote the file.
 				check := fmt.Sprintf("%s %d", distro, i)
 				cmds = append(cmds, fmt.Sprintf("grep %q %s", check, filepath.Join(dir, "hello")))
 			case c.GoBuild != nil || c.RustSCCache != nil || c.Bazel != nil:
-				// This should not exist because the cache is not shared between distros
+				// This should not exist because the cache is not shared between targets.
 				cmds = append(cmds, fmt.Sprintf("[ ! -f %q ]", filepath.Join(dir, "hello")))
 			}
 		}
@@ -174,10 +167,10 @@ func testArtifactBuildCacheDir(ctx context.Context, t *testing.T, cfg targetConf
 		cmds = cmds[:0]
 		checkCacheContents(ctx, t, client)
 
-		// Now make sure the cache is not shared with another distro
-		// This makes sure that that the 1st and 2nd cache are not shared with another distro, but the 3rd one is.
+		// Now make sure the cache is not shared with another target.
+		// This makes sure that that the 1st and 2nd cache are not shared with another target, but the 3rd one is.
 		cmds = cmds[:0]
-		checkDistro(ctx, t, client)
+		checkAltTarget(ctx, t, client)
 	})
 }
 

--- a/test/testenv/build.go
+++ b/test/testenv/build.go
@@ -53,7 +53,9 @@ func buildBaseFrontend(ctx context.Context, c gwclient.Client) (*gwclient.Result
 
 	// If the test runner requested frontend coverage, build the frontend binary
 	// with coverage instrumentation (Dockerfile uses DALEC_FRONTEND_COVERAGE).
-	frontendOpt := map[string]string{}
+	frontendOpt := map[string]string{
+		"build-arg:EXTRA_BUILD_FLAGS": "-tags alt_testing_targets",
+	}
 	if os.Getenv("DALEC_FRONTEND_GOCOVERDIR") != "" {
 		frontendOpt["build-arg:DALEC_FRONTEND_COVERAGE"] = "1"
 	}


### PR DESCRIPTION
Add test-only alternate target registration behind the alt_testing_targets build tag, and update the cache dir test to use the current target's alternate key instead of building a different distro.

For DEB targets, copy the distro config and tweak VersionID so the alt target has a distinct cache namespace without requiring a separate distro worker stack. This preserves cache isolation coverage while keeping CI integration jobs scoped to their assigned distro.

Fixes #1034