### PR TITLE
release: grant artifact-metadata permission to reusable workflow caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
       packages: write
       id-token: write  # Required for cosign OIDC signing
       attestations: write  # Required for GitHub attestations
+      artifact-metadata: write  # Must match frontend-image.yml; a called reusable workflow's permissions cannot exceed the caller's
 
     needs: tagList
     uses: ./.github/workflows/frontend-image.yml


### PR DESCRIPTION
## Problem

The Release workflow is failing at startup (`startup_failure`), e.g. https://github.com/project-dalec/dalec/actions/runs/27838646283 — a workflow-file validation error before any job runs.

## Root cause

The `build` job in `release.yml` invokes `frontend-image.yml` as a **reusable workflow**. `frontend-image.yml` requests `artifact-metadata: write` (re-added in the "Restore code reverted by bad rebase" commit; it had been dropped by a bad rebase, which is why releases after that briefly worked).

A called reusable workflow's permissions must be a **subset** of the permissions granted by the caller job. The `build` job did not grant `artifact-metadata: write`, so the called workflow requested more than it was allowed and the run was rejected at startup.

This is why `worker-images.yml` — which has the same permission but runs directly rather than via `workflow_call` — kept working: it has no caller cap.

## Fix

Grant `artifact-metadata: write` on the `build` job so the caller's permissions cover what `frontend-image.yml` requests. `frontend-image.yml` is the only reusable workflow and `release.yml` is its only caller, so no other changes are needed.