### PR TITLE
Add /opt artifact support

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -17,6 +17,8 @@ type Artifacts struct {
 	Binaries map[string]ArtifactConfig `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	// Libexec is the list of additional binaries that may be invoked by the main package binary.
 	Libexec map[string]ArtifactConfig `yaml:"libexec,omitempty" json:"libexec,omitempty"`
+	// Opt is the list of files to install under /opt.
+	Opt map[string]ArtifactConfig `yaml:"opt,omitempty" json:"opt,omitempty"`
 	// Manpages is the list of manpages to include in the package.
 	Manpages map[string]ArtifactConfig `yaml:"manpages,omitempty" json:"manpages,omitempty"`
 	// DataDirs is a list of read-only architecture-independent data files, to be placed in /usr/share/
@@ -211,6 +213,9 @@ func (a *Artifacts) IsEmpty() bool {
 	if len(a.Binaries) > 0 {
 		return false
 	}
+	if len(a.Opt) > 0 {
+		return false
+	}
 	if len(a.Manpages) > 0 {
 		return false
 	}
@@ -265,7 +270,7 @@ func (a *Artifacts) validate() error {
 	checkCapabilities := func(artifactType string, artifacts map[string]ArtifactConfig) {
 		for path, cfg := range artifacts {
 			if len(cfg.LinuxCapabilities) > 0 {
-				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec); cannot set capabilities on %s '%s'", artifactType, path))
+				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec, opt); cannot set capabilities on %s '%s'", artifactType, path))
 			}
 		}
 	}
@@ -282,12 +287,12 @@ func (a *Artifacts) validate() error {
 	if a.Systemd != nil {
 		for path, cfg := range a.Systemd.Units {
 			if artifact := cfg.Artifact(); artifact != nil && len(artifact.LinuxCapabilities) > 0 {
-				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec); cannot set capabilities on systemd unit '%s'", path))
+				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec, opt); cannot set capabilities on systemd unit '%s'", path))
 			}
 		}
 		for path, cfg := range a.Systemd.Dropins {
 			if artifact := cfg.Artifact(); artifact != nil && len(artifact.LinuxCapabilities) > 0 {
-				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec); cannot set capabilities on systemd dropin '%s'", path))
+				errs = append(errs, fmt.Errorf("capabilities can only be set on executable files (binaries, libs, libexec, opt); cannot set capabilities on systemd dropin '%s'", path))
 			}
 		}
 	}

--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -393,6 +393,16 @@
 					],
 					"description": "Manpages is the list of manpages to include in the package."
 				},
+				"opt": {
+					"additionalProperties": {
+						"$ref": "#/$defs/ArtifactConfig"
+					},
+					"type": [
+						"object",
+						"null"
+					],
+					"description": "Opt is the list of files to install under /opt."
+				},
 				"systemd": {
 					"$ref": "#/$defs/SystemdConfiguration",
 					"description": "Systemd is the list of systemd units and dropin files for the package"

--- a/load_test.go
+++ b/load_test.go
@@ -2228,6 +2228,18 @@ func TestArtifactsValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "capabilities on opt is valid",
+			artifacts: Artifacts{
+				Opt: map[string]ArtifactConfig{
+					"/tmp/helper": {
+						LinuxCapabilities: []ArtifactCapability{
+							{Name: "cap_net_bind_service", Effective: true, Permitted: true},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "capabilities on docs is invalid",
 			artifacts: Artifacts{
 				Docs: map[string]ArtifactConfig{

--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -582,12 +582,10 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 		}
 	}
 
-	if len(artifacts.Opt) > 0 {
-		for key, cfg := range dalec.SortedMapIter(artifacts.Opt) {
-			resolved := cfg.ResolveName(key)
-			targetDir := filepath.Join(OptPath, cfg.SubPath)
-			writeInstall(key, targetDir, resolved)
-		}
+	for key, cfg := range dalec.SortedMapIter(artifacts.Opt) {
+		resolved := cfg.ResolveName(key)
+		targetDir := filepath.Join(OptPath, cfg.SubPath)
+		writeInstall(key, targetDir, resolved)
 	}
 
 	if len(artifacts.Libs) > 0 {

--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -31,6 +31,7 @@ const (
 	DocsPath                  = "/usr/share/doc"
 	LibsPath                  = "/usr/lib"
 	LibexecPath               = "/usr/libexec"
+	OptPath                   = "/opt"
 	DataDirsPath              = "/usr/share"
 )
 
@@ -272,6 +273,7 @@ func fixupArtifactPerms(spec *dalec.Spec, target string, cfg *SourcePkgConfig) [
 	checkAndWritePerms(artifacts.Docs, filepath.Join(DocsPath, spec.Name))
 	checkAndWritePerms(artifacts.Libs, LibsPath)
 	checkAndWritePerms(artifacts.Libexec, LibexecPath)
+	checkAndWritePerms(artifacts.Opt, OptPath)
 	checkAndWritePerms(artifacts.DataDirs, DataDirsPath)
 
 	if artifacts.Directories != nil {
@@ -580,6 +582,16 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 		}
 	}
 
+	if len(artifacts.Opt) > 0 {
+		sorted := dalec.SortMapKeys(artifacts.Opt)
+		for _, key := range sorted {
+			cfg := artifacts.Opt[key]
+			resolved := cfg.ResolveName(key)
+			targetDir := filepath.Join(OptPath, cfg.SubPath)
+			writeInstall(key, targetDir, resolved)
+		}
+	}
+
 	if len(artifacts.Libs) > 0 {
 		sorted := dalec.SortMapKeys(artifacts.Libs)
 		for _, key := range sorted {
@@ -713,6 +725,7 @@ func setArtifactOwnershipPostInst(w *bytes.Buffer, spec *dalec.Spec, target stri
 	apply(artifacts.Docs, filepath.Join(DocsPath, spec.Name))
 	apply(artifacts.Libs, LibsPath)
 	apply(artifacts.Libexec, LibexecPath)
+	apply(artifacts.Opt, OptPath)
 	apply(artifacts.DataDirs, DataDirsPath)
 
 	applyDir := func(dirs map[string]dalec.ArtifactDirConfig, root string) {
@@ -769,4 +782,5 @@ func setArtifactCapabilitiesPostInst(w *bytes.Buffer, spec *dalec.Spec, target s
 	apply(artifacts.Binaries, BinariesPath)
 	apply(artifacts.Libs, LibsPath)
 	apply(artifacts.Libexec, LibexecPath)
+	apply(artifacts.Opt, OptPath)
 }

--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -583,9 +583,7 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 	}
 
 	if len(artifacts.Opt) > 0 {
-		sorted := dalec.SortMapKeys(artifacts.Opt)
-		for _, key := range sorted {
-			cfg := artifacts.Opt[key]
+		for key, cfg := range dalec.SortedMapIter(artifacts.Opt) {
 			resolved := cfg.ResolveName(key)
 			targetDir := filepath.Join(OptPath, cfg.SubPath)
 			writeInstall(key, targetDir, resolved)

--- a/packaging/linux/deb/template_rules.go
+++ b/packaging/linux/deb/template_rules.go
@@ -103,6 +103,7 @@ func (w *rulesWrapper) OverridePerms() fmt.Stringer {
 		checkPerms(artifacts.Docs) ||
 		checkPerms(artifacts.Libs) ||
 		checkPerms(artifacts.Libexec) ||
+		checkPerms(artifacts.Opt) ||
 		checkPerms(artifacts.DataDirs) ||
 		checkDirPerms(artifacts.Directories.GetConfig()) ||
 		checkDirPerms(artifacts.Directories.GetState())

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -769,9 +769,7 @@ func (w *specWrapper) getArtifactOwnership() string {
 		}
 	}
 	if artifacts.Opt != nil {
-		optKeys := dalec.SortMapKeys(artifacts.Opt)
-		for _, p := range optKeys {
-			cfg := artifacts.Opt[p]
+		for p, cfg := range dalec.SortedMapIter(artifacts.Opt) {
 			setArtifactOwnership(`/opt`, p, &cfg)
 		}
 	}
@@ -825,9 +823,7 @@ func (w *specWrapper) getArtifactCapabilities() string {
 		}
 	}
 	if artifacts.Opt != nil {
-		optKeys := dalec.SortMapKeys(artifacts.Opt)
-		for _, k := range optKeys {
-			cfg := artifacts.Opt[k]
+		for k, cfg := range dalec.SortedMapIter(artifacts.Opt) {
 			setArtifactCapabilities(`/opt`, k, &cfg)
 		}
 	}
@@ -991,9 +987,7 @@ func (w *specWrapper) Install() fmt.Stringer {
 	}
 
 	if artifacts.Opt != nil {
-		optFileKeys := dalec.SortMapKeys(artifacts.Opt)
-		for _, k := range optFileKeys {
-			opt := artifacts.Opt[k]
+		for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
 			copyArtifact(`%{buildroot}/opt`, k, &opt)
 		}
 	}
@@ -1119,9 +1113,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	}
 
 	if artifacts.Opt != nil {
-		optKeys := dalec.SortMapKeys(artifacts.Opt)
-		for _, k := range optKeys {
-			opt := artifacts.Opt[k]
+		for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
 			targetDir := filepath.Join(`/opt`, opt.SubPath)
 			fullPath := filepath.Join(targetDir, opt.ResolveName(k))
 			capString := dalec.CapabilitiesString(opt.LinuxCapabilities)

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -739,40 +739,18 @@ func (w *specWrapper) getArtifactOwnership() string {
 		}
 	}
 
-	if artifacts.ConfigFiles != nil {
-		configKeys := dalec.SortMapKeys(artifacts.ConfigFiles)
-		for _, c := range configKeys {
-			cfg := artifacts.ConfigFiles[c]
-			setArtifactOwnership(`/%{_sysconfdir}`, c, &cfg)
+	apply := func(root string, artifacts map[string]dalec.ArtifactConfig) {
+		for path, cfg := range dalec.SortedMapIter(artifacts) {
+			setArtifactOwnership(root, path, &cfg)
 		}
 	}
-	if artifacts.DataDirs != nil {
-		dataFileKeys := dalec.SortMapKeys(artifacts.DataDirs)
-		for _, k := range dataFileKeys {
-			df := artifacts.DataDirs[k]
-			setArtifactOwnership(`/%{_datadir}`, k, &df)
-		}
-	}
+
+	apply(`/%{_sysconfdir}`, artifacts.ConfigFiles)
+	apply(`/%{_datadir}`, artifacts.DataDirs)
 	// Directory ownership is handled in getDirectoryOwnership; do not duplicate here.
-	if artifacts.Libs != nil {
-		libs := dalec.SortMapKeys(artifacts.Libs)
-		for _, l := range libs {
-			cfg := artifacts.Libs[l]
-			setArtifactOwnership(`/%{_libdir}`, l, &cfg)
-		}
-	}
-	if artifacts.Binaries != nil {
-		binKeys := dalec.SortMapKeys(artifacts.Binaries)
-		for _, p := range binKeys {
-			cfg := artifacts.Binaries[p]
-			setArtifactOwnership(`/%{_bindir}`, p, &cfg)
-		}
-	}
-	if artifacts.Opt != nil {
-		for p, cfg := range dalec.SortedMapIter(artifacts.Opt) {
-			setArtifactOwnership(`/opt`, p, &cfg)
-		}
-	}
+	apply(`/%{_libdir}`, artifacts.Libs)
+	apply(`/%{_bindir}`, artifacts.Binaries)
+	apply(`/opt`, artifacts.Opt)
 
 	return b.String()
 }
@@ -801,32 +779,16 @@ func (w *specWrapper) getArtifactCapabilities() string {
 		fmt.Fprintf(b, "setcap '%s' %s\n", capString, targetPath)
 	}
 
-	if artifacts.Libs != nil {
-		libs := dalec.SortMapKeys(artifacts.Libs)
-		for _, l := range libs {
-			cfg := artifacts.Libs[l]
-			setArtifactCapabilities(`/%{_libdir}`, l, &cfg)
+	apply := func(root string, artifacts map[string]dalec.ArtifactConfig) {
+		for path, cfg := range dalec.SortedMapIter(artifacts) {
+			setArtifactCapabilities(root, path, &cfg)
 		}
 	}
-	if artifacts.Binaries != nil {
-		binKeys := dalec.SortMapKeys(artifacts.Binaries)
-		for _, p := range binKeys {
-			cfg := artifacts.Binaries[p]
-			setArtifactCapabilities(`/%{_bindir}`, p, &cfg)
-		}
-	}
-	if artifacts.Libexec != nil {
-		libexecKeys := dalec.SortMapKeys(artifacts.Libexec)
-		for _, k := range libexecKeys {
-			cfg := artifacts.Libexec[k]
-			setArtifactCapabilities(`/%{_libexecdir}`, k, &cfg)
-		}
-	}
-	if artifacts.Opt != nil {
-		for k, cfg := range dalec.SortedMapIter(artifacts.Opt) {
-			setArtifactCapabilities(`/opt`, k, &cfg)
-		}
-	}
+
+	apply(`/%{_libdir}`, artifacts.Libs)
+	apply(`/%{_bindir}`, artifacts.Binaries)
+	apply(`/%{_libexecdir}`, artifacts.Libexec)
+	apply(`/opt`, artifacts.Opt)
 
 	return b.String()
 }
@@ -986,10 +948,8 @@ func (w *specWrapper) Install() fmt.Stringer {
 		}
 	}
 
-	if artifacts.Opt != nil {
-		for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
-			copyArtifact(`%{buildroot}/opt`, k, &opt)
-		}
+	for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
+		copyArtifact(`%{buildroot}/opt`, k, &opt)
 	}
 
 	configKeys := dalec.SortMapKeys(artifacts.ConfigFiles)
@@ -1112,16 +1072,14 @@ func (w *specWrapper) Files() fmt.Stringer {
 		}
 	}
 
-	if artifacts.Opt != nil {
-		for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
-			targetDir := filepath.Join(`/opt`, opt.SubPath)
-			fullPath := filepath.Join(targetDir, opt.ResolveName(k))
-			capString := dalec.CapabilitiesString(opt.LinuxCapabilities)
-			if capString != "" && opt.User == "" && opt.Group == "" {
-				fmt.Fprintf(b, "%%caps(%s) %s\n", capString, fullPath)
-			} else {
-				fmt.Fprintln(b, fullPath)
-			}
+	for k, opt := range dalec.SortedMapIter(artifacts.Opt) {
+		targetDir := filepath.Join(`/opt`, opt.SubPath)
+		fullPath := filepath.Join(targetDir, opt.ResolveName(k))
+		capString := dalec.CapabilitiesString(opt.LinuxCapabilities)
+		if capString != "" && opt.User == "" && opt.Group == "" {
+			fmt.Fprintf(b, "%%caps(%s) %s\n", capString, fullPath)
+		} else {
+			fmt.Fprintln(b, fullPath)
 		}
 	}
 

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -244,6 +244,11 @@ func getOwnershipPostRequires(artifacts dalec.Artifacts) string {
 			return out
 		}
 	}
+	for _, cfg := range artifacts.Opt {
+		if cfg.User != "" || cfg.Group != "" {
+			return out
+		}
+	}
 
 	return ""
 }
@@ -763,6 +768,13 @@ func (w *specWrapper) getArtifactOwnership() string {
 			setArtifactOwnership(`/%{_bindir}`, p, &cfg)
 		}
 	}
+	if artifacts.Opt != nil {
+		optKeys := dalec.SortMapKeys(artifacts.Opt)
+		for _, p := range optKeys {
+			cfg := artifacts.Opt[p]
+			setArtifactOwnership(`/opt`, p, &cfg)
+		}
+	}
 
 	return b.String()
 }
@@ -810,6 +822,13 @@ func (w *specWrapper) getArtifactCapabilities() string {
 		for _, k := range libexecKeys {
 			cfg := artifacts.Libexec[k]
 			setArtifactCapabilities(`/%{_libexecdir}`, k, &cfg)
+		}
+	}
+	if artifacts.Opt != nil {
+		optKeys := dalec.SortMapKeys(artifacts.Opt)
+		for _, k := range optKeys {
+			cfg := artifacts.Opt[k]
+			setArtifactCapabilities(`/opt`, k, &cfg)
 		}
 	}
 
@@ -971,6 +990,14 @@ func (w *specWrapper) Install() fmt.Stringer {
 		}
 	}
 
+	if artifacts.Opt != nil {
+		optFileKeys := dalec.SortMapKeys(artifacts.Opt)
+		for _, k := range optFileKeys {
+			opt := artifacts.Opt[k]
+			copyArtifact(`%{buildroot}/opt`, k, &opt)
+		}
+	}
+
 	configKeys := dalec.SortMapKeys(artifacts.ConfigFiles)
 	for _, c := range configKeys {
 		cfg := artifacts.ConfigFiles[c]
@@ -1084,6 +1111,21 @@ func (w *specWrapper) Files() fmt.Stringer {
 			// Use %caps macro if capabilities are set and there's no chown
 			capString := dalec.CapabilitiesString(le.LinuxCapabilities)
 			if capString != "" && le.User == "" && le.Group == "" {
+				fmt.Fprintf(b, "%%caps(%s) %s\n", capString, fullPath)
+			} else {
+				fmt.Fprintln(b, fullPath)
+			}
+		}
+	}
+
+	if artifacts.Opt != nil {
+		optKeys := dalec.SortMapKeys(artifacts.Opt)
+		for _, k := range optKeys {
+			opt := artifacts.Opt[k]
+			targetDir := filepath.Join(`/opt`, opt.SubPath)
+			fullPath := filepath.Join(targetDir, opt.ResolveName(k))
+			capString := dalec.CapabilitiesString(opt.LinuxCapabilities)
+			if capString != "" && opt.User == "" && opt.Group == "" {
 				fmt.Fprintf(b, "%%caps(%s) %s\n", capString, fullPath)
 			} else {
 				fmt.Fprintln(b, fullPath)

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -319,6 +319,30 @@ func TestTemplateSources(t *testing.T) {
 }
 
 func TestTemplate_Artifacts(t *testing.T) {
+	t.Run("test opt ownership and capabilities", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{
+			Artifacts: dalec.Artifacts{
+				Opt: map[string]dalec.ArtifactConfig{
+					"src/helper": {
+						SubPath: "my-package/bin",
+						User:    "myuser",
+						Group:   "mygroup",
+						LinuxCapabilities: []dalec.ArtifactCapability{
+							{Name: "cap_net_bind_service", Effective: true, Permitted: true},
+						},
+					},
+				},
+			},
+		}}
+
+		assert.Equal(t, w.Post().String(), `%post
+chown -R myuser /opt/my-package/bin/helper
+chgrp -R mygroup /opt/my-package/bin/helper
+setcap 'cap_net_bind_service=ep' /opt/my-package/bin/helper
+
+`)
+	})
 
 	t.Run("test systemd post", func(t *testing.T) {
 		w := &specWrapper{Spec: &dalec.Spec{

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -3420,140 +3420,19 @@ func Value() string {
 		})
 	})
 
-	t.Run("test libexec and opt file installation", func(t *testing.T) {
+	t.Run("test libexec file installation", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
+		testArtifactFileInstallation(ctx, t, testConfig, "/usr/libexec", func(cfg map[string]dalec.ArtifactConfig) dalec.Artifacts {
+			return dalec.Artifacts{Libexec: cfg}
+		})
+	})
 
-		spec := &dalec.Spec{
-			Name:        "libexec-test",
-			Version:     "0.0.1",
-			Revision:    "1",
-			License:     "MIT",
-			Website:     "https://github.com/project-dalec/dalec",
-			Vendor:      "Dalec",
-			Packager:    "Dalec",
-			Description: "Should install specified data files",
-			Sources: map[string]dalec.Source{
-				"no_name_no_subpath": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o755,
-						},
-					},
-				},
-				"name_only": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o755,
-						},
-					},
-				},
-				"name_and_subpath": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o755,
-						},
-					},
-				},
-				"subpath_only": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o755,
-						},
-					},
-				},
-				"nested_subpath": {
-					Inline: &dalec.SourceInline{
-						File: &dalec.SourceInlineFile{
-							Contents:    "#!/usr/bin/env bash\necho hello world",
-							Permissions: 0o755,
-						},
-					},
-				},
-			},
-			Build: dalec.ArtifactBuild{},
-			Artifacts: dalec.Artifacts{
-				Binaries: map[string]dalec.ArtifactConfig{
-					"no_name_no_subpath": {},
-				},
-				Libexec: map[string]dalec.ArtifactConfig{
-					"no_name_no_subpath": {},
-					"name_only": {
-						Name: "this_is_the_name_only",
-					},
-					"name_and_subpath": {
-						SubPath: "subpath",
-						Name:    "custom_name",
-					},
-					"subpath_only": {
-						SubPath: "custom",
-					},
-					"nested_subpath": {
-						SubPath: "libexec-test/abcdefg",
-					},
-				},
-				Opt: map[string]dalec.ArtifactConfig{
-					"no_name_no_subpath": {},
-					"name_only": {
-						Name: "this_is_the_name_only",
-					},
-					"name_and_subpath": {
-						SubPath: "subpath",
-						Name:    "custom_name",
-					},
-					"subpath_only": {
-						SubPath: "custom",
-					},
-					"nested_subpath": {
-						SubPath: "opt-test/abcdefg",
-					},
-				},
-			},
-		}
-
-		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
-			req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
-			res := solveT(ctx, t, client, req)
-
-			ref, err := res.SingleRef()
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/no_name_no_subpath", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/this_is_the_name_only", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/subpath/custom_name", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/custom/subpath_only", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/libexec-test/abcdefg/nested_subpath", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/opt/no_name_no_subpath", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/opt/this_is_the_name_only", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/opt/subpath/custom_name", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/opt/custom/subpath_only", 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := validatePathAndPermissions(ctx, ref, "/opt/opt-test/abcdefg/nested_subpath", 0o755); err != nil {
-				t.Fatal(err)
-			}
+	t.Run("test opt file installation", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testArtifactFileInstallation(ctx, t, testConfig, "/opt", func(cfg map[string]dalec.ArtifactConfig) dalec.Artifacts {
+			return dalec.Artifacts{Opt: cfg}
 		})
 	})
 
@@ -3919,6 +3798,74 @@ func Value() string {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
 		testArtifactCapabilities(ctx, t, testConfig)
+	})
+}
+
+func testArtifactFileInstallation(ctx context.Context, t *testing.T, testConfig testLinuxConfig, root string, setArtifacts func(map[string]dalec.ArtifactConfig) dalec.Artifacts) {
+	sources := make(map[string]dalec.Source, 5)
+	for _, name := range []string{"no_name_no_subpath", "name_only", "name_and_subpath", "subpath_only", "nested_subpath"} {
+		sources[name] = dalec.Source{
+			Inline: &dalec.SourceInline{
+				File: &dalec.SourceInlineFile{
+					Contents:    "#!/usr/bin/env bash\necho hello world",
+					Permissions: 0o755,
+				},
+			},
+		}
+	}
+
+	artifacts := setArtifacts(map[string]dalec.ArtifactConfig{
+		"no_name_no_subpath": {},
+		"name_only": {
+			Name: "this_is_the_name_only",
+		},
+		"name_and_subpath": {
+			SubPath: "subpath",
+			Name:    "custom_name",
+		},
+		"subpath_only": {
+			SubPath: "custom",
+		},
+		"nested_subpath": {
+			SubPath: "artifact-test/abcdefg",
+		},
+	})
+	artifacts.Binaries = map[string]dalec.ArtifactConfig{"no_name_no_subpath": {}}
+
+	spec := &dalec.Spec{
+		Name:        "artifact-file-installation-test",
+		Version:     "0.0.1",
+		Revision:    "1",
+		License:     "MIT",
+		Website:     "https://github.com/project-dalec/dalec",
+		Vendor:      "Dalec",
+		Packager:    "Dalec",
+		Description: "Should install specified artifact files",
+		Sources:     sources,
+		Build:       dalec.ArtifactBuild{},
+		Artifacts:   artifacts,
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+		req := newSolveRequest(withBuildTarget(testConfig.Target.Container), withSpec(ctx, t, spec))
+		res := solveT(ctx, t, client, req)
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, path := range []string{
+			"no_name_no_subpath",
+			"this_is_the_name_only",
+			"subpath/custom_name",
+			"custom/subpath_only",
+			"artifact-test/abcdefg/nested_subpath",
+		} {
+			if err := validatePathAndPermissions(ctx, ref, filepath.Join(root, path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
 	})
 }
 
@@ -5903,7 +5850,7 @@ echo "This is a third test binary"
 					{
 						Command: "stat -c '%U' /opt/test-capabilities/ping-opt",
 						Stdout: dalec.CheckOutput{
-							Equals: "testuser\n",
+							Contains: []string{"testuser\n"},
 						},
 					},
 				},

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -3420,7 +3420,7 @@ func Value() string {
 		})
 	})
 
-	t.Run("test libexec file installation", func(t *testing.T) {
+	t.Run("test libexec and opt file installation", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)
 
@@ -3496,6 +3496,22 @@ func Value() string {
 						SubPath: "libexec-test/abcdefg",
 					},
 				},
+				Opt: map[string]dalec.ArtifactConfig{
+					"no_name_no_subpath": {},
+					"name_only": {
+						Name: "this_is_the_name_only",
+					},
+					"name_and_subpath": {
+						SubPath: "subpath",
+						Name:    "custom_name",
+					},
+					"subpath_only": {
+						SubPath: "custom",
+					},
+					"nested_subpath": {
+						SubPath: "opt-test/abcdefg",
+					},
+				},
 			},
 		}
 
@@ -3521,6 +3537,21 @@ func Value() string {
 				t.Fatal(err)
 			}
 			if err := validatePathAndPermissions(ctx, ref, "/usr/libexec/libexec-test/abcdefg/nested_subpath", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/opt/no_name_no_subpath", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/opt/this_is_the_name_only", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/opt/subpath/custom_name", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/opt/custom/subpath_only", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePathAndPermissions(ctx, ref, "/opt/opt-test/abcdefg/nested_subpath", 0o755); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -5808,6 +5808,20 @@ echo "This is a third test binary"
 					},
 				},
 			},
+			Opt: map[string]dalec.ArtifactConfig{
+				"/tmp/ping2": {
+					Name:    "ping-opt",
+					SubPath: "test-capabilities",
+					User:    "testuser",
+					LinuxCapabilities: []dalec.ArtifactCapability{
+						{
+							Name:      "cap_net_raw",
+							Effective: true,
+							Permitted: true,
+						},
+					},
+				},
+			},
 			Users: []dalec.AddUserConfig{
 				{
 					Name: "testuser",
@@ -5876,6 +5890,20 @@ echo "This is a third test binary"
 						Command: "stat -c '%G' /usr/bin/ping3",
 						Stdout: dalec.CheckOutput{
 							Contains: []string{"testgroup\n"},
+						},
+					},
+					{
+						Command: "getcap /opt/test-capabilities/ping-opt",
+						Stdout: dalec.CheckOutput{
+							Contains: []string{
+								"/opt/test-capabilities/ping-opt", "cap_net_raw", "ep",
+							},
+						},
+					},
+					{
+						Command: "stat -c '%U' /opt/test-capabilities/ping-opt",
+						Stdout: dalec.CheckOutput{
+							Equals: "testuser\n",
 						},
 					},
 				},

--- a/website/docs/artifacts.md
+++ b/website/docs/artifacts.md
@@ -87,6 +87,30 @@ artifacts:
 You may use a trailing wildcard to specify multiple binaries in a directory,
 though behavior may differ between different OS's/distros.
 
+### Opt
+
+Opt files are installed under `/opt`. Dalec does not add a package-specific
+directory, so use `subpath` to select the desired layout. This supports both
+package-specific paths such as `/opt/<package>/bin` and shared paths such as
+`/opt/bin`.
+
+Opt files are a mapping of file path to [artifact configuration](#artifact-configuration).
+For example:
+
+```yaml
+name: my_package
+
+artifacts:
+  opt:
+    src/my_bin:
+      subpath: my_package/bin
+    src/helper:
+      subpath: bin
+```
+
+This installs `my_bin` as `/opt/my_package/bin/my_bin` and `helper` as
+`/opt/bin/helper`.
+
 ### Manpages
 
 Manpages is short for manual pages.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds /opt as a supported artifact destination, allowing packages to install files into layouts such as /opt/<package>/bin or /opt/bin

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
