### PR TITLE
deb: skip dh_strip_nondeterminism and dh_shlibdeps when disabled

### DIFF
--- a/packaging/linux/deb/template_rules.go
+++ b/packaging/linux/deb/template_rules.go
@@ -200,6 +200,25 @@ func (w *rulesWrapper) OverrideStrip() fmt.Stringer {
 
 	if artifacts.DisableStrip {
 		buf.WriteString("override_dh_strip:\n")
+		// dh_strip_nondeterminism is a separate helper that debhelper runs even
+		// when dh_strip is overridden. It fails on some inputs (e.g. Go's corrupt
+		// archive test fixtures), so disable it alongside dh_strip.
+		buf.WriteString("override_dh_strip_nondeterminism:\n")
+	}
+	return buf
+}
+
+func (w *rulesWrapper) OverrideAutoRequires() fmt.Stringer {
+	artifacts := w.Spec.GetArtifacts(w.target)
+
+	buf := &strings.Builder{}
+
+	if artifacts.DisableAutoRequires {
+		// DisableAutoRequires drops the auto-discovered ${shlibs:Depends} from the
+		// control file, but dh_shlibdeps still runs and can fail on unrelated ELF
+		// fixtures. With auto-requires disabled its output is discarded anyway, so
+		// skip it entirely.
+		buf.WriteString("override_dh_shlibdeps:\n")
 	}
 	return buf
 }

--- a/packaging/linux/deb/template_rules_test.go
+++ b/packaging/linux/deb/template_rules_test.go
@@ -193,15 +193,29 @@ Depends: ${misc:Depends},
 }
 
 func TestRules_OverrideStrip(t *testing.T) {
-	w := &rulesWrapper{
-		Spec: &dalec.Spec{},
-	}
+	t.Run("strip enabled by default emits no overrides", func(t *testing.T) {
+		w := newRulesWrapper(dalec.Artifacts{})
+		assert.Equal(t, w.OverrideStrip().String(), "")
+	})
 
-	got := w.OverrideStrip()
-	assert.Equal(t, got.String(), "")
+	t.Run("disable_strip disables dh_strip and dh_strip_nondeterminism", func(t *testing.T) {
+		w := newRulesWrapper(dalec.Artifacts{DisableStrip: true})
+		assert.Equal(t, w.OverrideStrip().String(), "override_dh_strip:\noverride_dh_strip_nondeterminism:\n")
+	})
+}
 
-	w.Spec.Artifacts.DisableStrip = true
-	got = w.OverrideStrip()
-	expect := "override_dh_strip:\n"
-	assert.Equal(t, got.String(), expect)
+func TestRules_OverrideAutoRequires(t *testing.T) {
+	t.Run("auto-requires enabled by default lets dh_shlibdeps run", func(t *testing.T) {
+		w := newRulesWrapper(dalec.Artifacts{})
+		assert.Equal(t, w.OverrideAutoRequires().String(), "")
+	})
+
+	t.Run("disable_auto_requires disables dh_shlibdeps", func(t *testing.T) {
+		w := newRulesWrapper(dalec.Artifacts{DisableAutoRequires: true})
+		assert.Equal(t, w.OverrideAutoRequires().String(), "override_dh_shlibdeps:\n")
+	})
+}
+
+func newRulesWrapper(artifacts dalec.Artifacts) *rulesWrapper {
+	return &rulesWrapper{Spec: &dalec.Spec{Artifacts: artifacts}}
 }

--- a/packaging/linux/deb/templates/debian_rules.tmpl
+++ b/packaging/linux/deb/templates/debian_rules.tmpl
@@ -30,5 +30,7 @@ override_dh_dwz:
 
 {{ .OverrideStrip }}
 
+{{ .OverrideAutoRequires }}
+
 %:
 	dh $@ -v


### PR DESCRIPTION
`disable_strip` and `disable_auto_requires` are meant to turn off stripping and automatic dependency discovery, but each only covers part of what debhelper runs:

- `disable_strip` overrides `dh_strip` but leaves `dh_strip_nondeterminism` running.
- `disable_auto_requires` drops `${shlibs:Depends}` from the control file but leaves `dh_shlibdeps` running (its output is then discarded).

Those leftover helpers can fail on inputs the user has explicitly opted out of processing (e.g. corrupt archive fixtures, foreign-arch ELF fixtures — hit when building msft-golang). The existing options should already cover them, and there's no good spec-level workaround since mid-build `debian/rules` overrides aren't honored on newer dpkg.

This extends the existing options to emit the matching empty override targets at generation time:
- `disable_strip` also skips `dh_strip_nondeterminism`
- `disable_auto_requires` also skips `dh_shlibdeps`