### PR TITLE
test: verify frontend produces deterministic LLB

### DIFF
--- a/internal/testrunner/determinism_test.go
+++ b/internal/testrunner/determinism_test.go
@@ -1,0 +1,88 @@
+package testrunner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+func TestFileChecksProduceDeterministicLLB(t *testing.T) {
+	spec := &dalec.TestSpec{Files: manyFileChecks()}
+	base := llb.Image("example.com/base:latest")
+
+	t.Run("passthrough path requires checks in a stable order", func(t *testing.T) {
+		dalec.SetPassthroughOpSupported(true)
+		t.Cleanup(func() { dalec.SetPassthroughOpSupported(false) })
+
+		requireDeterministicDef(t, func() *llb.Definition {
+			return marshalState(t, base.With(withFileChecks(spec, withTestFrontend())))
+		})
+	})
+
+	t.Run("fallback path mounts checks in a stable order", func(t *testing.T) {
+		dalec.SetPassthroughOpSupported(false)
+
+		requireDeterministicDef(t, func() *llb.Definition {
+			return marshalState(t, base.With(withFileChecks(spec, withTestFrontend())))
+		})
+	})
+}
+
+func TestTestEnvProducesDeterministicLLB(t *testing.T) {
+	test := &dalec.TestSpec{Env: manyTestEnv()}
+	base := llb.Image("example.com/base:latest")
+
+	requireDeterministicDef(t, func() *llb.Definition {
+		opts := []ValidationOpt{withTestFrontend(), validationOptsFromTest(test, dalec.SourceOpts{})}
+		opt := checkFileNotExists.WithCheck("/check/file", &dalec.FileCheckOutput{NotExist: true}, opts...)
+		return marshalState(t, base.With(opt))
+	})
+}
+
+func marshalState(t *testing.T, st llb.State) *llb.Definition {
+	t.Helper()
+	def, err := st.Marshal(context.Background())
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	return def
+}
+
+// determinismRuns is well above the 2 runs needed to spot a diff: marshaling is
+// cheap, and extra runs drive the chance of a randomized map iteration happening
+// to repeat its order toward zero.
+const determinismRuns = 25
+
+// requireDeterministicDef rebuilds the definition on every run so the underlying
+// map iteration executes again, then asserts the marshaled op definitions are
+// byte-identical. Only Def (the op protos whose digests drive caching) is
+// compared; Metadata carries per-build noise such as progress-group IDs.
+func requireDeterministicDef(t *testing.T, build func() *llb.Definition) {
+	t.Helper()
+
+	want := build()
+	for i := 1; i < determinismRuns; i++ {
+		got := build()
+		assert.DeepEqual(t, got.Def, want.Def)
+	}
+}
+
+func manyFileChecks() map[string]dalec.FileCheckOutput {
+	files := make(map[string]dalec.FileCheckOutput, 12)
+	for i := 0; i < 12; i++ {
+		files[fmt.Sprintf("/check/file-%02d", i)] = dalec.FileCheckOutput{NotExist: true}
+	}
+	return files
+}
+
+func manyTestEnv() map[string]string {
+	env := make(map[string]string, 12)
+	for i := 0; i < 12; i++ {
+		env[fmt.Sprintf("VAR_%02d", i)] = fmt.Sprintf("value-%d", i)
+	}
+	return env
+}

--- a/internal/testrunner/files.go
+++ b/internal/testrunner/files.go
@@ -11,7 +11,7 @@ func withFileChecks(test *dalec.TestSpec, opts ...ValidationOpt) llb.StateOption
 	}
 
 	outs := make([]llb.StateOption, 0, len(test.Files))
-	for file, check := range test.Files {
+	for file, check := range dalec.SortedMapIter(test.Files) {
 		outs = append(outs, withFileCheck(file, &check, opts...)...)
 	}
 	return requireValidations(outs, opts...)

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -97,7 +97,7 @@ type ValidationInfo struct {
 
 func validationOptsFromTest(t *dalec.TestSpec, sOpt dalec.SourceOpts, opts ...llb.ConstraintsOpt) ValidationOpt {
 	return func(i *ValidationInfo) {
-		for k, v := range t.Env {
+		for k, v := range dalec.SortedMapIter(t.Env) {
 			i.ExtraOpts = append(i.ExtraOpts, llb.AddEnv(k, v))
 		}
 

--- a/test/fixtures/signer/main.go
+++ b/test/fixtures/signer/main.go
@@ -99,7 +99,7 @@ func main() {
 
 		// For any build-arg seen, write a file to /env/<KEY> with the contents
 		// being the value of the arg.
-		for k, v := range c.BuildOpts().Opts {
+		for k, v := range dalec.SortedMapIter(c.BuildOpts().Opts) {
 			_, key, ok := strings.Cut(k, "build-arg:")
 			if !ok {
 				// not a build arg

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -436,6 +436,7 @@ func (b *BuildxEnv) runTestWithStatus(ctx context.Context, t *testing.T, f TestF
 				gwc = wrapWithInput(gwc, id, f)
 			}
 			b.mu.Unlock()
+			gwc = withDeterminismCheck(gwc, t)
 			f(ctx, gwc)
 			return gwclient.NewResult(), nil
 		}, ch)

--- a/test/testenv/determinism.go
+++ b/test/testenv/determinism.go
@@ -1,0 +1,99 @@
+package testenv
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/opencontainers/go-digest"
+)
+
+// withDeterminismCheck wraps a client so that every successful frontend solve is
+// re-run and its generated LLB compared against the first run. It is intended to
+// be the outermost wrapper so it observes the requests tests actually issue and
+// re-issues them through the full frontend chain.
+func withDeterminismCheck(c gwclient.Client, t *testing.T) gwclient.Client {
+	return withCurrentFrontend(c, &determinismChecker{Client: c, t: t})
+}
+
+// determinismChecker re-runs the frontend for a request and asserts it produces
+// identical LLB.
+//
+// BuildKit executes the gateway frontend container on every solve (the frontend
+// process itself is not cached), so re-solving genuinely re-runs the frontend's
+// LLB-generation code. The re-solve forces Evaluate=false so the emitted refs
+// are not built: only the frontend runs, which keeps the check cheap relative to
+// the original (often Evaluate=true) build while still exercising LLB
+// generation.
+//
+// Only op-definition digests are compared. Legitimate per-run values such as
+// progress-group IDs and the image "Created" timestamp live in op metadata and
+// the image config, not in the op definitions, so comparing definition digests
+// avoids false positives while still catching non-deterministic op generation
+// (e.g. unsorted map iteration).
+type determinismChecker struct {
+	gwclient.Client
+	t *testing.T
+}
+
+func (c *determinismChecker) Solve(ctx context.Context, req gwclient.SolveRequest) (*gwclient.Result, error) {
+	res, err := c.Client.Solve(ctx, req)
+	if err != nil {
+		return res, err
+	}
+
+	// A request carrying a pre-built definition goes straight to the buildkit
+	// solver rather than running the dalec frontend, so there is no frontend
+	// LLB generation to check for determinism.
+	if req.Definition != nil {
+		return res, nil
+	}
+
+	req.Evaluate = false
+	res2, err := c.Client.Solve(ctx, req)
+	if err != nil {
+		c.t.Errorf("determinism: re-solving request failed: %+v", err)
+		return res, nil
+	}
+
+	want := resultLLBDigests(ctx, c.t, res)
+	got := resultLLBDigests(ctx, c.t, res2)
+
+	if !slices.Equal(got, want) {
+		c.t.Errorf("frontend produced non-deterministic LLB across solves:\nfirst:  %v\nsecond: %v", want, got)
+	}
+
+	return res, nil
+}
+
+// resultLLBDigests returns the sorted digests of every op definition across all
+// refs in the result. Sorting makes the comparison independent of the
+// (map-backed, non-deterministic) iteration order of multi-platform refs.
+func resultLLBDigests(ctx context.Context, t *testing.T, res *gwclient.Result) []string {
+	t.Helper()
+
+	var digests []string
+	if err := res.EachRef(func(ref gwclient.Reference) error {
+		st, err := ref.ToState()
+		if err != nil {
+			return err
+		}
+
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, dt := range def.Def {
+			digests = append(digests, digest.FromBytes(dt).String())
+		}
+
+		return nil
+	}); err != nil {
+		t.Errorf("determinism: extracting LLB from result: %v", err)
+	}
+
+	slices.Sort(digests)
+	return digests
+}


### PR DESCRIPTION
Re-runs each successful frontend solve with `Evaluate: false` and compares the generated op definitions, failing the test if they differ.

Wired as the outermost client wrapper in the test harness, so all integration solves are covered (including direct `gwc.Solve` calls that bypass the `solveT` helpers). Skips raw-definition solves and negative-path (errored) solves. The re-solve doesn't execute build steps, so overhead is just LLB generation.

Complements the unit-level checks in `determinism_test.go` by exercising the full frontend build path.