### PR TITLE
Make generated LLB deterministic by sorting map iteration

### DIFF
--- a/determinism_test.go
+++ b/determinism_test.go
@@ -1,0 +1,232 @@
+package dalec
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"gotest.tools/v3/assert"
+)
+
+// determinismRuns is how many times a generator is re-run when checking that
+// its output does not depend on Go's randomized map iteration order. A single
+// extra run (i.e. 2 total) only catches a regression ~50% of the time for a
+// two-key map, so we marshal many times: marshaling is cheap and each
+// additional run drives the false-pass probability toward zero.
+const determinismRuns = 25
+
+// requireDeterministicLLB rebuilds the state from scratch on every run (so the
+// previously-unsorted map iteration executes again) and asserts the marshaled
+// op definitions are byte-identical. Only Def is compared: it holds the op
+// protos whose digests drive BuildKit's cache. Metadata is intentionally
+// ignored because it carries per-build noise such as progress-group IDs.
+func requireDeterministicLLB(ctx context.Context, t *testing.T, build func() llb.State) {
+	t.Helper()
+
+	want, err := build().Marshal(ctx)
+	assert.NilError(t, err)
+
+	for i := 1; i < determinismRuns; i++ {
+		got, err := build().Marshal(ctx)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got.Def, want.Def)
+	}
+}
+
+// manyEnv returns an env map with enough entries that a single unsorted
+// iteration is overwhelmingly likely to differ between runs. The prefix keeps
+// the keys of two maps from overlapping when both are used in one state.
+func manyEnv(prefix string) map[string]string {
+	env := make(map[string]string, 12)
+	for i := 0; i < 12; i++ {
+		env[fmt.Sprintf("%s_VAR_%02d", prefix, i)] = fmt.Sprintf("value-%d", i)
+	}
+	return env
+}
+
+func TestImageCommandEnvProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sOpt := SourceOpts{
+		GetContext: func(name string, opts ...llb.LocalOption) (*llb.State, error) {
+			st := llb.Local(name, opts...)
+			return &st, nil
+		},
+	}
+
+	buildFrom := func(cmd *Command) func() llb.State {
+		return func() llb.State {
+			src := Source{DockerImage: &SourceDockerImage{Ref: "localhost:0/does/not/exist:latest", Cmd: cmd}}
+			src.fillDefaults()
+			name := ""
+			if !src.IsDir() {
+				name = "test"
+			}
+			return src.ToState(name, sOpt)
+		}
+	}
+
+	t.Run("command env ordering is stable", func(t *testing.T) {
+		cmd := &Command{
+			Dir:   "/work",
+			Env:   manyEnv("CMD"),
+			Steps: []*BuildStep{{Command: "true"}},
+		}
+		requireDeterministicLLB(ctx, t, buildFrom(cmd))
+	})
+
+	t.Run("step env ordering is stable", func(t *testing.T) {
+		cmd := &Command{
+			Steps: []*BuildStep{{Command: "true", Env: manyEnv("STEP")}},
+		}
+		requireDeterministicLLB(ctx, t, buildFrom(cmd))
+	})
+
+	t.Run("command and step env with different keys stay stable", func(t *testing.T) {
+		cmd := &Command{
+			Dir:   "/work",
+			Env:   manyEnv("CMD"),
+			Steps: []*BuildStep{{Command: "true", Env: manyEnv("STEP")}},
+		}
+		requireDeterministicLLB(ctx, t, buildFrom(cmd))
+	})
+}
+
+// TestGetRepoKeysIsDeterministic covers GetRepoKeys, which collects GPG keys
+// from an unordered map. The returned names feed downstream import-key command
+// arguments and the generated key mounts feed an exec, so GetRepoKeys sorts its
+// iteration to keep both stable rather than relying on normalization in lower
+// layers.
+func TestGetRepoKeysIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := &RepoPlatformConfig{GPGKeyRoot: "/etc/apt/keyrings"}
+	sOpt := SourceOpts{
+		GetContext: func(name string, opts ...llb.LocalOption) (*llb.State, error) {
+			st := llb.Local(name, opts...)
+			return &st, nil
+		},
+	}
+
+	newConfigs := func() []PackageRepositoryConfig {
+		keys := make(map[string]Source, 12)
+		for i := 0; i < 12; i++ {
+			keys[fmt.Sprintf("key-%02d.gpg", i)] = Source{
+				Inline: &SourceInline{
+					File: &SourceInlineFile{Contents: fmt.Sprintf("key-material-%d", i)},
+				},
+			}
+		}
+		return []PackageRepositoryConfig{{Keys: keys}}
+	}
+
+	want := make([]string, 0, 12)
+	for i := 0; i < 12; i++ {
+		want = append(want, fmt.Sprintf("key-%02d.gpg", i))
+	}
+
+	t.Run("names come back in sorted order", func(t *testing.T) {
+		_, names := GetRepoKeys(newConfigs(), cfg, sOpt)
+		assert.DeepEqual(t, names, want)
+	})
+
+	t.Run("names are stable across runs", func(t *testing.T) {
+		for i := 0; i < determinismRuns; i++ {
+			_, names := GetRepoKeys(newConfigs(), cfg, sOpt)
+			assert.DeepEqual(t, names, want)
+		}
+	})
+
+	t.Run("generated key mounts are stable across runs", func(t *testing.T) {
+		build := func() llb.State {
+			runOpt, _ := GetRepoKeys(newConfigs(), cfg, sOpt)
+			return llb.Scratch().Run(llb.Args([]string{"true"}), runOpt).Root()
+		}
+		requireDeterministicLLB(ctx, t, build)
+	})
+}
+
+func TestGomodAuthProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sOpt := SourceOpts{
+		GetContext: func(name string, opts ...llb.LocalOption) (*llb.State, error) {
+			st := llb.Local(name, opts...)
+			return &st, nil
+		},
+		GitCredHelperOpt: func() (llb.RunOption, error) {
+			st := llb.Scratch().File(llb.Mkfile("/frontend", 0o755, []byte("#!/usr/bin/env bash\nexit 0\n")))
+			return RunOptFunc(func(ei *llb.ExecInfo) {
+				llb.AddMount("/usr/local/bin/frontend", st, llb.SourcePath("/frontend")).SetRunOption(ei)
+			}), nil
+		},
+	}
+
+	newSpec := func() *Spec {
+		auth := make(map[string]GomodGitAuth, 12)
+		for i := 0; i < 12; i++ {
+			auth[fmt.Sprintf("host-%02d.example.com", i)] = GomodGitAuth{
+				Token: fmt.Sprintf("DALEC_TOKEN_%02d", i),
+			}
+		}
+		return &Spec{
+			Sources: map[string]Source{
+				"foo": {
+					Git: &SourceGit{URL: "https://localhost/test.git", Commit: "deadbeef"},
+					Generate: []*SourceGenerator{
+						{Gomod: &GeneratorGomod{Auth: auth}},
+					},
+				},
+			},
+		}
+	}
+
+	build := func() llb.State {
+		st := newSpec().GomodDeps(sOpt, llb.Scratch())
+		assert.Assert(t, st != nil)
+		return *st
+	}
+
+	requireDeterministicLLB(ctx, t, build)
+}
+
+func TestGomodPatchEnvProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	auth := make(map[string]GomodGitAuth, 12)
+	for i := 0; i < 12; i++ {
+		auth[fmt.Sprintf("host-%02d.example.com", i)] = GomodGitAuth{
+			Token: fmt.Sprintf("DALEC_TOKEN_%02d", i),
+		}
+	}
+
+	gen := &SourceGenerator{
+		Gomod: &GeneratorGomod{
+			Auth: auth,
+			Edits: &GomodEdits{
+				Replace: []GomodReplace{
+					{Original: "example.com/old", Update: "example.com/new v1.2.3"},
+				},
+			},
+		},
+	}
+
+	spec := &Spec{}
+	base := llb.Scratch()
+	worker := llb.Scratch()
+
+	build := func() llb.State {
+		st, err := spec.generateGomodPatchStateForSource("src", gen, base, worker, nil)
+		assert.NilError(t, err)
+		assert.Assert(t, st != nil)
+		return *st
+	}
+
+	requireDeterministicLLB(ctx, t, build)
+}

--- a/generator_gomod.go
+++ b/generator_gomod.go
@@ -170,7 +170,7 @@ func (g *SourceGenerator) withGomodSecretsAndSockets() llb.RunOption {
 
 		const basePath = "/run/secrets"
 
-		for host, auth := range g.Gomod.Auth {
+		for host, auth := range SortedMapIter(g.Gomod.Auth) {
 			if auth.Token != "" {
 				p := filepath.Join(basePath, host, "token")
 				llb.AddSecret(p, llb.SecretID(auth.Token)).SetRunOption(ei)

--- a/helpers.go
+++ b/helpers.go
@@ -536,7 +536,7 @@ func GetRepoKeys(configs []PackageRepositoryConfig, cfg *RepoPlatformConfig, sOp
 	mounts := make([]llb.RunOption, 0, len(configs))
 	names := make([]string, 0, len(configs))
 	for _, config := range configs {
-		for name, repoKey := range config.Keys {
+		for name, repoKey := range SortedMapIter(config.Keys) {
 			mountPath := filepath.Join(cfg.GPGKeyRoot, name)
 			st, mountOpts := repoKey.ToMount(sOpt, append(opts, ProgressGroup("Fetching repo key: "+name))...)
 			mounts = append(mounts, llb.AddMount(mountPath, st, mountOpts...))

--- a/packaging/linux/deb/determinism_test.go
+++ b/packaging/linux/deb/determinism_test.go
@@ -1,0 +1,106 @@
+package deb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+// determinismRuns is intentionally well above the 2 runs needed to spot an
+// obvious diff: marshaling is cheap, and extra runs drive the chance of a
+// randomized map iteration happening to repeat its order toward zero.
+const determinismRuns = 25
+
+// requireDeterministicLLB rebuilds the state on each run so the underlying map
+// iteration executes again, then asserts the marshaled op definitions are
+// byte-identical. Only Def (the op protos whose digests drive caching) is
+// compared; Metadata carries per-build noise and is ignored.
+func requireDeterministicLLB(ctx context.Context, t *testing.T, build func() llb.State) {
+	t.Helper()
+
+	want, err := build().Marshal(ctx)
+	assert.NilError(t, err)
+
+	for i := 1; i < determinismRuns; i++ {
+		got, err := build().Marshal(ctx)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got.Def, want.Def)
+	}
+}
+
+func manySourceStates() map[string]llb.State {
+	states := make(map[string]llb.State, 12)
+	for i := 0; i < 12; i++ {
+		name := fmt.Sprintf("src-%02d", i)
+		states[name] = llb.Scratch().File(llb.Mkfile("/"+name, 0o644, []byte(name)))
+	}
+	return states
+}
+
+func TestMountSourcesProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	build := func() llb.State {
+		runOpt := mountSources(manySourceStates(), "/src", nil)
+		return llb.Scratch().Run(llb.Args([]string{"true"}), runOpt).Root()
+	}
+
+	// mountSources sorts its mounts so the result is deterministic regardless of
+	// BuildKit internals. This guards that observable property end to end.
+	requireDeterministicLLB(ctx, t, build)
+}
+
+func TestTarDebSourcesProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{}
+	sOpt := dalec.SourceOpts{
+		GetContext: func(name string, opts ...llb.LocalOption) (*llb.State, error) {
+			st := llb.Local(name, opts...)
+			return &st, nil
+		},
+	}
+
+	build := func() llb.State {
+		return TarDebSources(llb.Scratch(), spec, manySourceStates(), "/sources.tar", sOpt)
+	}
+
+	requireDeterministicLLB(ctx, t, build)
+}
+
+func TestRulesEnvProducesDeterministicOutput(t *testing.T) {
+	t.Parallel()
+
+	newWrapper := func() *rulesWrapper {
+		env := make(map[string]string, 12)
+		for i := 0; i < 12; i++ {
+			env[fmt.Sprintf("VAR_%02d", i)] = fmt.Sprintf("value-%d", i)
+		}
+		return &rulesWrapper{
+			Spec: &dalec.Spec{Build: dalec.ArtifactBuild{Env: env}},
+		}
+	}
+
+	t.Run("env exports are sorted by key", func(t *testing.T) {
+		want := &strings.Builder{}
+		for i := 0; i < 12; i++ {
+			fmt.Fprintf(want, "export VAR_%02d := value-%d\n", i, i)
+		}
+		assert.Equal(t, newWrapper().Envs().String(), want.String())
+	})
+
+	t.Run("rendered output is stable across runs", func(t *testing.T) {
+		want := newWrapper().Envs().String()
+		for i := 1; i < determinismRuns; i++ {
+			assert.Equal(t, newWrapper().Envs().String(), want)
+		}
+	})
+}

--- a/packaging/linux/deb/pkg.go
+++ b/packaging/linux/deb/pkg.go
@@ -24,7 +24,7 @@ const (
 
 func mountSources(sources map[string]llb.State, dir string, mod func(string) string) llb.RunOption {
 	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
-		for key, src := range sources {
+		for key, src := range dalec.SortedMapIter(sources) {
 			if mod != nil {
 				key = mod(key)
 			}
@@ -193,7 +193,7 @@ func BuildDeb(worker llb.State, spec *dalec.Spec, srcPkg llb.State, distroVersio
 func TarDebSources(work llb.State, spec *dalec.Spec, srcStates map[string]llb.State, dest string, sOpts dalec.SourceOpts, opts ...llb.ConstraintsOpt) llb.State {
 	opts = append(opts, dalec.ProgressGroup("Prepare debian sources"))
 	states := make([]llb.State, 0, len(srcStates))
-	for key, state := range srcStates {
+	for key, state := range dalec.SortedMapIter(srcStates) {
 		src, ok := spec.Sources[key]
 
 		// If the source is not explicitly listed in the spec sources, assume it is a directory (e.g., for gomod dependencies)

--- a/packaging/linux/deb/template_rules.go
+++ b/packaging/linux/deb/template_rules.go
@@ -50,7 +50,7 @@ type rulesWrapper struct {
 func (w *rulesWrapper) Envs() fmt.Stringer {
 	b := &strings.Builder{}
 
-	for k, v := range w.Spec.Build.Env {
+	for k, v := range dalec.SortedMapIter(w.Spec.Build.Env) {
 		fmt.Fprintf(b, "export %s := %s\n", k, v)
 	}
 

--- a/preprocess.go
+++ b/preprocess.go
@@ -280,7 +280,7 @@ func (s *Spec) generateGomodPatchStateForSource(sourceName string, gen *SourceGe
 	}
 
 	// Add environment variables from the script
-	for key, value := range envVars {
+	for key, value := range SortedMapIter(envVars) {
 		runOpts = append(runOpts, llb.AddEnv(key, value))
 	}
 

--- a/source_image.go
+++ b/source_image.go
@@ -261,7 +261,7 @@ func (cmd *Command) baseState(opts fetchOptions) llb.StateOption {
 			subPath = "/"
 		}
 
-		for k, v := range cmd.Env {
+		for k, v := range SortedMapIter(cmd.Env) {
 			img = img.AddEnv(k, v)
 		}
 		if cmd.Dir != "" {
@@ -282,7 +282,7 @@ func (cmd *Command) baseState(opts fetchOptions) llb.StateOption {
 
 			rOpts = append(rOpts, baseRunOpts...)
 
-			for k, v := range step.Env {
+			for k, v := range SortedMapIter(step.Env) {
 				rOpts = append(rOpts, llb.AddEnv(k, v))
 			}
 

--- a/targets/linux/deb/distro/determinism_test.go
+++ b/targets/linux/deb/distro/determinism_test.go
@@ -1,0 +1,40 @@
+package distro
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+// determinismRuns is intentionally far above 2: the function under test ranges
+// a map, and Go randomizes that order per range, so repeating the call many
+// times makes an accidentally-stable order vanishingly unlikely.
+const determinismRuns = 25
+
+func TestBuildCandidatePathsIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	deps := make(map[string]dalec.PackageConstraints, 12)
+	for i := 0; i < 12; i++ {
+		deps[fmt.Sprintf("golang-1.%02d", i)] = dalec.PackageConstraints{}
+	}
+
+	t.Run("candidates follow sorted dependency order", func(t *testing.T) {
+		want := make([]string, 0, 12)
+		for i := 0; i < 12; i++ {
+			want = append(want, fmt.Sprintf("/usr/lib/go-1.%02d/bin", i))
+		}
+
+		got := buildCandidatePaths(deps, "golang", "/usr/lib/go", "/bin")
+		assert.DeepEqual(t, got, want)
+	})
+
+	t.Run("output is stable across runs", func(t *testing.T) {
+		want := buildCandidatePaths(deps, "golang", "/usr/lib/go", "/bin")
+		for i := 1; i < determinismRuns; i++ {
+			assert.DeepEqual(t, buildCandidatePaths(deps, "golang", "/usr/lib/go", "/bin"), want)
+		}
+	})
+}

--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -120,7 +120,7 @@ func searchForAltGolang(ctx context.Context, client gwclient.Client, spec *dalec
 func buildCandidatePaths(deps map[string]dalec.PackageConstraints, prefix, basePath, suffix string) []string {
 	var candidates []string
 
-	for dep := range deps {
+	for _, dep := range dalec.SortMapKeys(deps) {
 		if strings.HasPrefix(dep, prefix+"-") {
 			// Get the base version component
 			_, ver, _ := strings.Cut(dep, "-")

--- a/targets/linux/rpm/distro/determinism_test.go
+++ b/targets/linux/rpm/distro/determinism_test.go
@@ -1,0 +1,75 @@
+package distro
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+// determinismRuns stays well above 2: building the download LLB is cheap, and
+// extra runs make an accidentally-stable randomized map order unlikely enough
+// to reliably catch a regression.
+const determinismRuns = 25
+
+// requireDeterministicLLB rebuilds the state each run so the underlying map
+// iteration executes again, then asserts the marshaled op definitions match.
+// Only Def (the cache-relevant op protos) is compared; Metadata is ignored.
+func requireDeterministicLLB(ctx context.Context, t *testing.T, build func() llb.State) {
+	t.Helper()
+
+	want, err := build().Marshal(ctx)
+	assert.NilError(t, err)
+
+	for i := 1; i < determinismRuns; i++ {
+		got, err := build().Marshal(ctx)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got.Def, want.Def)
+	}
+}
+
+func TestDownloadDepsProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// A context-backed worker keeps the LLB offline so the test exercises only
+	// the dnf download argument assembly. InstallFunc is stubbed since the
+	// download path runs the worker's bootstrap install before downloading.
+	cfg := &Config{
+		ContextRef: "worker",
+		CacheName:  "test-cache",
+		InstallFunc: func(_ *dnfInstallConfig, _ string, pkgs []string) llb.RunOption {
+			return llb.Args(append([]string{"install"}, pkgs...))
+		},
+	}
+	sOpt := dalec.SourceOpts{
+		GetContext: func(name string, opts ...llb.LocalOption) (*llb.State, error) {
+			st := llb.Scratch()
+			return &st, nil
+		},
+	}
+	spec := &dalec.Spec{}
+
+	newConstraints := func() dalec.PackageDependencyList {
+		deps := make(dalec.PackageDependencyList, 12)
+		for i := 0; i < 12; i++ {
+			name := fmt.Sprintf("pkg-%02d", i)
+			c := dalec.PackageConstraints{}
+			if i%2 == 0 {
+				c.Version = []string{fmt.Sprintf(">=%d.0", i)}
+			}
+			deps[name] = c
+		}
+		return deps
+	}
+
+	build := func() llb.State {
+		return cfg.DownloadDeps(sOpt, spec, "", newConstraints())
+	}
+
+	requireDeterministicLLB(ctx, t, build)
+}

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -340,7 +340,7 @@ func (cfg *Config) DownloadDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetK
 	// dnf5 requires the destination path be specified as an argument to the `download` verb
 	// and only supports the `--destdir` option name. These args work for both versions.
 	args := []string{"download", "--destdir", "/output"}
-	for name, constraint := range constraints {
+	for name, constraint := range dalec.SortedMapIter(constraints) {
 		if len(constraint.Version) == 0 {
 			args = append(args, name)
 			continue

--- a/targets/windows/determinism_test.go
+++ b/targets/windows/determinism_test.go
@@ -1,0 +1,62 @@
+package windows
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+// determinismRuns is kept well above 2: regenerating the build script is cheap,
+// and each extra run lowers the chance that a randomized map iteration happens
+// to repeat its order and hide a regression.
+const determinismRuns = 25
+
+// requireDeterministicLLB rebuilds the state each run so the underlying map
+// iteration runs again, then asserts the marshaled op definitions match. Only
+// Def (the cache-relevant op protos) is compared; Metadata is ignored.
+func requireDeterministicLLB(ctx context.Context, t *testing.T, build func() llb.State) {
+	t.Helper()
+
+	want, err := build().Marshal(ctx)
+	assert.NilError(t, err)
+
+	for i := 1; i < determinismRuns; i++ {
+		got, err := build().Marshal(ctx)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got.Def, want.Def)
+	}
+}
+
+func TestCreateBuildScriptProducesDeterministicLLB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	newSpec := func() *dalec.Spec {
+		mkEnv := func() map[string]string {
+			env := make(map[string]string, 12)
+			for i := 0; i < 12; i++ {
+				env[fmt.Sprintf("VAR_%02d", i)] = fmt.Sprintf("value-%d", i)
+			}
+			return env
+		}
+		return &dalec.Spec{
+			Build: dalec.ArtifactBuild{
+				Steps: dalec.BuildStepList{
+					{Command: "echo one", Env: mkEnv()},
+					{Command: "echo two", Env: mkEnv()},
+				},
+			},
+		}
+	}
+
+	build := func() llb.State {
+		return createBuildScript(newSpec())
+	}
+
+	requireDeterministicLLB(ctx, t, build)
+}

--- a/targets/windows/handle_zip.go
+++ b/targets/windows/handle_zip.go
@@ -199,7 +199,7 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 			}
 		}),
 		dalec.RunOptFunc(func(ei *llb.ExecInfo) {
-			for k, v := range spec.Build.Env {
+			for k, v := range dalec.SortedMapIter(spec.Build.Env) {
 				ei.State = ei.State.With(llb.AddEnv(k, v))
 			}
 		}),
@@ -273,7 +273,7 @@ func createBuildScript(spec *dalec.Spec, opts ...llb.ConstraintsOpt) llb.State {
 	for i, step := range spec.Build.Steps {
 		fmt.Fprintln(buf, "(")
 
-		for k, v := range step.Env {
+		for k, v := range dalec.SortedMapIter(step.Env) {
 			fmt.Fprintf(buf, "export %s=\"%s\"", k, v)
 		}
 


### PR DESCRIPTION
## What

Several code paths iterated Go maps directly while assembling LLB and while generating build artifacts. Go randomizes map iteration order, so the same input spec produced different op definitions / file contents from build to build, changing BuildKit vertex digests — defeating the cache and making output non-reproducible.

This sorts those iterations (`SortedMapIter`, or `SortMapKeys` where only keys are used) so identical specs yield identical LLB and identical generated files. The cost is sorting a few small maps; behavior is otherwise unchanged.

## Fixed sites

LLB op digest:
- `source_image.go` — image-source command env and run-step env (`AddEnv`)
- `preprocess.go` — gomod patch run env (`AddEnv`)
- `helpers.go` `GetRepoKeys` — repo GPG key mounts + returned names slice
- `generator_gomod.go` `withGomodSecretsAndSockets` — gomod `Auth` secrets/SSH sockets
- `targets/windows/handle_zip.go` — Windows build env (`AddEnv`)
- `targets/linux/rpm/distro/dnf_install.go` — dnf download argument list (the DEB equivalent was already sorted via `AppendConstraints`)
- `packaging/linux/deb/pkg.go` — `mountSources` source mounts and `TarDebSources` merge order feeding `MergeAtPath`/`Tar`

Generated build content:
- `targets/windows/handle_zip.go` — build-script `export` lines
- `packaging/linux/deb/template_rules.go` `Envs()` — `debian/rules` export lines

Narrow selection:
- `targets/linux/deb/distro/pkg.go` `buildCandidatePaths` — alt-Go candidate path search (first-match could vary)

## Intentionally not changed

- `frontend/build.go` `time.Now()` → image `Created`: image-config reproducibility (needs `SOURCE_DATE_EPOCH`), not LLB op digest.
- `template_rules.go:177` `maps.Keys(grouping)[0]`: output bytes are invariant here (`requiresCustomEnable` forces `--no-enable` in the only mixed case) — latent fragility, not a current bug.
- `ProgressGroup(identity.NewID())`: op metadata only, does not affect op digest.
