### PR TITLE
Resolve YAML aliases and merge keys inside dependency maps and build steps

### DIFF
--- a/deps.go
+++ b/deps.go
@@ -44,7 +44,11 @@ func (pc *PackageConstraints) UnmarshalYAML(ctx context.Context, node ast.Node) 
 	var i internal
 
 	if node.Type() != ast.NullType {
-		if err := yaml.NodeToValue(node, &i, decodeOpts(ctx)...); err != nil {
+		// Decode via getDecoder so the document's anchor definitions (carried as
+		// reference readers) are available; this lets an alias used as a
+		// package's value resolve against a top-level anchor.
+		dec := getDecoder(ctx)
+		if err := dec.DecodeFromNodeContext(ctx, node, &i); err != nil {
 			return errors.Wrap(err, "unmarshal package constraints")
 		}
 	}
@@ -86,32 +90,55 @@ func (l *PackageDependencyList) UnmarshalYAML(ctx context.Context, node ast.Node
 			}
 		}
 
+		*l = result
+
 		return nil
 	}
 
-	result := make(PackageDependencyList)
+	// Decode the whole mapping through getDecoder so the document's anchor
+	// definitions are available. This lets the yaml library resolve aliases used
+	// as package values and expand `<<:` merge keys that reference top-level
+	// anchors. Decode into the unnamed map type so this method is not re-entered.
+	result := make(map[string]PackageConstraints)
 	dec := getDecoder(ctx)
-	for _, v := range mapNode.Values {
-		var pc PackageConstraints
-		if err := dec.DecodeFromNodeContext(ctx, v.Value, &pc); err != nil {
-			return errors.Wrap(err, "unmarshal package constraints")
-		}
+	if err := dec.DecodeFromNodeContext(ctx, mapNode, &result); err != nil {
+		return errors.Wrap(err, "unmarshal package constraints")
+	}
 
+	// Merged/aliased entries keep the source map of their anchor definition.
+	// Directly-specified entries need an adjustment: when a package constraint is
+	// specified, e.g.
+	//   pkg-name:
+	//   	version: [">=1.0.0"]
+	// the value node's source map points at the line below `pkg-name`. However,
+	// we want to include the package name itself in the source map, so pull the
+	// start line up to the package key.
+	for _, v := range mapNode.Values {
+		// A merge key (`<<:`) is not a package: its key is the literal `<<` and
+		// the packages it contributes are declared in the referenced anchor, not
+		// in this mapping. Those merged packages already have a source map
+		// pointing at their anchor definition (set when the decoder resolved the
+		// alias), and their key nodes don't exist here to adjust, so skip them.
+		if v.Key.IsMergeKey() {
+			continue
+		}
 		key, ok := v.Key.(*ast.StringNode)
 		if !ok {
 			return goerrors.New("expected string key for package dependency")
 		}
-
-		// Handle case where a package constraint is specified:
-		// e.g.
-		//   pkg-name:
-		//	 	version: [">=1.0.0"]
-		// In this case, the the line number would be pointing at the line below `pkg-name`
-		// However, we want to include the package name itself in the source map.
+		pc := result[key.Value]
+		if pc._sourceMap == nil {
+			continue
+		}
+		// The value can be an alias whose anchor is declared above this key (e.g.
+		// `somepkg: *c`), so the entry may already start above the key line. Only
+		// pull the start line up to the key when the value node sits below it, so
+		// the name itself is included without discarding an earlier anchor
+		// position. _sourceMap is shared with the map entry by pointer, so
+		// mutating it in place needs no write-back.
 		if pc._sourceMap.pos.Start.Line > int32(key.GetToken().Position.Line) {
 			pc._sourceMap.pos.Start.Line = int32(key.GetToken().Position.Line)
 		}
-		result[key.Value] = pc
 	}
 
 	*l = result

--- a/deps_test.go
+++ b/deps_test.go
@@ -1,0 +1,279 @@
+package dalec
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestPackageDependencyAliasResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an alias referenced as a package's value resolves to the anchor's constraints", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+x-c: &c
+  version: [">= 1.0"]
+dependencies:
+  build:
+    somepkg: *c
+`)
+		build := spec.Dependencies.Build
+		assert.Assert(t, cmp.Contains(build, "somepkg"))
+		assert.DeepEqual(t, build["somepkg"].Version, []string{">= 1.0"})
+	})
+
+	t.Run("a merge key inside a package map merges the anchor's packages", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+x-b: &b
+  somepkg:
+    version: [">= 1.0"]
+dependencies:
+  build:
+    <<: *b
+    gnupg2:
+`)
+		build := spec.Dependencies.Build
+		assert.Assert(t, cmp.Contains(build, "somepkg"))
+		assert.Assert(t, cmp.Contains(build, "gnupg2"))
+		assert.DeepEqual(t, build["somepkg"].Version, []string{">= 1.0"})
+	})
+
+	t.Run("a merge key at the dependencies level merges the anchor's lists", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+x-d: &d
+  build:
+    somepkg:
+      version: [">= 1.0"]
+dependencies:
+  <<: *d
+`)
+		build := spec.Dependencies.Build
+		assert.Assert(t, cmp.Contains(build, "somepkg"))
+		assert.DeepEqual(t, build["somepkg"].Version, []string{">= 1.0"})
+	})
+
+	t.Run("an explicit package overrides a merged package of the same name", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+x-b: &b
+  somepkg:
+    version: [">= 1.0"]
+dependencies:
+  build:
+    <<: *b
+    somepkg:
+      version: [">= 2.0"]
+`)
+		build := spec.Dependencies.Build
+		assert.DeepEqual(t, build["somepkg"].Version, []string{">= 2.0"})
+	})
+
+	t.Run("an alias resolves for runtime dependencies", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+x-c: &c
+  version: [">= 1.0"]
+dependencies:
+  runtime:
+    somepkg: *c
+`)
+		runtime := spec.Dependencies.Runtime
+		assert.Assert(t, cmp.Contains(runtime, "somepkg"))
+		assert.DeepEqual(t, runtime["somepkg"].Version, []string{">= 1.0"})
+	})
+}
+
+func TestPackageDependencyListSequenceForm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a dependency list written as a sequence of package names loads every package", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+dependencies:
+  build:
+    - somepkg
+    - otherpkg
+`)
+		build := spec.Dependencies.Build
+		assert.Assert(t, cmp.Contains(build, "somepkg"))
+		assert.Assert(t, cmp.Contains(build, "otherpkg"))
+	})
+
+	t.Run("a package listed in sequence form keeps a source map pointing at its list entry", func(t *testing.T) {
+		t.Parallel()
+		doc := depsSpecHeader + `
+dependencies:
+  build:
+    - somepkg
+`
+		spec, err := LoadSpec([]byte(doc))
+		assert.NilError(t, err)
+
+		pc := spec.Dependencies.Build["somepkg"]
+		assert.Assert(t, pc._sourceMap != nil)
+		assert.Equal(t, int(pc._sourceMap.pos.Start.Line), lineOf(doc, "- somepkg"))
+	})
+}
+
+func TestPackageDependencyEmptySequence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an empty dependency sequence leaves the list unset rather than an empty map", func(t *testing.T) {
+		t.Parallel()
+		spec := loadDepsSpec(t, `
+dependencies:
+  build: []
+`)
+		assert.Assert(t, spec.Dependencies.Build == nil)
+	})
+}
+
+func TestPackageDependencyDecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a package constraint that cannot be decoded surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		err := loadDepsSpecErr(t, `
+dependencies:
+  build:
+    somepkg:
+      version:
+        not: a-list
+`)
+		assert.ErrorContains(t, err, "unmarshal package constraints")
+	})
+
+	t.Run("a non-string package key surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		err := loadDepsSpecErr(t, `
+dependencies:
+  build:
+    123:
+      version: [">= 1.0"]
+`)
+		assert.ErrorContains(t, err, "expected string key")
+	})
+}
+
+func TestPackageDependencySourceMaps(t *testing.T) {
+	t.Parallel()
+
+	// Line numbers are derived from the document text below so the assertions
+	// are not tied to a hand-counted offset. `merged-pkg` is declared inside the
+	// anchor; `direct-pkg` is declared directly under build via a merge key.
+	doc := `name: t
+version: "1.0"
+revision: "1"
+packager: t
+vendor: t
+license: MIT
+description: t
+x-b: &b
+  merged-pkg:
+    version: [">= 1.0"]
+dependencies:
+  build:
+    <<: *b
+    direct-pkg:
+      version: [">= 2.0"]
+`
+	spec, err := LoadSpec([]byte(doc))
+	assert.NilError(t, err)
+
+	build := spec.Dependencies.Build
+	assert.Assert(t, cmp.Contains(build, "merged-pkg"))
+	assert.Assert(t, cmp.Contains(build, "direct-pkg"))
+
+	t.Run("a package pulled in by a merge key maps to its anchor definition, not the merge-key line", func(t *testing.T) {
+		t.Parallel()
+		merged := build["merged-pkg"]
+		assert.Assert(t, merged._sourceMap != nil)
+		// The merged package's source map points at the anchor's value node (where
+		// it is actually declared), not at the `<<: *b` merge-key line under build.
+		assert.Equal(t, int(merged._sourceMap.pos.Start.Line), lineOf(doc, `version: [">= 1.0"]`))
+		assert.Assert(t, int(merged._sourceMap.pos.Start.Line) != lineOf(doc, "<<: *b"))
+	})
+
+	t.Run("a directly-specified package has a source map starting at its own key line", func(t *testing.T) {
+		t.Parallel()
+		direct := build["direct-pkg"]
+		assert.Assert(t, direct._sourceMap != nil)
+		assert.Equal(t, int(direct._sourceMap.pos.Start.Line), lineOf(doc, "direct-pkg:"))
+	})
+}
+
+func TestPackageDependencyAliasValueSourceMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a package whose value is an alias keeps the anchor's source map instead of moving to its own key", func(t *testing.T) {
+		t.Parallel()
+		doc := depsSpecHeader + `
+x-c: &c
+  version: [">= 1.0"]
+dependencies:
+  build:
+    somepkg: *c
+`
+		spec, err := LoadSpec([]byte(doc))
+		assert.NilError(t, err)
+
+		pc := spec.Dependencies.Build["somepkg"]
+		assert.Assert(t, pc._sourceMap != nil)
+		// The value is an alias to an anchor declared above the `somepkg` key, so the
+		// entry's source map precedes its key. It must stay at the anchor rather than
+		// being pulled down to the key line.
+		assert.Equal(t, int(pc._sourceMap.pos.Start.Line), lineOf(doc, "x-c: &c"))
+		assert.Assert(t, int(pc._sourceMap.pos.Start.Line) != lineOf(doc, "somepkg: *c"))
+	})
+}
+
+// depsSpecHeader is a minimal valid spec header that the dependency tests prefix
+// to a dependencies block so the document loads.
+const depsSpecHeader = `
+name: t
+version: "1.0"
+revision: "1"
+packager: t
+vendor: t
+license: MIT
+description: t
+`
+
+// loadDepsSpec loads a spec composed of a minimal valid header plus the given
+// body (typically an anchor and a dependencies block) and fails the test if it
+// cannot be loaded.
+func loadDepsSpec(t *testing.T, body string) *Spec {
+	t.Helper()
+
+	spec, err := LoadSpec([]byte(depsSpecHeader + body))
+	assert.NilError(t, err)
+	assert.Assert(t, spec.Dependencies != nil)
+	return spec
+}
+
+// loadDepsSpecErr loads a spec composed of the minimal header plus body and
+// returns the resulting error for the caller to assert on.
+func loadDepsSpecErr(t *testing.T, body string) error {
+	t.Helper()
+
+	_, err := LoadSpec([]byte(depsSpecHeader + body))
+	return err
+}
+
+// lineOf returns the 1-based line number of the first line in doc that contains
+// substr, or 0 if it is not found.
+func lineOf(doc, substr string) int {
+	line := 0
+	for l := range strings.SplitSeq(doc, "\n") {
+		line++
+		if strings.Contains(l, substr) {
+			return line
+		}
+	}
+	return 0
+}

--- a/spec.go
+++ b/spec.go
@@ -439,20 +439,18 @@ type ArtifactBuild struct {
 type BuildStepList []BuildStep
 
 func (ls *BuildStepList) UnmarshalYAML(ctx context.Context, node ast.Node) error {
-	seq, ok := node.(*ast.SequenceNode)
-	if !ok {
+	if _, ok := node.(*ast.SequenceNode); !ok {
 		return errors.New("expected sequence node for build steps")
 	}
 
-	result := make([]BuildStep, 0, len(seq.Values))
-	for _, n := range seq.Values {
-		var step BuildStep
-
-		if err := yaml.NodeToValue(n, &step, decodeOpts(ctx)...); err != nil {
-			return err
-		}
-		step._sourceMap = newSourceMap(ctx, n)
-		result = append(result, step)
+	// Decode the whole sequence through getDecoder so the document's anchor
+	// definitions are available; this lets an alias or `<<:` merge referencing a
+	// top-level anchor be used as a build step. Each element is decoded by
+	// BuildStep.UnmarshalYAML, which attaches its own source map.
+	var result []BuildStep
+	dec := getDecoder(ctx)
+	if err := dec.DecodeFromNodeContext(ctx, node, &result); err != nil {
+		return err
 	}
 
 	*ls = result

--- a/spec_test.go
+++ b/spec_test.go
@@ -10,6 +10,46 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
+func TestBuildStepListAliasResolution(t *testing.T) {
+	t.Parallel()
+
+	const header = `name: t
+version: "1.0"
+revision: "1"
+packager: t
+vendor: t
+license: MIT
+description: t
+`
+	t.Run("an aliased build step resolves to the anchor's step", func(t *testing.T) {
+		t.Parallel()
+		spec, err := LoadSpec([]byte(header + `
+x-step: &s
+  command: echo hi
+build:
+  steps:
+    - *s
+`))
+		assert.NilError(t, err)
+		assert.Assert(t, cmp.Len(spec.Build.Steps, 1))
+		assert.Equal(t, spec.Build.Steps[0].Command, "echo hi")
+	})
+
+	t.Run("a merge key in a build step resolves to the anchor's step", func(t *testing.T) {
+		t.Parallel()
+		spec, err := LoadSpec([]byte(header + `
+x-step: &s
+  command: echo hi
+build:
+  steps:
+    - <<: *s
+`))
+		assert.NilError(t, err)
+		assert.Assert(t, cmp.Len(spec.Build.Steps, 1))
+		assert.Equal(t, spec.Build.Steps[0].Command, "echo hi")
+	})
+}
+
 func TestDate(t *testing.T) {
 	expect := "2023-10-01"
 	expectTime, err := time.Parse(time.DateOnly, expect)


### PR DESCRIPTION
Fixes #1134.

YAML aliases and `<<:` merge keys that reference a top-level anchor failed to load
with `could not find alias` when used inside a dependency package map — and, as an
audit turned up, inside `build.steps` as well. The same anchor resolves when the
merge is applied at a level that is decoded as a whole (e.g. the `dependencies:`
node), which is the tell for the root cause.

## Why

The custom unmarshallers that attach source maps re-decoded child AST nodes in
isolation, without the document's anchor table:

- `PackageConstraints.UnmarshalYAML` used `yaml.NodeToValue` (no reference readers).
- `PackageDependencyList.UnmarshalYAML` hand-iterated the mapping and never expanded
  `<<:` merge-key nodes.
- `BuildStepList.UnmarshalYAML` hand-iterated the sequence and decoded each step with
  `yaml.NodeToValue`, duplicating what `BuildStep.UnmarshalYAML` already does.

None of these isolated decodes carried the document's anchors, so an alias landing
inside them could not be resolved. This regressed in `ef94b3d8` when the node-based
unmarshallers were introduced for source maps.

The project already has the right primitive: `getDecoder(ctx)` builds a decoder
configured with `yaml.ReferenceReaders(baseDoc)`, which repopulates the anchor
table. The fix routes these decodes through it and lets the YAML library expand
merge keys and resolve aliases natively.

## Changes

- Decode `PackageConstraints` through the reference-reader decoder so an alias used
  as a package value resolves against the top-level anchor.
- Decode the whole package mapping in one pass so `<<:` merge keys and aliases are
  expanded natively, keeping the source-map refinement (start line pulled up to the
  package key) for directly-specified entries; merged entries keep the source map of
  their anchor definition.
- Decode `build.steps` as a whole sequence and let `BuildStep` resolve aliases/merge
  keys and attach its own source map (removing the redundant, buggy manual loop).
- Fix dependency lists written in the sequence-of-names form being silently dropped:
  the decoded result was built but never assigned.

## Audit

I checked every custom `UnmarshalYAML` / node re-decode and verified each with a real
spec. The only broken sites were the dependency maps and `build.steps` (both fixed
here). Scalar `sourceMappedValue` fields (test `command`, dependency names, uid/gid)
and the full-document decodes are fine, because they are reached through a
`getDecoder`-decoded parent (or already contain the anchor definitions).

## Tests

- `deps_test.go`: alias-as-value, merge-key-inside-map, merge at the `dependencies`
  level, explicit-overrides-merged precedence, aliases for runtime lists, the
  sequence-of-names form, and source-map attribution for merged vs. direct packages.
- `spec_test.go`: aliased and merge-key build steps resolve to the anchor's step.