### PR TITLE
Make package-manager cache sharing mode configurable

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
@@ -19,7 +20,49 @@ const (
 
 	BazelDefaultSocketID = "bazel-default" // Default ID for bazel socket
 
+	// BuildArgDalecPackageCacheSharing is the build-arg used to select the
+	// BuildKit cache mount sharing mode for package-manager caches (apt/dnf/tdnf).
+	// Valid values are "shared", "locked", and "private". When unset the default
+	// is "locked".
+	BuildArgDalecPackageCacheSharing = "DALEC_PACKAGE_CACHE_SHARING"
 )
+
+// packageCacheSharing holds the sharing mode used for package-manager cache
+// mounts. It defaults to llb.CacheMountLocked, which is the best choice for a
+// single warm build. Tests set it to "private" to avoid serializing concurrent
+// builds that share a cache key.
+var packageCacheSharing atomic.Int32
+
+func init() {
+	packageCacheSharing.Store(int32(llb.CacheMountLocked))
+}
+
+// SetPackageCacheSharing sets the sharing mode used for package-manager cache
+// mounts (apt/dnf/tdnf). The default is llb.CacheMountLocked.
+func SetPackageCacheSharing(mode llb.CacheMountSharingMode) {
+	packageCacheSharing.Store(int32(mode))
+}
+
+// PackageCacheSharingMode returns the configured sharing mode for
+// package-manager cache mounts.
+func PackageCacheSharingMode() llb.CacheMountSharingMode {
+	return llb.CacheMountSharingMode(packageCacheSharing.Load())
+}
+
+// ParseCacheSharingMode maps a string ("shared", "locked", or "private") to the
+// corresponding llb.CacheMountSharingMode.
+func ParseCacheSharingMode(s string) (llb.CacheMountSharingMode, error) {
+	switch s {
+	case cacheMountShared:
+		return llb.CacheMountShared, nil
+	case cacheMountLocked:
+		return llb.CacheMountLocked, nil
+	case cacheMountPrivate:
+		return llb.CacheMountPrivate, nil
+	default:
+		return 0, fmt.Errorf("invalid cache sharing mode %q: must be one of %q, %q, %q", s, cacheMountShared, cacheMountLocked, cacheMountPrivate)
+	}
+}
 
 // getSccacheSource returns a Source for downloading and verifying sccache using SourceHTTP
 func getSccacheSource(p *ocispecs.Platform) Source {

--- a/frontend/router.go
+++ b/frontend/router.go
@@ -100,6 +100,14 @@ func (r *Router) Handler(opts ...func(context.Context, gwclient.Client, *Router)
 			dalec.DisableDiffMerge(true)
 		}
 
+		if v, ok := GetBuildArg(client, dalec.BuildArgDalecPackageCacheSharing); ok {
+			mode, err := dalec.ParseCacheSharingMode(v)
+			if err != nil {
+				return nil, err
+			}
+			dalec.SetPackageCacheSharing(mode)
+		}
+
 		for _, opt := range opts {
 			if err := opt(ctx, client, r); err != nil {
 				return nil, err

--- a/helpers.go
+++ b/helpers.go
@@ -82,13 +82,13 @@ func WithMountedAptCache(namePrefix string, opts ...llb.ConstraintsOpt) llb.RunO
 		llb.AddMount(
 			"/var/cache/apt",
 			llb.Scratch(),
-			llb.AsPersistentCacheDir(namePrefix+"dalec-var-cache-apt", llb.CacheMountLocked),
+			llb.AsPersistentCacheDir(namePrefix+"dalec-var-cache-apt", PackageCacheSharingMode()),
 		).SetRunOption(ei)
 
 		llb.AddMount(
 			"/var/lib/apt",
 			llb.Scratch(),
-			llb.AsPersistentCacheDir(namePrefix+"dalec-var-lib-apt", llb.CacheMountLocked),
+			llb.AsPersistentCacheDir(namePrefix+"dalec-var-lib-apt", PackageCacheSharingMode()),
 		).SetRunOption(ei)
 	})
 }

--- a/load.go
+++ b/load.go
@@ -49,6 +49,8 @@ func knownArg(key string) bool {
 		return true
 	case "DALEC_SOURCE_FILTER_CONFIG_CONTEXT_NAME":
 		return true
+	case BuildArgDalecPackageCacheSharing:
+		return true
 	case KeyDalecTarget:
 		return true
 	}

--- a/targets/linux/rpm/distro/distro.go
+++ b/targets/linux/rpm/distro/distro.go
@@ -75,7 +75,7 @@ func (cfg *Config) PackageCacheMount(root string) llb.RunOption {
 			llb.AddMount(
 				joinUnderRoot(root, d),
 				llb.Scratch(),
-				llb.AsPersistentCacheDir(k, llb.CacheMountLocked),
+				llb.AsPersistentCacheDir(k, dalec.PackageCacheSharingMode()),
 			).SetRunOption(ei)
 		}
 

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -243,7 +243,7 @@ func (cfg *Config) InstallIntoRoot(rootfsPath string, pkgs []string, targetArch 
 				llb.AddMount(
 					joinUnderRoot(rootfsPath, d),
 					llb.Scratch(),
-					llb.AsPersistentCacheDir(k, llb.CacheMountLocked),
+					llb.AsPersistentCacheDir(k, dalec.PackageCacheSharingMode()),
 				),
 			)
 		}

--- a/test/testenv/build.go
+++ b/test/testenv/build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/pkg/errors"
+	"github.com/project-dalec/dalec"
 	"github.com/tonistiigi/fsutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -143,6 +144,14 @@ func withDalecInput(ctx context.Context, gwc gwclient.Client, opts *gwclient.Sol
 
 	opts.FrontendOpt["source"] = id
 	opts.Frontend = "gateway.v0"
+
+	// Default the package-manager cache sharing mode to "private" for test builds
+	// so the parallel test matrix does not serialize on locked caches. Tests that
+	// set this build-arg explicitly keep their value.
+	cacheSharingKey := "build-arg:" + dalec.BuildArgDalecPackageCacheSharing
+	if _, ok := opts.FrontendOpt[cacheSharingKey]; !ok {
+		opts.FrontendOpt[cacheSharingKey] = "private"
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What

Adds a `DALEC_PACKAGE_CACHE_SHARING` build-arg (`shared` | `locked` | `private`) that selects the BuildKit cache mount sharing mode used for package-manager caches (apt / dnf / tdnf). Default stays `locked`, so single-build behavior is unchanged.

## Why

Package-manager cache mounts were hardcoded to `llb.CacheMountLocked`. `locked` makes BuildKit serialize concurrent builds that share a cache key (`getRefCacheDirNoCache(block=true)` loops/waits while the ref is in use). The integration test suite runs a large parallel matrix (~6-8 distros x ~20 sub-tests, all `t.Parallel`), and every concurrent build for a given distro+arch shares one cache key — so package installs fully serialize and slow the suite.

`private` (`getRefCacheDirNoCache(block=false)`) reuses a free unlocked ref if one exists, otherwise creates a new ref without blocking. Concurrent builds each get an isolated cache ref (no corruption) and never wait (no serialization). Retained refs keep warm caches across runs. `shared` is unsafe here (one global ref mounted into all concurrent builds → concurrent apt/dnf writers risk corruption).

## Changes

- `cache.go`: `BuildArgDalecPackageCacheSharing` const; process-global sharing mode (`atomic.Int32`, defaults to `locked`); `SetPackageCacheSharing` / `PackageCacheSharingMode` / `ParseCacheSharingMode`.
- `load.go`: register the build-arg in `knownArg` so spec arg substitution accepts it.
- Three call sites now consult `PackageCacheSharingMode()` instead of hardcoded `llb.CacheMountLocked`: `helpers.go` `WithMountedAptCache`, `targets/linux/rpm/distro/distro.go` `PackageCacheMount`, `targets/linux/rpm/distro/dnf_install.go` `InstallIntoRoot`.
- `frontend/router.go` `Handler`: parse the build-arg once per request and set the global (mirrors existing `DisableDiffMerge` wiring).
- `test/testenv/build.go` `withDalecInput`: default the build-arg to `private` for test builds at the single dalec-frontend choke point (tests that set it explicitly keep their value).

Process-global state follows the existing `disableDiffMerge atomic.Bool` precedent.

## Trade-off

Under high concurrency, `private` grows disk usage to roughly peak-concurrency copies per cache key. Acceptable for tests; production default remains `locked`.

## Draft intent

Opened as draft to compare test-suite runtime with `private` cache sharing vs the current `locked` serialization.