### PR TITLE
apply per-step env vars in test runner steps

### DIFF
--- a/internal/testrunner/determinism_test.go
+++ b/internal/testrunner/determinism_test.go
@@ -43,6 +43,14 @@ func TestTestEnvProducesDeterministicLLB(t *testing.T) {
 	})
 }
 
+func TestStepEnvProducesDeterministicLLB(t *testing.T) {
+	step := dalec.TestStep{Command: "true", Env: manyTestEnv()}
+
+	requireDeterministicDef(t, func() *llb.Definition {
+		return definitionFromStateOption(t, stepRunner.withTestStep(step, withTestFrontend()))
+	})
+}
+
 func marshalState(t *testing.T, st llb.State) *llb.Definition {
 	t.Helper()
 	def, err := st.Marshal(context.Background())

--- a/internal/testrunner/step.go
+++ b/internal/testrunner/step.go
@@ -97,12 +97,16 @@ func (c stepRunnerCommand) withTestStep(step dalec.TestStep, opts ...ValidationO
 			string(c),
 		}
 
-		out := in.Run(
+		runOptions := []llb.RunOption{
 			llb.AddMount(c.stepJSONPath(), st, llb.SourcePath("step.json")),
 			testRunner(args, opts...),
 			step.GetSourceLocation(in),
 			llb.WithCustomName(step.Command),
-		).Root()
+		}
+		for k, v := range dalec.SortedMapIter(step.Env) {
+			runOptions = append(runOptions, llb.AddEnv(k, v))
+		}
+		out := in.Run(runOptions...).Root()
 
 		// Do any stdout/stderr checks
 		var stateOpts []llb.StateOption

--- a/internal/testrunner/step_test.go
+++ b/internal/testrunner/step_test.go
@@ -1,0 +1,37 @@
+package testrunner
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/project-dalec/dalec"
+)
+
+func TestWithTestStepAppliesStepEnv(t *testing.T) {
+	t.Parallel()
+
+	step := dalec.TestStep{
+		Command: "true",
+		Env: map[string]string{
+			"FOO":   "bar",
+			"EMPTY": "",
+		},
+	}
+	def := definitionFromStateOption(t, stepRunner.withTestStep(step, withTestFrontend()))
+	exec := singleExecOp(t, def)
+
+	assert.DeepEqual(t, exec.Meta.Env, []string{"EMPTY=", "FOO=bar"})
+}
+
+func TestWithTestStepNoEnv(t *testing.T) {
+	t.Parallel()
+
+	step := dalec.TestStep{
+		Command: "true",
+	}
+	def := definitionFromStateOption(t, stepRunner.withTestStep(step, withTestFrontend()))
+	exec := singleExecOp(t, def)
+
+	assert.Assert(t, len(exec.Meta.Env) == 0)
+}

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -694,6 +694,37 @@ index 0000000..5260cb1
 				solveT(ctx, t, gwc, sr)
 			})
 		})
+
+		t.Run("step_env_vars_are_passed_to_the_command", func(t *testing.T) {
+			t.Parallel()
+			ctx := startTestSpan(baseCtx, t)
+
+			spec := testLinuxSpec(t, dalec.Spec{
+				Tests: []*dalec.TestSpec{
+					{
+						Name: "Verify step env vars are passed to the command",
+						Steps: []dalec.TestStep{
+							{
+								Command: `/bin/sh -c 'echo -n "${EMPTY-empty}_${FOO-foo}_${UNDEFINED-undefined}"'`,
+								Env: map[string]string{
+									"FOO":   "bar",
+									"EMPTY": "",
+								},
+								Stdout: dalec.CheckOutput{Equals: "_bar_undefined"},
+							},
+						},
+					},
+				},
+			})
+
+			testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+				sr := newSolveRequest(
+					withSpec(ctx, t, &spec),
+					withBuildTarget(testConfig.Target.Package),
+				)
+				solveT(ctx, t, gwc, sr)
+			})
+		})
 	})
 
 	t.Run("depsonly", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a regression in DALEC 0.21 where environment variables defined in test steps were not being passed to the test command.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1174

**Special notes for your reviewer**:
N/A