### PR TITLE
Drop dependency on pault.ag/go/debian

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	gotest.tools/v3 v3.5.2
-	pault.ag/go/debian v0.18.0
 )
 
 require (
@@ -68,7 +67,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
-	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
@@ -84,7 +82,6 @@ require (
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.69.0 // indirect
@@ -103,5 +100,4 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	pault.ag/go/topsort v0.1.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcI
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d h1:RnWZeH8N8KXfbwMTex/KKMYMj0FJRCF6tQubUuQ02GM=
-github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -209,8 +207,6 @@ github.com/vearutop/dynhist-go v1.2.4 h1:EVGgvW9+F7fQb4ZyyZV8znqo4JiWx6FyvVFmGrf
 github.com/vearutop/dynhist-go v1.2.4/go.mod h1:pZcCNVJxPDn7+Q/UYVGOcyrYupnh9tWNmr5uKwyHYNg=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -314,7 +310,3 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
-pault.ag/go/debian v0.18.0 h1:nr0iiyOU5QlG1VPnhZLNhnCcHx58kukvBJp+dvaM6CQ=
-pault.ag/go/debian v0.18.0/go.mod h1:JFl0XWRCv9hWBrB5MDDZjA5GSEs1X3zcFK/9kCNIUmE=
-pault.ag/go/topsort v0.1.1 h1:L0QnhUly6LmTv0e3DEzbN2q6/FGgAcQvaEw65S53Bg4=
-pault.ag/go/topsort v0.1.1/go.mod h1:r1kc/L0/FZ3HhjezBIPaNVhkqv8L0UJ9bxRuHRVZ0q4=

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +40,6 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
-	"pault.ag/go/debian/deb"
 )
 
 type workerConfig struct {
@@ -5186,28 +5186,40 @@ func testTargetPlatform(ctx context.Context, t *testing.T, cfg testLinuxConfig) 
 	})
 }
 
-func extractDebControlFile(t *testing.T, f io.ReaderAt) io.ReadCloser {
+// extractDebControlFile reads the control member from a .deb, which is a Unix
+// ar archive: an 8-byte magic followed by entries, each with a 60-byte header
+// and payload padded to a 2-byte boundary.
+func extractDebControlFile(t *testing.T, f io.Reader) io.ReadCloser {
 	t.Helper()
 
-	ar, err := deb.LoadAr(f)
+	const arMagic = "!<arch>\n"
+	magic := make([]byte, len(arMagic))
+	_, err := io.ReadFull(f, magic)
 	assert.NilError(t, err)
+	assert.Equal(t, string(magic), arMagic, "not an ar archive")
 
 	for {
-		entry, err := ar.Next()
-		if err == io.EOF {
+		var hdr [60]byte
+		if _, err := io.ReadFull(f, hdr[:]); err == io.EOF {
 			break
+		} else {
+			assert.NilError(t, err)
 		}
+
+		// Name is bytes 0-16 (GNU ar terminates it with a trailing "/");
+		// size is the decimal byte count at bytes 48-58.
+		name := strings.TrimRight(strings.TrimRight(string(hdr[0:16]), " "), "/")
+		size, err := strconv.ParseInt(strings.TrimSpace(string(hdr[48:58])), 10, 64)
 		assert.NilError(t, err)
 
-		if entry == nil {
-			break
-		}
-
-		if !strings.HasPrefix(entry.Name, "control.") {
+		if !strings.HasPrefix(name, "control.") {
+			// Skip the payload plus its odd-size padding byte.
+			_, err := io.CopyN(io.Discard, f, size+size%2)
+			assert.NilError(t, err)
 			continue
 		}
 
-		rdr, err := compression.DecompressStream(entry.Data)
+		rdr, err := compression.DecompressStream(io.LimitReader(f, size))
 		assert.NilError(t, err)
 		return rdr
 	}
@@ -5312,7 +5324,7 @@ func testPackageProvidesReplaces(ctx context.Context, t *testing.T, cfg testLinu
 			assert.NilError(t, err)
 			defer f.Close()
 
-			cf := extractDebControlFile(t, f.(io.ReaderAt))
+			cf := extractDebControlFile(t, f)
 			assert.Assert(t, cf != nil, "control file not found in deb")
 			defer cf.Close()
 
@@ -5513,7 +5525,7 @@ int main() {
 				}
 				defer f.Close()
 
-				cf := extractDebControlFile(t, f.(io.ReaderAt))
+				cf := extractDebControlFile(t, f)
 				defer cf.Close()
 
 				buf := bytes.NewBuffer(nil)


### PR DESCRIPTION

**What this PR does / why we need it**:

The libarary doesn't seem to be maintained and one of it's transitive depedencies, github.com/kjk/lzma, has been removed which causes issues right now.

Replacing relevant code is test-only and relatively simple, so I think this is a reasoanble thing to do.


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Closes #1171
