### PR TITLE
feat(rpm): add SUSE Linux Enterprise 15 (sles15) target

### DIFF
--- a/targets/linux/rpm/distro/distro.go
+++ b/targets/linux/rpm/distro/distro.go
@@ -42,6 +42,14 @@ type Config struct {
 
 	// erofs-utils 1.7+ is required for tar support.
 	SysextSupported bool
+
+	// CrossArchInstallUnsupported indicates the distro's package manager cannot
+	// install packages into a foreign-architecture rootfs. The cross-arch worker
+	// path relies on dnf's --forcearch/--installroot combination, which zypper
+	// (SUSE/openSUSE) does not support. When true, worker builds for a
+	// non-native target platform fail fast with a clear error instead of
+	// silently invoking dnf.
+	CrossArchInstallUnsupported bool
 }
 
 func (cfg *Config) PackageCacheMount(root string) llb.RunOption {

--- a/targets/linux/rpm/distro/worker.go
+++ b/targets/linux/rpm/distro/worker.go
@@ -157,6 +157,14 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 		).Root()
 	}
 
+	// The cross-arch path below installs into a foreign-arch rootfs using dnf's
+	// --forcearch/--installroot. Package managers that lack that capability
+	// (e.g. zypper) cannot cross-compile this way, so fail fast rather than
+	// silently invoking dnf on an image that does not have it.
+	if cfg.CrossArchInstallUnsupported {
+		return dalec.ErrorState(llb.Scratch(), errors.Errorf("cross-architecture builds are not supported for %s", cfg.FullName))
+	}
+
 	targetArch, err := rpmArchFromPlatform(targetPlat)
 	if err != nil {
 		return dalec.ErrorState(llb.Scratch(), err)
@@ -199,6 +207,10 @@ func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsO
 			dalec.WithConstraints(append(opts, llb.Platform(targetPlat))...),
 			cfg.Install([]string{"erofs-utils"}, installOpts...),
 		).Root()
+	}
+
+	if cfg.CrossArchInstallUnsupported {
+		return dalec.ErrorState(llb.Scratch(), errors.Errorf("cross-architecture sysext builds are not supported for %s", cfg.FullName))
 	}
 
 	targetArch, err := rpmArchFromPlatform(targetPlat)

--- a/targets/linux/rpm/distro/zypper_install.go
+++ b/targets/linux/rpm/distro/zypper_install.go
@@ -1,0 +1,93 @@
+package distro
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+)
+
+// zypperRepoPlatform describes where zypper (SUSE/openSUSE) expects repository
+// configuration and signing keys to live. It mirrors dnfRepoPlatform but points
+// at zypper's repo directory (/etc/zypp/repos.d) instead of /etc/yum.repos.d.
+var zypperRepoPlatform = dalec.RepoPlatformConfig{
+	ConfigRoot: "/etc/zypp/repos.d",
+	GPGKeyRoot: "/etc/pki/rpm-gpg",
+	ConfigExt:  ".repo",
+}
+
+// ZypperInstall installs packages using zypper, the package manager used by
+// SUSE Linux Enterprise and openSUSE. It satisfies the PackageInstaller
+// signature so it can be plugged into a distro Config's InstallFunc, and it
+// reuses the shared dnfInstallConfig option plumbing (keys, root, mounts,
+// constraints) so callers use the same DnfInstallOpt set as the dnf/tdnf paths.
+//
+// releaseVer is accepted for signature compatibility but is unused: unlike dnf,
+// zypper does not take a --releasever flag (the release is fixed by the base
+// image).
+func ZypperInstall(cfg *dnfInstallConfig, releaseVer string, pkgs []string) llb.RunOption {
+	return zypperCommand(cfg, append([]string{"install"}, pkgs...), nil)
+}
+
+func zypperCommand(cfg *dnfInstallConfig, zypperSubCmd []string, zypperArgs []string) llb.RunOption {
+	const importKeysPath = "/tmp/dalec/internal/zypper/import-keys.sh"
+
+	// zypper cannot install into a foreign-architecture rootfs the way dnf can
+	// (it has no --forcearch). cfg.root is only set for cross-arch/rootfs
+	// installs, which are guarded out for zypper-based distros at the worker
+	// level (Config.CrossArchInstallUnsupported), so this is a best-effort
+	// native rootfs install only.
+	rootFlag := ""
+	if cfg.root != "" {
+		rootFlag = "--root " + cfg.root + " "
+	}
+
+	// Global zypper flags: run unattended and auto-import repo signing keys.
+	globalFlags := "--non-interactive --gpg-auto-import-keys " + rootFlag
+	// Install-time flags: accept licenses non-interactively and tolerate the
+	// vendor/version differences that arise when pulling from the Microsoft
+	// prod repos alongside the base SUSE repos.
+	installFlags := "--auto-agree-with-licenses --allow-downgrade --allow-vendor-change"
+
+	installScriptDt := `#!/usr/bin/env bash
+set -eux -o pipefail
+
+import_keys_path="` + importKeysPath + `"
+global_flags="` + globalFlags + `"
+zypper_sub_cmd="` + strings.Join(zypperSubCmd, " ") + `"
+install_flags="` + installFlags + `"
+
+if [ -x "$import_keys_path" ]; then
+	"$import_keys_path"
+fi
+
+zypper $global_flags $zypper_sub_cmd $install_flags "${@}"
+`
+	var runOpts []llb.RunOption
+
+	installScript := llb.Scratch().File(llb.Mkfile("install.sh", 0o700, []byte(installScriptDt)), cfg.constraints...)
+	const installScriptPath = "/tmp/dalec/internal/zypper/install.sh"
+
+	runOpts = append(runOpts, llb.AddMount(installScriptPath, installScript, llb.SourcePath("install.sh"), llb.Readonly))
+
+	// If we have keys to import in order to access a repo, mount a script that
+	// imports them into the rpm keyring (zypper uses the same rpm keyring).
+	// zypper's --gpg-auto-import-keys covers most cases, but importing up front
+	// keeps parity with the dnf path for repos that reference keys via file://.
+	if len(cfg.keys) > 0 {
+		importScript := importGPGScript(cfg.keys)
+		runOpts = append(runOpts, llb.AddMount(importKeysPath,
+			llb.Scratch().File(llb.Mkfile("/import-keys.sh", 0755, []byte(importScript)), cfg.constraints...),
+			llb.Readonly,
+			llb.SourcePath("/import-keys.sh")))
+	}
+
+	cmd := make([]string, 0, len(zypperArgs)+1)
+	cmd = append(cmd, installScriptPath)
+	cmd = append(cmd, zypperArgs...)
+
+	runOpts = append(runOpts, llb.Args(cmd))
+	runOpts = append(runOpts, cfg.mounts...)
+
+	return dalec.WithRunOptions(runOpts...)
+}

--- a/targets/linux/rpm/suse/common.go
+++ b/targets/linux/rpm/suse/common.go
@@ -1,0 +1,52 @@
+package suse
+
+import (
+	"github.com/project-dalec/dalec"
+)
+
+// builderPackages are the packages needed inside the worker image to build an
+// rpm on SUSE. rpm-build provides rpmbuild; the rest are the standard build
+// toolchain. Individual specs add their own build dependencies on top of these.
+var builderPackages = []string{
+	"rpm-build",
+	"binutils",
+	"gcc",
+	"make",
+	"tar",
+	"gzip",
+	"ca-certificates",
+}
+
+// defaultPlatformConfig tells dalec where zypper expects repository
+// configuration and signing keys to live. zypper reads repos from
+// /etc/zypp/repos.d (not /etc/yum.repos.d like dnf).
+var defaultPlatformConfig = dalec.RepoPlatformConfig{
+	ConfigRoot: "/etc/zypp/repos.d",
+	GPGKeyRoot: "/etc/pki/rpm-gpg",
+	ConfigExt:  ".repo",
+}
+
+func basePackages(name string) []dalec.Spec {
+	const (
+		base    = "dalec-base-"
+		license = "Apache-2.0"
+
+		version = "0.0.1"
+		rev     = "1"
+	)
+
+	return []dalec.Spec{
+		{
+			Name:        base + name,
+			Version:     version,
+			Revision:    rev,
+			License:     license,
+			Description: "DALEC base packages for " + name,
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: dalec.PackageDependencyList{
+					"tzdata": {},
+				},
+			},
+		},
+	}
+}

--- a/targets/linux/rpm/suse/sles15.go
+++ b/targets/linux/rpm/suse/sles15.go
@@ -1,0 +1,38 @@
+package suse
+
+import (
+	"github.com/project-dalec/dalec/targets/linux/rpm/distro"
+)
+
+const (
+	// SLES15TargetKey is the target name recipes use, e.g. "sles15/rpm".
+	SLES15TargetKey   = "sles15"
+	zypperCacheSLES15 = "sles15-zypper-cache"
+
+	// sles15Ref is the image ref used for the base worker image.
+	sles15Ref      = "registry.suse.com/bci/bci-base:15.6"
+	sles15FullName = "SUSE Linux Enterprise 15"
+	// sles15WorkerContextName is the build context name that can be used to look
+	// up a caller-provided worker image instead of building one from sles15Ref.
+	sles15WorkerContextName = "dalec-sles15-worker"
+)
+
+// ConfigSLES15 is the dalec distro configuration for SUSE Linux Enterprise 15.
+// It builds rpms inside a SUSE base image using zypper. Cross-architecture
+// builds are not supported because zypper lacks dnf's --forcearch/--installroot
+// mechanism.
+var ConfigSLES15 = &distro.Config{
+	ImageRef:   sles15Ref,
+	ContextRef: sles15WorkerContextName,
+
+	CacheName: zypperCacheSLES15,
+	CacheDir:  []string{"/var/cache/zypp"},
+
+	ReleaseVer:                  "15",
+	BuilderPackages:             builderPackages,
+	BasePackages:                basePackages(SLES15TargetKey),
+	RepoPlatformConfig:          &defaultPlatformConfig,
+	InstallFunc:                 distro.ZypperInstall,
+	CrossArchInstallUnsupported: true,
+	FullName:                    sles15FullName,
+}

--- a/targets/plugin/init.go
+++ b/targets/plugin/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-dalec/dalec/targets/linux/rpm/almalinux"
 	"github.com/project-dalec/dalec/targets/linux/rpm/azlinux"
 	"github.com/project-dalec/dalec/targets/linux/rpm/rockylinux"
+	"github.com/project-dalec/dalec/targets/linux/rpm/suse"
 	"github.com/project-dalec/dalec/targets/windows"
 )
 
@@ -39,6 +40,8 @@ func init() {
 
 	registerRoutes(azlinux.AzLinux3TargetKey, azlinux.Azlinux3Config.Routes)
 	registerRoutes(azlinux.AzLinux4TargetKey, azlinux.Azlinux4Config.Routes)
+
+	registerRoutes(suse.SLES15TargetKey, suse.ConfigSLES15.Routes)
 
 	registerRoutes(flatcar.TargetKey, flatcar.DefaultConfig.Routes)
 

--- a/test/target_suse_test.go
+++ b/test/target_suse_test.go
@@ -1,0 +1,195 @@
+package test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/targets/linux/rpm/distro"
+	"github.com/project-dalec/dalec/targets/linux/rpm/suse"
+)
+
+func TestSLES15(t *testing.T) {
+	t.Parallel()
+
+	ctx := startTestSpan(baseCtx, t)
+	cfg := testLinuxConfig{
+		Target: targetConfig{
+			Key:       "sles15",
+			Package:   "sles15/rpm",
+			Container: "sles15/container",
+			DepsOnly:  "sles15/container/depsonly",
+			Worker:    "sles15/worker",
+			FormatDepEqual: func(v, _ string) string {
+				return v
+			},
+			// SUSE rpms carry no %{?dist} tag, so sign-file names have no dist component.
+			ListExpectedSignFiles: suseListSignFiles,
+			PackageOverrides: map[string]string{
+				"rust":  "rust cargo",
+				"bazel": noPackageAvailable,
+			},
+		},
+		LicenseDir: "/usr/share/licenses",
+		SystemdDir: struct {
+			Units   string
+			Targets string
+		}{
+			Units:   "/usr/lib/systemd",
+			Targets: "/etc/systemd/system",
+		},
+		Libdir: "/usr/lib64",
+		Worker: workerConfig{
+			ContextName:    suse.ConfigSLES15.ContextRef,
+			CreateRepo:     createZypperRepo(suse.ConfigSLES15),
+			SignRepo:       signRepoZypper,
+			TestRepoConfig: azlinuxTestRepoConfig,
+		},
+		Release: OSRelease{
+			ID:        "sles",
+			VersionID: "15.6",
+		},
+		SupportsGomodVersionUpdate: true,
+		// SUSE workers only support native-architecture builds
+		// (CrossArchInstallUnsupported), so the cross-platform subtests
+		// auto-skip when only the native platform is listed.
+		Platforms: []ocispecs.Platform{
+			{OS: "linux", Architecture: "amd64"},
+		},
+		PackageOutputPath: suseTargetOutputPath,
+	}
+	testLinuxDistro(ctx, t, cfg)
+	testSuseExtra(ctx, t, cfg, suse.ConfigSLES15.ImageRef)
+}
+
+func testSuseExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig, distroImageRef string) {
+	testSignedRPMCustomBaseImage(ctx, t, cfg.Target, distroImageRef)
+}
+
+// suseTargetOutputPath produces the built-rpm path for SUSE. Unlike the
+// el9/azl3 distros, SUSE rpms have an empty %{?dist} tag, so there is no dist
+// component in the file name.
+func suseTargetOutputPath(spec *dalec.Spec, platform ocispecs.Platform) string {
+	arch := suseRpmArch(platform.Architecture)
+	return fmt.Sprintf("/RPMS/%s/%s-%s-%s.%s.rpm", arch, spec.Name, spec.Version, spec.Revision, arch)
+}
+
+// suseListSignFiles lists the rpm artifacts expected to be signed for SUSE.
+// SUSE has no %{?dist} tag, so the file names contain no dist component.
+func suseListSignFiles(spec *dalec.Spec, platform ocispecs.Platform) []string {
+	base := fmt.Sprintf("%s-%s-%s", spec.Name, spec.Version, spec.Revision)
+	arch := suseRpmArch(platform.Architecture)
+
+	return []string{
+		filepath.Join("SRPMS", fmt.Sprintf("%s.src.rpm", base)),
+		filepath.Join("RPMS", arch, fmt.Sprintf("%s.%s.rpm", base, arch)),
+	}
+}
+
+func suseRpmArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "aarch64"
+	default:
+		return arch
+	}
+}
+
+// createZypperRepo mirrors createYumRepo for zypper-based SUSE workers. It
+// installs createrepo_c (SUSE has no bare "createrepo" package, but the
+// createrepo_c package also provides a /usr/bin/createrepo compatibility
+// symlink) and lays the local repo file under /etc/zypp/repos.d.
+func createZypperRepo(installer *distro.Config) func(rpms llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
+	return func(rpms llb.State, repoPath string, opts ...llb.StateOption) llb.StateOption {
+		return func(in llb.State) llb.State {
+			suffixBytes := sha256.Sum256([]byte(repoPath))
+			suffix := hex.EncodeToString(suffixBytes[:])[:8]
+			localRepo := []byte(`
+[Local-` + suffix + `]
+name=Local Repository
+baseurl=file://` + repoPath + `
+gpgcheck=0
+priority=0
+enabled=1
+metadata_expire=0
+`)
+
+			pg := dalec.ProgressGroup("Install local repo for test")
+
+			installOpts := []distro.DnfInstallOpt{
+				distro.DnfInstallWithConstraints([]llb.ConstraintsOpt{pg}),
+			}
+
+			withRepos := in.
+				Run(installer.Install([]string{"createrepo_c"}, installOpts...), pg).
+				File(llb.Mkdir(filepath.Join(repoPath, "RPMS"), 0o755, llb.WithParents(true)), pg).
+				File(llb.Mkdir(filepath.Join(repoPath, "SRPMS"), 0o755), pg).
+				File(llb.Mkfile("/etc/zypp/repos.d/local-"+suffix+".repo", 0o644, localRepo), pg).
+				Run(
+					llb.AddMount("/tmp/st", rpms, llb.Readonly),
+					dalec.ShArgsf("cp /tmp/st/RPMS/$(uname -m)/* %s/RPMS/ && cp /tmp/st/SRPMS/* %s/SRPMS", repoPath, repoPath),
+					pg,
+				).
+				Run(dalec.ShArgs("createrepo --compatibility "+repoPath),
+					pg,
+				).Root()
+
+			for _, opt := range opts {
+				withRepos = withRepos.With(opt)
+			}
+
+			return withRepos
+		}
+	}
+}
+
+// signRepoZypper mirrors signRepoDnf for SUSE. zypper verifies both package and
+// repo-metadata signatures. SUSE provides rpmsign via the rpm-build package
+// (there is no rpm-sign package), and createrepo via createrepo_c.
+func signRepoZypper(gpgKey llb.State, repoPath string) llb.StateOption {
+	// key should be a state that has a public key under /public.key
+	return func(in llb.State) llb.State {
+		scriptDt := `
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+if ! command -v rpmsign &> /dev/null; then
+	zypper --non-interactive install rpm-build createrepo_c gpg2
+fi
+
+gpg --import < /tmp/gpg/private.key
+ID=$(gpg --list-keys --keyid-format LONG | grep -B 2 'test@example.com' | grep 'pub' | awk '{print $2}' | cut -d'/' -f2)
+
+echo "%_gpg_name $ID" > ~/.rpmmacros
+find ` + repoPath + `/RPMS -name "*.rpm" -exec rpmsign --addsign {} \;
+
+# Regenerate (and sign) repo metadata
+rm -rf ` + repoPath + `/repodata
+createrepo --compatibility ` + repoPath + `
+gpg --detach-sign --default-key "$ID" --armor --yes ` + repoPath + `/repodata/repomd.xml
+`
+
+		pg := dalec.ProgressGroup("in-signing-script")
+
+		script := llb.Scratch().File(
+			llb.Mkfile("/script.sh", 0o755, []byte(scriptDt)),
+			pg,
+		)
+
+		return in.Run(
+			llb.AddMount("/tmp/signing", script, llb.Readonly),
+			llb.AddMount("/tmp/gpg", gpgKey, llb.Readonly),
+			dalec.ShArgs("/tmp/signing/script.sh"),
+			pg,
+		).Root()
+	}
+}

--- a/website/docs/examples/targets.md
+++ b/website/docs/examples/targets.md
@@ -88,6 +88,13 @@ rockylinux9/rpm/debug/buildroot  Outputs an rpm buildroot suitable for passing t
 rockylinux9/rpm/debug/sources    Outputs all the sources specified in the spec file in the format given to rpmbuild.
 rockylinux9/rpm/debug/spec       Outputs the generated RPM spec file
 rockylinux9/worker               Builds the base worker image responsible for building the rpm
+sles15/container (default)       Builds a container image for SUSE Linux Enterprise 15
+sles15/container/depsonly        Builds a container image with only the runtime dependencies installed.
+sles15/rpm                       Builds an rpm and src.rpm.
+sles15/rpm/debug/buildroot       Outputs an rpm buildroot suitable for passing to rpmbuild.
+sles15/rpm/debug/sources         Outputs all the sources specified in the spec file in the format given to rpmbuild.
+sles15/rpm/debug/spec            Outputs the generated RPM spec file
+sles15/worker                    Builds the base worker image responsible for building the rpm
 trixie/container                 Builds a container image.
 trixie/deb (default)             Builds a deb package.
 trixie/dsc                       Builds a Debian source package.

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -26,6 +26,7 @@ DALEC includes a number of built-in targets that you can either use in your spec
 - `almalinux8` - AlmaLinux 8 (v0.13)
 - `rockylinux8` - Rocky Linux 8 (v0.13)
 - `rockylinux9` - Rocky Linux 9 (v0.13)
+- `sles15` - SUSE Linux Enterprise 15 (native-architecture builds only)
 
 When specifying a "target" to `docker build --target=<target>` DALEC treats
 `<target>` as a route (much like an HTTP path) and each of the above mentioned


### PR DESCRIPTION
## What

Adds **SUSE Linux Enterprise 15 (`sles15`)** as a new zypper-based RPM distro target, mirroring the existing `rockylinux` target structure.

## Changes

- **`targets/linux/rpm/suse`** — `ConfigSLES15` distro config (`registry.suse.com/bci/bci-base:15.6`, target key `sles15`) + base/builder packages.
- **`targets/linux/rpm/distro/zypper_install.go`** — `ZypperInstall` install func: `zypper --non-interactive --gpg-auto-import-keys`, `--auto-agree-with-licenses --allow-downgrade --allow-vendor-change`, GPG key import.
- **`distro.Config.CrossArchInstallUnsupported`** + fail-fast guards in `workerWithBuildPlatform`/`SysextWorker` — SUSE workers support **native-architecture builds only**.
- **`targets/plugin/init.go`** — register the `sles15` routes.
- **`test/target_suse_test.go`** — `TestSLES15` integration test with SUSE-specific helpers.
- **`website/docs/targets.md`**, **`website/docs/examples/targets.md`** — document the new target.

## SUSE-specific notes (empirically verified against the BCI base image)

- **No `%{?dist}` tag** — `rpm --eval '%{?dist}'` is empty on SUSE (unlike `el9`/`azl3`). The test output-path and sign-file helpers omit the dist component to avoid a double-dot in file names.
- **`createrepo`** — SUSE has no bare `createrepo` package; `createZypperRepo` installs `createrepo_c`, which also provides a `/usr/bin/createrepo` compatibility symlink (so `createrepo --compatibility` works).
- **`rpmsign`** — comes from `rpm-build` (there is no `rpm-sign` package on SUSE); `signRepoZypper` installs `rpm-build`, `createrepo_c`, and `gpg2` via zypper.
- **Native-only** — `TestSLES15` lists the amd64 platform only, so the cross-platform subtests auto-skip (consistent with `CrossArchInstallUnsupported`).

## Validation

- `go build ./...`, `go vet ./test/ ./targets/...`, and `gofmt` are clean.
- Short unit suite (`go test --test.short ./targets/linux/rpm/...`) passes.
- The full `TestSLES15` integration run (buildkit + SUSE BCI/MCR image pulls) is exercised in CI.