### PR TITLE
Add hugo version to netlify build environment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,6 +44,7 @@ jobs:
             proxy.golang.org:443
             storage.googleapis.com:443
             sum.golang.org:443
+            cdn.jsdelivr.net:443
 
       - name: Build Hugo image
         run: docker build --tag dalec-hugo .

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,12 @@
   command = "hugo --gc --minify"
   publish = "public"
 
+[build.environment]
+  HUGO_VERSION = "0.164.0"
+
 [context.deploy-preview]
   command = 'hugo --gc --minify --baseURL "$DEPLOY_PRIME_URL"'
 
 [context.branch-deploy]
   command = 'hugo --gc --minify --baseURL "$DEPLOY_PRIME_URL"'
+

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -9,7 +9,7 @@ disableKinds:
 module:
   hugoVersion:
     extended: true
-    min: 0.146.0
+    min: 0.164.0
   imports:
     - path: github.com/imfing/hextra
 


### PR DESCRIPTION
I'm not sure how the PR that introduced the netlify.toml was able to build the preview site... but for sure its broken on all PR's now.

Netlify detects that it needs hugo based on the env being set in the build env.