### PR TITLE
Use native buildkit symlink file action for post-install symlinks

### DIFF
--- a/frontend/support.go
+++ b/frontend/support.go
@@ -1,0 +1,25 @@
+package frontend
+
+import (
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/project-dalec/dalec"
+)
+
+// NativeSymlinkSupport reports whether the given client's buildkit supports the
+// native LLB symlink file action.
+func NativeSymlinkSupport(client gwclient.Client) dalec.NativeSymlinkSupport {
+	return &nativeSymlinkSupport{client}
+}
+
+type nativeSymlinkSupport struct {
+	client gwclient.Client
+}
+
+func (c *nativeSymlinkSupport) SupportsNativeSymlinks() bool {
+	opts := c.client.BuildOpts()
+	if opts.Opts["build-arg:DALEC_DISABLE_SYMLINK"] == "1" {
+		return false
+	}
+	return opts.LLBCaps.Supports(pb.CapFileSymlinkCreate) == nil
+}

--- a/helpers.go
+++ b/helpers.go
@@ -304,11 +304,13 @@ func ShArgsf(format string, args ...interface{}) llb.RunOption {
 	return ShArgs(fmt.Sprintf(format, args...))
 }
 
-// InstallPostSymlinks returns a RunOption that adds symlinks defined in the [PostInstall] underneath the provided rootfs path.
-func InstallPostSymlinks(post *PostInstall, worker llb.State, opts ...llb.ConstraintsOpt) llb.StateOption {
-	return func(in llb.State) llb.State {
-		const rootfsPath = "/tmp/rootfs"
+type NativeSymlinkSupport interface {
+	SupportsNativeSymlinks() bool
+}
 
+// InstallPostSymlinks returns a RunOption that adds symlinks defined in the [PostInstall] underneath the provided rootfs path.
+func InstallPostSymlinks(post *PostInstall, worker llb.State, symlinkSupport NativeSymlinkSupport, opts ...llb.ConstraintsOpt) llb.StateOption {
+	return func(in llb.State) llb.State {
 		if post == nil {
 			return in
 		}
@@ -317,46 +319,136 @@ func InstallPostSymlinks(post *PostInstall, worker llb.State, opts ...llb.Constr
 			return in
 		}
 
-		buf := bytes.NewBuffer(nil)
-		buf.WriteString("set -ex\n")
-
-		sortedKeys := SortMapKeys(post.Symlinks)
-		var needsMount bool
-		for _, oldpath := range sortedKeys {
-			cfg := post.Symlinks[oldpath]
-			newpaths := cfg.Paths
-			sort.Strings(newpaths)
-
-			for _, newpath := range newpaths {
-				fmt.Fprintf(buf, "mkdir -p %q\n", filepath.Join(rootfsPath, filepath.Dir(newpath)))
-				fmt.Fprintf(buf, "ln -s %q %q\n", oldpath, filepath.Join(rootfsPath, newpath))
-				if cfg.User != "" {
-					needsMount = true
-					fmt.Fprintf(buf, "chown -h %s %q\n", cfg.User, filepath.Join(rootfsPath, newpath))
-				}
-				if cfg.Group != "" {
-					needsMount = true
-					fmt.Fprintf(buf, "chgrp -h %s %q\n", cfg.Group, filepath.Join(rootfsPath, newpath))
-				}
-			}
+		if symlinkSupport == nil || symlinkSupport.SupportsNativeSymlinks() {
+			return installPostSymlinksNative(post, in, opts...)
 		}
 
-		const name = "tmp.dalec.symlink.sh"
-		script := llb.Scratch().File(llb.Mkfile(name, 0o700, buf.Bytes()), opts...)
-
-		return worker.Run(
-			ShArgs("/tmp/add_symlink.sh"),
-			llb.AddMount("/tmp/add_symlink.sh", script, llb.SourcePath(name)),
-			RunOptFunc(func(ei *llb.ExecInfo) {
-				if needsMount {
-					llb.AddMount("/etc/group", in, llb.SourcePath("/etc/group")).SetRunOption(ei)
-					llb.AddMount("/etc/passwd", in, llb.SourcePath("/etc/passwd")).SetRunOption(ei)
-				}
-			}),
-			withConstraints(opts),
-			ProgressGroup("Add post-install symlinks"),
-		).AddMount(rootfsPath, in)
+		return installPostSymlinksExec(post, worker, in, opts...)
 	}
+}
+
+// installPostSymlinksNative creates the post-install symlinks using the native
+// [llb.Symlink] file action. It is used when the connected buildkit advertises
+// support for the symlink file action.
+func installPostSymlinksNative(post *PostInstall, in llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	var chain *llb.FileAction
+
+	appendMkdir := func(dir string) {
+		// The symlink file action does not create parent directories and will
+		// fail if they do not exist, so create them first (without changing
+		// ownership, matching the `mkdir -p` behavior of the exec fallback).
+		if dir == "/" || dir == "." || dir == "" {
+			return
+		}
+
+		mkdir := llb.Mkdir
+		if chain != nil {
+			mkdir = chain.Mkdir
+		}
+
+		chain = mkdir(dir, 0o755, llb.WithParents(true))
+	}
+
+	appendSymlink := func(oldpath, newpath string, symlinkOpts []llb.SymlinkOption) {
+		symlink := llb.Symlink
+		if chain != nil {
+			symlink = chain.Symlink
+		}
+
+		chain = symlink(oldpath, newpath, symlinkOpts...)
+	}
+
+	for _, oldpath := range SortMapKeys(post.Symlinks) {
+		cfg := post.Symlinks[oldpath]
+		newpaths := slices.Clone(cfg.Paths)
+		sort.Strings(newpaths)
+
+		var symlinkOpts []llb.SymlinkOption
+		if cfg.User != "" || cfg.Group != "" {
+			symlinkOpts = append(symlinkOpts, symlinkChown(cfg.User, cfg.Group))
+		}
+
+		for _, newpath := range newpaths {
+			appendMkdir(filepath.Dir(newpath))
+			appendSymlink(oldpath, newpath, symlinkOpts)
+		}
+	}
+
+	if chain == nil {
+		return in
+	}
+
+	return in.File(chain, withConstraints(opts), ProgressGroup("Add post-install symlinks"))
+}
+
+// symlinkChown builds an [llb.ChownOption] for a symlink that mirrors the
+// ownership behavior of the exec fallback (`chown -h` / `chgrp -h`).
+//
+// User and group names are resolved by buildkit against the file op's input
+// (the installed rootfs), which contains any users/groups created by the spec.
+//
+// Both the user and group are always set explicitly: chowning by user name alone
+// would also set the group to that user's primary group, whereas the exec
+// fallback leaves the unspecified side as root (id 0).
+func symlinkChown(userName, groupName string) llb.ChownOption {
+	user := llb.UserOpt{UID: 0}
+	if userName != "" {
+		user = llb.UserOpt{Name: userName}
+	}
+
+	group := llb.UserOpt{UID: 0}
+	if groupName != "" {
+		group = llb.UserOpt{Name: groupName}
+	}
+
+	return llb.ChownOpt{User: &user, Group: &group}
+}
+
+// installPostSymlinksExec creates the post-install symlinks by executing a shell
+// script in the worker. It is the fallback used when the connected buildkit does
+// not support the native symlink file action.
+func installPostSymlinksExec(post *PostInstall, worker, in llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	const rootfsPath = "/tmp/rootfs"
+
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString("set -ex\n")
+
+	sortedKeys := SortMapKeys(post.Symlinks)
+	var needsMount bool
+	for _, oldpath := range sortedKeys {
+		cfg := post.Symlinks[oldpath]
+		newpaths := slices.Clone(cfg.Paths)
+		sort.Strings(newpaths)
+
+		for _, newpath := range newpaths {
+			fmt.Fprintf(buf, "mkdir -p %q\n", filepath.Join(rootfsPath, filepath.Dir(newpath)))
+			fmt.Fprintf(buf, "ln -s %q %q\n", oldpath, filepath.Join(rootfsPath, newpath))
+			if cfg.User != "" {
+				needsMount = true
+				fmt.Fprintf(buf, "chown -h %s %q\n", cfg.User, filepath.Join(rootfsPath, newpath))
+			}
+			if cfg.Group != "" {
+				needsMount = true
+				fmt.Fprintf(buf, "chgrp -h %s %q\n", cfg.Group, filepath.Join(rootfsPath, newpath))
+			}
+		}
+	}
+
+	const name = "tmp.dalec.symlink.sh"
+	script := llb.Scratch().File(llb.Mkfile(name, 0o700, buf.Bytes()), opts...)
+
+	return worker.Run(
+		ShArgs("/tmp/add_symlink.sh"),
+		llb.AddMount("/tmp/add_symlink.sh", script, llb.SourcePath(name)),
+		RunOptFunc(func(ei *llb.ExecInfo) {
+			if needsMount {
+				llb.AddMount("/etc/group", in, llb.SourcePath("/etc/group")).SetRunOption(ei)
+				llb.AddMount("/etc/passwd", in, llb.SourcePath("/etc/passwd")).SetRunOption(ei)
+			}
+		}),
+		withConstraints(opts),
+		ProgressGroup("Add post-install symlinks"),
+	).AddMount(rootfsPath, in)
 }
 
 func (s *Spec) GetSigner(targetKey string) (*PackageSigner, bool) {

--- a/helpers_symlink_test.go
+++ b/helpers_symlink_test.go
@@ -1,0 +1,290 @@
+package dalec
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/project-dalec/dalec/internal/test"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestInstallPostSymlinksNative(t *testing.T) {
+	ctx := t.Context()
+
+	st := installPostSymlinksNative(testSymlinkPostInstall(), llb.Scratch())
+	ops := test.LLBOpsFromState(ctx, t, st)
+
+	assert.Check(t, !hasExecOp(ops), "native symlink path should not emit an exec op")
+
+	symlinks, mkdirs := collectSymlinkActions(ops)
+
+	// Every newpath should produce a symlink action pointing at the right oldpath.
+	assert.Check(t, cmp.Equal(len(symlinks), 5))
+	assertSymlinkTarget(t, symlinks, "/src1", "/usr/bin/src1")
+	assertSymlinkTarget(t, symlinks, "/non/existing/dir/src2", "/usr/bin/src2")
+	assertSymlinkTarget(t, symlinks, "/non/existing/dir/src3", "/usr/bin/src3")
+	assertSymlinkTarget(t, symlinks, "/non/existing/dir2/src3", "/usr/bin/src3")
+	assertSymlinkTarget(t, symlinks, "/plain", "/usr/bin/src4")
+
+	// Parent directories that don't already exist must be created, but the root
+	// directory should never be created.
+	assert.Check(t, cmp.Contains(mkdirs, "/non/existing/dir"))
+	assert.Check(t, cmp.Contains(mkdirs, "/non/existing/dir2"))
+	_, hasRoot := mkdirs["/"]
+	assert.Check(t, !hasRoot, "root directory should not be created")
+
+	// User only: uid by name, gid forced to root (0) to match the exec fallback.
+	assertOwnerByName(t, symlinks["/src1"].GetOwner().GetUser(), "need")
+	assertOwnerByID(t, symlinks["/src1"].GetOwner().GetGroup(), 0)
+
+	// Group only: uid forced to root (0), gid by name.
+	assertOwnerByID(t, symlinks["/non/existing/dir/src2"].GetOwner().GetUser(), 0)
+	assertOwnerByName(t, symlinks["/non/existing/dir/src2"].GetOwner().GetGroup(), "coffee")
+
+	// Both set: uid and gid both by name.
+	for _, p := range []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"} {
+		assertOwnerByName(t, symlinks[p].GetOwner().GetUser(), "need")
+		assertOwnerByName(t, symlinks[p].GetOwner().GetGroup(), "coffee")
+	}
+
+	// No ownership: no chown should be applied at all.
+	assert.Check(t, cmp.Nil(symlinks["/plain"].GetOwner()))
+}
+
+func TestInstallPostSymlinksExecFallback(t *testing.T) {
+	ctx := t.Context()
+	worker := llb.Image("busybox")
+
+	build := func() llb.State {
+		return installPostSymlinksExec(testSymlinkPostInstall(), worker, llb.Scratch())
+	}
+
+	t.Run("symlinks are created by a worker exec, not native file actions", func(t *testing.T) {
+		ops := test.LLBOpsFromState(ctx, t, build())
+
+		assert.Check(t, hasExecOp(ops), "exec fallback should emit an exec op")
+		symlinks, _ := collectSymlinkActions(ops)
+		assert.Check(t, cmp.Equal(len(symlinks), 0), "exec fallback should not emit native symlink actions")
+	})
+
+	t.Run("the generated script", func(t *testing.T) {
+		script := execScript(ctx, t, build())
+
+		t.Run("links every path to its source target", func(t *testing.T) {
+			assert.Check(t, cmp.Contains(script, `ln -s "/usr/bin/src1" "/tmp/rootfs/src1"`))
+			assert.Check(t, cmp.Contains(script, `ln -s "/usr/bin/src2" "/tmp/rootfs/non/existing/dir/src2"`))
+			assert.Check(t, cmp.Contains(script, `ln -s "/usr/bin/src3" "/tmp/rootfs/non/existing/dir/src3"`))
+			assert.Check(t, cmp.Contains(script, `ln -s "/usr/bin/src3" "/tmp/rootfs/non/existing/dir2/src3"`))
+			assert.Check(t, cmp.Contains(script, `ln -s "/usr/bin/src4" "/tmp/rootfs/plain"`))
+		})
+
+		t.Run("creates missing parent directories before linking", func(t *testing.T) {
+			assert.Check(t, cmp.Contains(script, `mkdir -p "/tmp/rootfs/non/existing/dir"`))
+			assert.Check(t, cmp.Contains(script, `mkdir -p "/tmp/rootfs/non/existing/dir2"`))
+		})
+
+		t.Run("chowns a link that sets only a user and leaves the group as root", func(t *testing.T) {
+			assert.Check(t, cmp.DeepEqual(ownershipCommandsFor(script, "/tmp/rootfs/src1"),
+				[]string{`chown -h need "/tmp/rootfs/src1"`}))
+		})
+
+		t.Run("chgrps a link that sets only a group and leaves the user as root", func(t *testing.T) {
+			assert.Check(t, cmp.DeepEqual(ownershipCommandsFor(script, "/tmp/rootfs/non/existing/dir/src2"),
+				[]string{`chgrp -h coffee "/tmp/rootfs/non/existing/dir/src2"`}))
+		})
+
+		t.Run("chowns and chgrps a link that sets both", func(t *testing.T) {
+			assert.Check(t, cmp.DeepEqual(ownershipCommandsFor(script, "/tmp/rootfs/non/existing/dir/src3"),
+				[]string{
+					`chown -h need "/tmp/rootfs/non/existing/dir/src3"`,
+					`chgrp -h coffee "/tmp/rootfs/non/existing/dir/src3"`,
+				}))
+			assert.Check(t, cmp.DeepEqual(ownershipCommandsFor(script, "/tmp/rootfs/non/existing/dir2/src3"),
+				[]string{
+					`chown -h need "/tmp/rootfs/non/existing/dir2/src3"`,
+					`chgrp -h coffee "/tmp/rootfs/non/existing/dir2/src3"`,
+				}))
+		})
+
+		t.Run("does not change ownership of a link that sets neither", func(t *testing.T) {
+			assert.Check(t, cmp.Len(ownershipCommandsFor(script, "/tmp/rootfs/plain"), 0))
+		})
+	})
+
+	t.Run("passwd and group", func(t *testing.T) {
+		t.Run("are mounted when a link configures ownership", func(t *testing.T) {
+			dests := execMountDests(ctx, t, build())
+			assert.Check(t, slices.Contains(dests, "/etc/passwd"), "expected /etc/passwd mount, got %v", dests)
+			assert.Check(t, slices.Contains(dests, "/etc/group"), "expected /etc/group mount, got %v", dests)
+		})
+
+		t.Run("are not mounted when no link configures ownership", func(t *testing.T) {
+			post := &PostInstall{
+				Symlinks: map[string]SymlinkTarget{
+					"/usr/bin/src4": {Paths: []string{"/plain"}},
+				},
+			}
+			dests := execMountDests(ctx, t, installPostSymlinksExec(post, worker, llb.Scratch()))
+			assert.Check(t, !slices.Contains(dests, "/etc/passwd"), "unexpected /etc/passwd mount in %v", dests)
+			assert.Check(t, !slices.Contains(dests, "/etc/group"), "unexpected /etc/group mount in %v", dests)
+		})
+	})
+}
+
+func TestInstallPostSymlinksDispatch(t *testing.T) {
+	ctx := t.Context()
+	worker := llb.Image("busybox")
+
+	assertNative := func(t *testing.T, checker NativeSymlinkSupport) {
+		t.Helper()
+		st := llb.Scratch().With(InstallPostSymlinks(testSymlinkPostInstall(), worker, checker))
+		ops := test.LLBOpsFromState(ctx, t, st)
+		assert.Check(t, !hasExecOp(ops), "expected native symlink actions, got an exec op")
+		symlinks, _ := collectSymlinkActions(ops)
+		assert.Check(t, cmp.Equal(len(symlinks), 5))
+	}
+
+	t.Run("uses the native file action when symlink support is available", func(t *testing.T) {
+		assertNative(t, fakeNativeSymlinkSupport(true))
+	})
+
+	t.Run("falls back to an exec when symlink support is unavailable", func(t *testing.T) {
+		st := llb.Scratch().With(InstallPostSymlinks(testSymlinkPostInstall(), worker, fakeNativeSymlinkSupport(false)))
+		ops := test.LLBOpsFromState(ctx, t, st)
+		assert.Check(t, hasExecOp(ops), "expected exec fallback, got native symlink actions")
+		symlinks, _ := collectSymlinkActions(ops)
+		assert.Check(t, cmp.Equal(len(symlinks), 0))
+	})
+
+	t.Run("defaults to the native file action when no checker is provided", func(t *testing.T) {
+		assertNative(t, nil)
+	})
+}
+
+func collectSymlinkActions(ops []test.LLBOp) (map[string]*pb.FileActionSymlink, map[string]struct{}) {
+	symlinks := map[string]*pb.FileActionSymlink{}
+	mkdirs := map[string]struct{}{}
+
+	for _, op := range ops {
+		fileOp := op.Op.GetFile()
+		if fileOp == nil {
+			continue
+		}
+		for _, action := range fileOp.GetActions() {
+			if sl := action.GetSymlink(); sl != nil {
+				symlinks[sl.GetNewpath()] = sl
+			}
+			if md := action.GetMkdir(); md != nil {
+				mkdirs[md.GetPath()] = struct{}{}
+			}
+		}
+	}
+	return symlinks, mkdirs
+}
+
+func hasExecOp(ops []test.LLBOp) bool {
+	for _, op := range ops {
+		if op.Op.GetExec() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+type fakeNativeSymlinkSupport bool
+
+func (f fakeNativeSymlinkSupport) SupportsNativeSymlinks() bool { return bool(f) }
+
+func execScript(ctx context.Context, t *testing.T, st llb.State) string {
+	t.Helper()
+
+	for _, op := range test.LLBOpsFromState(ctx, t, st) {
+		fileOp := op.Op.GetFile()
+		if fileOp == nil {
+			continue
+		}
+		for _, action := range fileOp.GetActions() {
+			if mf := action.GetMkfile(); mf != nil {
+				return string(mf.GetData())
+			}
+		}
+	}
+
+	t.Fatal("no script file was created by the exec fallback")
+	return ""
+}
+
+func execMountDests(ctx context.Context, t *testing.T, st llb.State) []string {
+	t.Helper()
+
+	for _, op := range test.LLBOpsFromState(ctx, t, st) {
+		exec := op.Op.GetExec()
+		if exec == nil {
+			continue
+		}
+		dests := make([]string, 0, len(exec.GetMounts()))
+		for _, m := range exec.GetMounts() {
+			dests = append(dests, m.GetDest())
+		}
+		return dests
+	}
+
+	t.Fatal("exec fallback did not emit an exec op")
+	return nil
+}
+
+// ownershipCommandsFor returns the chown/chgrp script lines that target the
+// given rootfs path, in the order they appear.
+func ownershipCommandsFor(script, rootfsPath string) []string {
+	suffix := `"` + rootfsPath + `"`
+
+	var cmds []string
+	for _, line := range strings.Split(script, "\n") {
+		if !strings.HasSuffix(line, suffix) {
+			continue
+		}
+		if strings.HasPrefix(line, "chown ") || strings.HasPrefix(line, "chgrp ") {
+			cmds = append(cmds, line)
+		}
+	}
+	return cmds
+}
+
+func testSymlinkPostInstall() *PostInstall {
+	return &PostInstall{
+		Symlinks: map[string]SymlinkTarget{
+			"/usr/bin/src1": {Paths: []string{"/src1"}, User: "need"},
+			"/usr/bin/src2": {Paths: []string{"/non/existing/dir/src2"}, Group: "coffee"},
+			"/usr/bin/src3": {Paths: []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"}, User: "need", Group: "coffee"},
+			"/usr/bin/src4": {Paths: []string{"/plain"}},
+		},
+	}
+}
+
+func assertSymlinkTarget(t *testing.T, symlinks map[string]*pb.FileActionSymlink, newpath, oldpath string) {
+	t.Helper()
+	sl, ok := symlinks[newpath]
+	assert.Assert(t, ok, "missing symlink for %q", newpath)
+	assert.Check(t, cmp.Equal(sl.GetOldpath(), oldpath))
+}
+
+func assertOwnerByName(t *testing.T, u *pb.UserOpt, name string) {
+	t.Helper()
+	assert.Assert(t, u != nil)
+	byName := u.GetByName()
+	assert.Assert(t, byName != nil, "expected user/group by name %q, got %v", name, u)
+	assert.Check(t, cmp.Equal(byName.GetName(), name))
+}
+
+func assertOwnerByID(t *testing.T, u *pb.UserOpt, id uint32) {
+	t.Helper()
+	assert.Assert(t, u != nil)
+	_, isName := u.GetUser().(*pb.UserOpt_ByName)
+	assert.Check(t, !isName, "expected user/group by id %d, got name", id)
+	assert.Check(t, cmp.Equal(u.GetByID(), id))
+}

--- a/internal/test/llb.go
+++ b/internal/test/llb.go
@@ -25,6 +25,7 @@ func LLBOpsFromState(ctx context.Context, t *testing.T, state llb.State) []LLBOp
 	var ops []LLBOp
 	for _, dt := range def.Def {
 		var op pb.Op
+		err := op.UnmarshalVT(dt)
 		assert.NilError(t, err, "error parsing op")
 		dgst := digest.FromBytes(dt)
 		ent := LLBOp{Digest: dgst, Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}

--- a/internal/test/llb.go
+++ b/internal/test/llb.go
@@ -4,29 +4,28 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
+	"testing"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
 )
 
 // LLBOpsFromState extracts the list of LLB operations from the provided LLB state.
 //
 // This function and LLBOp type has been inspired by
 // https://github.com/moby/buildkit/blob/c70e8e666f8f6ee3c0d83b20c338be5aedeaa97a/cmd/buildctl/debug/dumpllb.go#L59.
-func LLBOpsFromState(ctx context.Context, state llb.State) ([]LLBOp, error) {
+func LLBOpsFromState(ctx context.Context, t *testing.T, state llb.State) []LLBOp {
+	t.Helper()
+
 	def, err := state.Marshal(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling state: %w", err)
-	}
+	assert.NilError(t, err)
 
 	var ops []LLBOp
 	for _, dt := range def.Def {
 		var op pb.Op
-		if err := op.UnmarshalVT(dt); err != nil {
-			return nil, fmt.Errorf("parsing op: %w", err)
-		}
+		assert.NilError(t, err, "error parsing op")
 		dgst := digest.FromBytes(dt)
 		ent := LLBOp{Digest: dgst, Op: &op, OpMetadata: def.Metadata[dgst].ToPB()}
 
@@ -37,7 +36,7 @@ func LLBOpsFromState(ctx context.Context, state llb.State) ([]LLBOp, error) {
 		ops = ops[:len(ops)-1] // Last operation is a final export, it has no operations.
 	}
 
-	return ops, nil
+	return ops
 }
 
 // LLBOpsToJSON converts a list of LLB operations to a JSON string.

--- a/load.go
+++ b/load.go
@@ -39,6 +39,8 @@ func knownArg(key string) bool {
 		return true
 	case "DALEC_DISABLE_PASSTHROUGH":
 		return true
+	case "DALEC_DISABLE_SYMLINK":
+		return true
 	case "DALEC_SKIP_SIGNING":
 		return true
 	case "DALEC_SIGNING_CONFIG_CONTEXT_NAME":

--- a/targets/linux/deb/distro/container.go
+++ b/targets/linux/deb/distro/container.go
@@ -143,7 +143,7 @@ func installPackagesInContainer(input buildContainerInput, ro []llb.RunOption) l
 				frontend.IgnoreCache(input.Client, targets.IgnoreCacheKeyContainer),
 			)...,
 		).Root().
-			With(dalec.InstallPostSymlinks(input.Spec.GetImagePost(input.Target), input.Worker, opts...))
+			With(dalec.InstallPostSymlinks(input.Spec.GetImagePost(input.Target), input.Worker, frontend.NativeSymlinkSupport(input.Client), opts...))
 	}
 }
 

--- a/targets/linux/deb/distro/container_test.go
+++ b/targets/linux/deb/distro/container_test.go
@@ -58,10 +58,7 @@ func Test_Building_container(t *testing.T) {
 
 		state := c.BuildContainer(ctx, client, sopt, spec, "target", llb.State{})
 
-		ops, err := test.LLBOpsFromState(ctx, state)
-		if err != nil {
-			t.Fatalf("failed to get llb ops from state: %v", err)
-		}
+		ops := test.LLBOpsFromState(ctx, t, state)
 
 		specPackageImageSourceFound := false
 
@@ -112,10 +109,7 @@ func Test_Building_container(t *testing.T) {
 
 		state := c.BuildContainer(ctx, client, sopt, spec, "target", llb.State{})
 
-		ops, err := test.LLBOpsFromState(ctx, state)
-		if err != nil {
-			t.Fatalf("failed to get llb ops from state: %v", err)
-		}
+		ops := test.LLBOpsFromState(ctx, t, state)
 
 		if len(ops) == 0 {
 			t.Fatalf("expected at least one llb op, got none")
@@ -152,10 +146,7 @@ func Test_Building_container(t *testing.T) {
 				},
 			}
 
-			ops, err := test.LLBOpsFromState(ctx, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
 
 			for _, op := range ops {
 				if op.OpMetadata.ProgressGroup != nil && op.OpMetadata.ProgressGroup.Name == "Bootstrap Base Image" {
@@ -212,10 +203,7 @@ func Test_Building_container(t *testing.T) {
 					},
 				}
 
-				ops, err := test.LLBOpsFromState(ctx, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
-				if err != nil {
-					t.Fatalf("failed to get llb ops from state: %v", err)
-				}
+				ops := test.LLBOpsFromState(ctx, t, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
 
 				expectedMountPath := "/etc/apt/sources.list.d/" + extraInstallRepo + ".list"
 
@@ -268,10 +256,7 @@ func Test_Building_container(t *testing.T) {
 					},
 				}
 
-				ops, err := test.LLBOpsFromState(ctx, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
-				if err != nil {
-					t.Fatalf("failed to get llb ops from state: %v", err)
-				}
+				ops := test.LLBOpsFromState(ctx, t, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch()))
 
 				for _, op := range ops {
 					e := op.Op.GetExec()
@@ -360,10 +345,7 @@ func Test_Building_container(t *testing.T) {
 					return nil, nil
 				},
 			}
-			ops, err := test.LLBOpsFromState(ctx, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.State{}))
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.State{}))
 
 			found := false
 			for _, op := range ops {
@@ -417,10 +399,7 @@ func Test_Building_container(t *testing.T) {
 
 			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
 
-			ops, err := test.LLBOpsFromState(ctx, state)
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, state)
 
 			aptCacheFound := false
 
@@ -482,10 +461,7 @@ func Test_Building_container(t *testing.T) {
 
 			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
 
-			ops, err := test.LLBOpsFromState(ctx, state)
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, state)
 
 			for _, op := range ops {
 				e := op.Op.GetExec()
@@ -544,10 +520,7 @@ func Test_Building_container(t *testing.T) {
 
 			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", pkg, dalec.ProgressGroup("foo"))
 
-			ops, err := test.LLBOpsFromState(ctx, state)
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, state)
 
 			basePkgFound := false
 			pkgFound := false
@@ -612,10 +585,7 @@ func Test_Building_container(t *testing.T) {
 
 			state := c.BuildContainer(ctx, &testClient{}, sopt, &dalec.Spec{}, "target", llb.Scratch(), dalec.ProgressGroup("foo"))
 
-			ops, err := test.LLBOpsFromState(ctx, state)
-			if err != nil {
-				t.Fatalf("failed to get llb ops from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, state)
 
 			aptCacheFound := false
 

--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -74,7 +74,7 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, s
 	).AddMount(workPath, rootfs)
 
 	if post := spec.GetImagePost(targetKey); post != nil && len(post.Symlinks) > 0 {
-		rootfs = rootfs.With(dalec.InstallPostSymlinks(post, worker, opts...))
+		rootfs = rootfs.With(dalec.InstallPostSymlinks(post, worker, frontend.NativeSymlinkSupport(client), opts...))
 	}
 
 	return rootfs

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -312,10 +312,7 @@ func verifyConstraintsPropagation(ctx context.Context, t *testing.T, req gwclien
 			Ref: ref,
 		}
 
-		ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
-		if err != nil {
-			t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
-		}
+		ops := test.LLBOpsFromState(ctx, t, resultToState(t, res))
 
 		allOps = append(allOps, ops...)
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -5954,90 +5954,126 @@ func testContainerTarget(ctx context.Context, t *testing.T, testConfig testLinux
 	t.Run("creates_post_install_symlinks", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := startTestSpan(ctx, t)
-
-		spec := testLinuxSpec(t, dalec.Spec{
-			Sources: map[string]dalec.Source{
-				"src1": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o700,
+		// newSpec returns a fresh spec per run so that each mode gets its own
+		// copy. This avoids a data race and prevents the Path->Paths
+		// normalization from mutating a spec shared between subtests.
+		newSpec := func() *dalec.Spec {
+			spec := testLinuxSpec(t, dalec.Spec{
+				Sources: map[string]dalec.Source{
+					"src1": {
+						Inline: &dalec.SourceInline{
+							File: &dalec.SourceInlineFile{
+								Contents:    "#!/usr/bin/env bash\necho hello world",
+								Permissions: 0o700,
+							},
+						},
+					},
+					"src3": {
+						Inline: &dalec.SourceInline{
+							File: &dalec.SourceInlineFile{
+								Contents:    "#!/usr/bin/env bash\necho goodbye",
+								Permissions: 0o700,
+							},
 						},
 					},
 				},
-				"src3": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho goodbye",
-							Permissions: 0o700,
+				Artifacts: dalec.Artifacts{
+					Binaries: map[string]dalec.ArtifactConfig{
+						"src1": {},
+						"src3": {},
+					},
+					Users: []dalec.AddUserConfig{
+						{
+							Name: "need",
+						},
+					},
+					Groups: []dalec.AddGroupConfig{
+						{
+							Name: "coffee",
 						},
 					},
 				},
-			},
-			Artifacts: dalec.Artifacts{
-				Binaries: map[string]dalec.ArtifactConfig{
-					"src1": {},
-					"src3": {},
+				Image: &dalec.ImageConfig{
+					Post: &dalec.PostInstall{
+						Symlinks: map[string]dalec.SymlinkTarget{
+							// User-only ownership: the group must stay root (gid 0).
+							// Uses the singular Path field to exercise its normalization.
+							"/usr/bin/src1": {
+								Path: "/src1",
+								User: "need",
+							},
+							// Group-only ownership: the user must stay root (uid 0).
+							// The link lands in a directory that does not exist yet,
+							// exercising parent-directory creation. The target is not
+							// installed, so this is a dangling symlink.
+							"/usr/bin/src2": {
+								Paths: []string{"/non/existing/dir/src2"},
+								Group: "coffee",
+							},
+							// User+group ownership across multiple paths, both of
+							// which also land in non-existing directories.
+							"/usr/bin/src3": {
+								Paths: []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"},
+								User:  "need",
+								Group: "coffee",
+							},
+						},
+					},
 				},
-				Users: []dalec.AddUserConfig{
+				Tests: []*dalec.TestSpec{
 					{
-						Name: "need",
-					},
-				},
-				Groups: []dalec.AddGroupConfig{
-					{
-						Name: "coffee",
-					},
-				},
-			},
-			Image: &dalec.ImageConfig{
-				Post: &dalec.PostInstall{
-					Symlinks: map[string]dalec.SymlinkTarget{
-						"/usr/bin/src1": {
-							Path: "/src1",
-							User: "need",
+						Name: "Post-install symlinks should be created and have correct ownership",
+						Files: map[string]dalec.FileCheckOutput{
+							"/src1":                  {},
+							"/non/existing/dir/src3": {},
 						},
-						"/usr/bin/src3": {
-							Paths: []string{"/non/existing/dir/src3", "/non/existing/dir2/src3"},
-							User:  "need",
-							Group: "coffee",
-						},
-					},
-				},
-			},
-			Tests: []*dalec.TestSpec{
-				{
-					Name: "Post-install symlinks should be created and have correct ownership",
-					Files: map[string]dalec.FileCheckOutput{
-						"/src1":                  {},
-						"/non/existing/dir/src3": {},
-					},
-					Steps: []dalec.TestStep{
-						{Command: "/usr/bin/env bash -exc 'test -L /src1'"},
-						{Command: "/usr/bin/env bash -exc 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
-						{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /src1); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-						{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+						Steps: []dalec.TestStep{
+							{Command: "/usr/bin/env bash -exc 'test -L /src1'"},
+							{Command: "/usr/bin/env bash -exc 'test \"$(readlink /src1)\" = \"/usr/bin/src1\"'"},
+							{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=0; LINK_OWNER=$(stat -c \"%u:%g\" /src1); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+							{Command: "/src1", Stdout: dalec.CheckOutput{Equals: "hello world\n"}, Stderr: dalec.CheckOutput{Empty: true}},
 
-						{Command: "/usr/bin/env bash -exc 'test -L /non/existing/dir/src3'"},
-						{Command: "/usr/bin/env bash -exc 'test \"$(readlink /non/existing/dir/src3)\" = \"/usr/bin/src3\"'"},
-						{Command: "/usr/bin/env bash -exc 'test -L /non/existing/dir2/src3'"},
-						{Command: "/usr/bin/env bash -exc 'test \"$(readlink /non/existing/dir2/src3)\" = \"/usr/bin/src3\"'"},
-						{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=$(grep ^coffee /etc/group | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-						{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=$(grep ^coffee /etc/group | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir2/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
-						{Command: "/non/existing/dir/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
-						{Command: "/non/existing/dir2/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+							{Command: "/usr/bin/env bash -exc 'test -L /non/existing/dir/src2'"},
+							{Command: "/usr/bin/env bash -exc 'test \"$(readlink /non/existing/dir/src2)\" = \"/usr/bin/src2\"'"},
+							{Command: "/usr/bin/env bash -exc 'NEED_UID=0; COFFEE_GID=$(grep ^coffee /etc/group | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src2); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+
+							{Command: "/usr/bin/env bash -exc 'test -L /non/existing/dir/src3'"},
+							{Command: "/usr/bin/env bash -exc 'test \"$(readlink /non/existing/dir/src3)\" = \"/usr/bin/src3\"'"},
+							{Command: "/usr/bin/env bash -exc 'test -L /non/existing/dir2/src3'"},
+							{Command: "/usr/bin/env bash -exc 'test \"$(readlink /non/existing/dir2/src3)\" = \"/usr/bin/src3\"'"},
+							{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=$(grep ^coffee /etc/group | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+							{Command: "/usr/bin/env bash -exc 'NEED_UID=$(grep ^need /etc/passwd | cut -d: -f3); COFFEE_GID=$(grep ^coffee /etc/group | cut -d: -f3); LINK_OWNER=$(stat -c \"%u:%g\" /non/existing/dir2/src3); [ \"$LINK_OWNER\" = \"$NEED_UID:$COFFEE_GID\" ]'"},
+							{Command: "/non/existing/dir/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+							{Command: "/non/existing/dir2/src3", Stdout: dalec.CheckOutput{Equals: "goodbye\n"}, Stderr: dalec.CheckOutput{Empty: true}},
+						},
 					},
 				},
-			},
+			})
+			return &spec
+		}
+
+		run := func(t *testing.T, extraOpts ...srOpt) {
+			ctx := startTestSpan(ctx, t)
+			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+				opts := append([]srOpt{
+					withSpec(ctx, t, newSpec()),
+					withBuildTarget(target),
+				}, extraOpts...)
+				sr := newSolveRequest(opts...)
+				solveT(ctx, t, gwc, sr)
+			})
+		}
+
+		// Default path: native buildkit symlink file action (when supported).
+		t.Run("native_symlink_file_action", func(t *testing.T) {
+			t.Parallel()
+			run(t)
 		})
 
-		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
-			sr := newSolveRequest(
-				withSpec(ctx, t, &spec),
-				withBuildTarget(target),
-			)
-			solveT(ctx, t, gwc, sr)
+		// Fallback path: force the legacy shell-exec implementation.
+		t.Run("exec_fallback", func(t *testing.T) {
+			t.Parallel()
+			run(t, withBuildArg("DALEC_DISABLE_SYMLINK", "1"))
 		})
 	})
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -6153,10 +6153,7 @@ func testContainerTarget(ctx context.Context, t *testing.T, testConfig testLinux
 
 			res := solveT(ctx, t, gwc, sr)
 
-			ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
-			if err != nil {
-				t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, resultToState(t, res))
 
 			cacheIgnored := 0
 			execFound := false
@@ -6224,10 +6221,7 @@ func testContainerTarget(ctx context.Context, t *testing.T, testConfig testLinux
 
 			res := solveT(ctx, t, gwc, sr)
 
-			ops, err := test.LLBOpsFromState(ctx, resultToState(t, res))
-			if err != nil {
-				t.Fatalf("Unexpected error extracting LLB OPs from state: %v", err)
-			}
+			ops := test.LLBOpsFromState(ctx, t, resultToState(t, res))
 
 			badOps := []test.LLBOp{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Post-install symlinks (`image.post.symlinks`) were created by executing a shell
script (`ln -s`, `chown -h`, `chgrp -h`) in the worker, mounting `/etc/passwd`
and `/etc/group` to resolve ownership by name. Buildkit now provides a native
symlink file action, so this switches to it when it is available.

Support is detected via the `pb.CapFileSymlinkCreate` LLB capability, mirroring
the existing diff/merge capability detection. When the connected buildkit does
not advertise the capability — or `DALEC_DISABLE_SYMLINK=1` is set — Dalec falls
back to the original shell-exec implementation, so older buildkit versions keep
working.

The native path chains `llb.Mkdir` (for parent directories, which the symlink
action does not create itself) and `llb.Symlink` into a single file op resolved
against the installed rootfs. This avoids the extra `exec` and the `/etc/passwd`
/ `/etc/group` mounts.

Ownership semantics are preserved exactly. Chowning by user name alone would
also set the group to that user's primary group, whereas the exec fallback
leaves the unspecified side as root. To match, both user and group are always
set explicitly and an unspecified side stays `0`, mirroring `chown -h user` /
`chgrp -h group`.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- Capability detection lives in `frontend/gateway.go` (`SupportsSymlink`) and is
  wired in `frontend/router.go`, just like `DisableDiffMerge`.
- `DALEC_DISABLE_SYMLINK` is registered as a known build-arg in `load.go` and can
  be used to force the legacy behavior.
- Unit tests in `helpers_symlink_test.go` assert the marshaled LLB for both the
  native and exec paths (symlink actions, parent mkdirs, and ownership).
- The integration test `testLinuxPostInstallSymlinks` runs the post-install
  symlink scenario under **both** paths via subtests — native by default and the
  exec fallback with `DALEC_DISABLE_SYMLINK=1`. The equivalent block was removed
  from the large combined container test to avoid duplicating the coverage.
