### PR TITLE
replace `github.com/kjk/lzma`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	pault.ag/go/topsort v0.1.1 // indirect
 )
+
+replace github.com/kjk/lzma => salsa.debian.org/go-team/packages/golang-github-kjk-lzma v0.0.0-20211201122250-73cfdbf7cdfb

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcI
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d h1:RnWZeH8N8KXfbwMTex/KKMYMj0FJRCF6tQubUuQ02GM=
-github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -320,3 +318,5 @@ pault.ag/go/debian v0.18.0 h1:nr0iiyOU5QlG1VPnhZLNhnCcHx58kukvBJp+dvaM6CQ=
 pault.ag/go/debian v0.18.0/go.mod h1:JFl0XWRCv9hWBrB5MDDZjA5GSEs1X3zcFK/9kCNIUmE=
 pault.ag/go/topsort v0.1.1 h1:L0QnhUly6LmTv0e3DEzbN2q6/FGgAcQvaEw65S53Bg4=
 pault.ag/go/topsort v0.1.1/go.mod h1:r1kc/L0/FZ3HhjezBIPaNVhkqv8L0UJ9bxRuHRVZ0q4=
+salsa.debian.org/go-team/packages/golang-github-kjk-lzma v0.0.0-20211201122250-73cfdbf7cdfb h1:lSwtd5gBoUMsJISs1FrXW5iPAaSDrQAZtRU+TBDC2Wo=
+salsa.debian.org/go-team/packages/golang-github-kjk-lzma v0.0.0-20211201122250-73cfdbf7cdfb/go.mod h1:3EeEYXg640guYvDvi9NHFE0ZkEHNbuJsVXCdLuF4XuY=


### PR DESCRIPTION
**What this PR does / why we need it**:
The repository for `github.com/kjk/lzma` was deleted and we indirectly have it as a dependency. This caused `go list -m all` to fail and IDE support for this project to break. This PR replaces that dependency with a fork of it maintained by Debian.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1171

**Special notes for your reviewer**:
N/A
