### PR TITLE
Remove GOINSECURE from gomod patch generation

### DIFF
--- a/preprocess.go
+++ b/preprocess.go
@@ -139,7 +139,7 @@ func buildGomodPatchEnv(editArgs string, paths []string, gen *SourceGenerator, s
 
 	// Build git config section
 	gitConfig := &strings.Builder{}
-	var goPrivate, goInsecure string
+	var goPrivate string
 
 	sortedHosts := SortMapKeys(gen.Gomod.Auth)
 	if len(sortedHosts) > 0 {
@@ -173,9 +173,7 @@ func buildGomodPatchEnv(editArgs string, paths []string, gen *SourceGenerator, s
 			}
 		}
 
-		joined := strings.Join(goPrivateHosts, ",")
-		goPrivate = joined
-		goInsecure = joined
+		goPrivate = strings.Join(goPrivateHosts, ",")
 	}
 
 	// Build module info for each path
@@ -214,9 +212,6 @@ func buildGomodPatchEnv(editArgs string, paths []string, gen *SourceGenerator, s
 	}
 	if goPrivate != "" {
 		env["GOPRIVATE"] = goPrivate
-	}
-	if goInsecure != "" {
-		env["GOINSECURE"] = goInsecure
 	}
 
 	return env, nil

--- a/scripts/gomod-patch.sh
+++ b/scripts/gomod-patch.sh
@@ -17,7 +17,6 @@ fi
 # - EDIT_ARGS: Newline-separated list of -replace= arguments for go mod edit
 # - GIT_CONFIG_SCRIPT: Optional git configuration script
 # - GOPRIVATE: Optional GOPRIVATE setting
-# - GOINSECURE: Optional GOINSECURE setting
 # - GOMOD_FILENAME: Filename for go.mod (default: go.mod)
 # - GOSUM_FILENAME: Filename for go.sum (default: go.sum)
 # - MODULE_PATHS: Colon-separated list of module paths to process
@@ -40,12 +39,9 @@ if [ -n "$GIT_CONFIG_SCRIPT" ]; then
   eval "$GIT_CONFIG_SCRIPT"
 fi
 
-# Setup Go private/insecure settings if provided
+# Setup Go private settings if provided
 if [ -n "$GOPRIVATE" ]; then
   export GOPRIVATE
-fi
-if [ -n "$GOINSECURE" ]; then
-  export GOINSECURE
 fi
 
 # Process each module path


### PR DESCRIPTION
## Why

The gomod replace/tidy preprocessing step set `GOINSECURE` to the same host list as `GOPRIVATE`, silently disabling TLS certificate verification for those hosts.

Investigating its actual behavior:

- **Inert for SSH auth.** The git `insteadOf` rewrite redirects to `ssh://` before Go's HTTP client is involved, so there is no TLS path for `GOINSECURE` to affect.
- **Inconsistently applied.** It was only set in the patch/tidy preprocessing step, never in the dependency download step (`generator_gomod.go`). A private HTTPS host with an untrusted cert would still fail there, so the setting never enabled a working end-to-end scenario.
- **Untested.** No test combines a private-auth host with gomod edits and live execution, so nothing exercised it.

In short, it weakened certificate validation without enabling any working behavior. This removes it. `GOPRIVATE` is retained, so module privacy (skipping proxy/sumdb for the configured hosts) is unchanged.